### PR TITLE
Fix repeated onboarding timestamp prompt

### DIFF
--- a/next_features_bugfixes.md
+++ b/next_features_bugfixes.md
@@ -1,0 +1,19 @@
+# Next Features & Bugfixes
+
+This file tracks features, bugfixes, and refactors that have been implemented locally on feature branches but not yet released to PyPI. Once a subset of issues (e.g. 4-5) is completed, they will be combined and published under a single version bump.
+
+---
+
+## 1. Fix Repeated Onboarding Prompt
+
+### Problem
+When the Zsh or Bash history file has legacy (timestamp-less) entries, `parse_zsh_history()` and `parse_bash_history()` always find legacy items and set the environment variable `TERMSTORY_MISSING_TIMESTAMPS = 1`. 
+Enabling history timestamps in shell config files (via `setopt EXTENDED_HISTORY` or `HISTTIMEFORMAT`) only applies to *new* commands, so old commands remain dateless. As a result, `termstory ui` repeatedly prompts the user on every launch.
+
+### Fix
+- Added `"has_seen_timestamp_prompt": False` to the configuration defaults in `load_config()`.
+- Updated `show_ui()` in `cli.py` to only trigger the prompt when `TERMSTORY_MISSING_TIMESTAMPS == "1"` AND the `has_seen_timestamp_prompt` config flag is `False`.
+- Persist `has_seen_timestamp_prompt = True` to `config.json` once the user responds (either `Y` or `N`).
+- Updated CLI tests in `test_cli_commands.py` to mock `get_config_path` and assert that the prompt saves the flag.
+
+---

--- a/next_features_bugfixes.md
+++ b/next_features_bugfixes.md
@@ -12,8 +12,9 @@ Enabling history timestamps in shell config files (via `setopt EXTENDED_HISTORY`
 
 ### Fix
 - Added `"has_seen_timestamp_prompt": False` to the configuration defaults in `load_config()`.
-- Updated `show_ui()` in `cli.py` to only trigger the prompt when `TERMSTORY_MISSING_TIMESTAMPS == "1"` AND the `has_seen_timestamp_prompt` config flag is `False`.
-- Persist `has_seen_timestamp_prompt = True` to `config.json` once the user responds (either `Y` or `N`).
-- Updated CLI tests in `test_cli_commands.py` to mock `get_config_path` and assert that the prompt saves the flag.
+- Updated `show_ui()` in `cli.py` to check that the `has_seen_timestamp_prompt` config flag is `False` before triggering the timekeeping prompt.
+- Handled default response parsing: pressing Enter (empty response `""`) now defaults to `"y"` to match the `[Y/n]` prompt style.
+- Restrict flag persistence: only save `has_seen_timestamp_prompt = True` on valid, explicit responses (`y`/`yes`/`n`/`no`/KeyboardInterrupt/EOF) to allow prompts to reappear if the user types invalid input.
+- Updated CLI tests in `test_cli_commands.py` to mock `get_config_path` and assert that the prompt saves the flag. Added a regression test calling the CLI twice sequentially to ensure the prompt is successfully suppressed on the second run.
 
 ---

--- a/next_features_bugfixes.md
+++ b/next_features_bugfixes.md
@@ -14,7 +14,9 @@ Enabling history timestamps in shell config files (via `setopt EXTENDED_HISTORY`
 - Added `"has_seen_timestamp_prompt": False` to the configuration defaults in `load_config()`.
 - Updated `show_ui()` in `cli.py` to check that the `has_seen_timestamp_prompt` config flag is `False` before triggering the timekeeping prompt.
 - Handled default response parsing: pressing Enter (empty response `""`) now defaults to `"y"` to match the `[Y/n]` prompt style.
-- Restrict flag persistence: only save `has_seen_timestamp_prompt = True` on valid, explicit responses (`y`/`yes`/`n`/`no`/KeyboardInterrupt/EOF) to allow prompts to reappear if the user types invalid input.
+- Restrict flag persistence: only save `has_seen_timestamp_prompt = True` on valid, explicit responses (`y`/`yes`/`n`/`no`/KeyboardInterrupt/EOF). In the `"yes"` branch, the flag is saved *only after* the shell config file append operation succeeds. This prevents the prompt from being suppressed if the write fails (e.g. read-only filesystem or permission error).
+- Avoid unconditional configuration loading: deferred `load_config()` on the typical `termstory ui` run. Now it checks the environment variable `TERMSTORY_MISSING_TIMESTAMPS` first, and only loads the configuration from disk if history timestamps are indeed missing.
 - Updated CLI tests in `test_cli_commands.py` to mock `get_config_path` and assert that the prompt saves the flag. Added a regression test calling the CLI twice sequentially to ensure the prompt is successfully suppressed on the second run.
 
 ---
+

--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -180,6 +180,8 @@ def show_ui(
             response = input(
                 "Would you like TermStory to automatically enable history timestamps in your shell config file (`~/.zshrc` or `~/.bashrc`)? [Y/n] "
             ).strip().lower()
+            if response == "":
+                response = "y"
         except (KeyboardInterrupt, EOFError):
             console.print()
             response = "n"
@@ -198,10 +200,12 @@ def show_ui(
             except Exception as e:
                 console.print(f"[bold red]Error modifying {config_display}: {e}[/bold red]")
                 console.print("Continuing with legacy history fallback...")
-        else:
+        elif response in ("n", "no"):
             _cfg["has_seen_timestamp_prompt"] = True
             save_config(_cfg)
             console.print("Continuing with legacy history fallback...")
+        else:
+            console.print("Invalid response. Continuing with legacy history fallback...")
             
     from termstory.tui import TermStoryWorkspace
     app_tui = TermStoryWorkspace(db, days_limit=None if all_history else days)

--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -156,7 +156,9 @@ def show_ui(
     # boot sequence to offer automatic configuration injection into the user's shell
     # config file. We detect the user's default shell (bash vs zsh) and write the
     # appropriate timekeeping directive. Never perform this without explicit user consent ('Y').
-    if os.environ.get("TERMSTORY_MISSING_TIMESTAMPS") == "1":
+    from termstory.config import load_config, save_config
+    _cfg = load_config()
+    if os.environ.get("TERMSTORY_MISSING_TIMESTAMPS") == "1" and not _cfg.get("has_seen_timestamp_prompt", False):
         # Detect default shell from $SHELL (e.g. /bin/bash, /usr/bin/zsh)
         shell_path = os.environ.get("SHELL", "")
         is_bash = "bash" in os.path.basename(shell_path).lower()
@@ -183,6 +185,8 @@ def show_ui(
             response = "n"
             
         if response in ("y", "yes"):
+            _cfg["has_seen_timestamp_prompt"] = True
+            save_config(_cfg)
             try:
                 with open(config_path, "a") as f:
                     f.write(config_directive)
@@ -195,6 +199,8 @@ def show_ui(
                 console.print(f"[bold red]Error modifying {config_display}: {e}[/bold red]")
                 console.print("Continuing with legacy history fallback...")
         else:
+            _cfg["has_seen_timestamp_prompt"] = True
+            save_config(_cfg)
             console.print("Continuing with legacy history fallback...")
             
     from termstory.tui import TermStoryWorkspace

--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -156,9 +156,12 @@ def show_ui(
     # boot sequence to offer automatic configuration injection into the user's shell
     # config file. We detect the user's default shell (bash vs zsh) and write the
     # appropriate timekeeping directive. Never perform this without explicit user consent ('Y').
-    from termstory.config import load_config, save_config
-    _cfg = load_config()
-    if os.environ.get("TERMSTORY_MISSING_TIMESTAMPS") == "1" and not _cfg.get("has_seen_timestamp_prompt", False):
+    missing_ts = os.environ.get("TERMSTORY_MISSING_TIMESTAMPS") == "1"
+    _cfg = {}
+    if missing_ts:
+        from termstory.config import load_config, save_config
+        _cfg = load_config()
+    if missing_ts and not _cfg.get("has_seen_timestamp_prompt", False):
         # Detect default shell from $SHELL (e.g. /bin/bash, /usr/bin/zsh)
         shell_path = os.environ.get("SHELL", "")
         is_bash = "bash" in os.path.basename(shell_path).lower()
@@ -187,11 +190,11 @@ def show_ui(
             response = "n"
             
         if response in ("y", "yes"):
-            _cfg["has_seen_timestamp_prompt"] = True
-            save_config(_cfg)
             try:
                 with open(config_path, "a") as f:
                     f.write(config_directive)
+                _cfg["has_seen_timestamp_prompt"] = True
+                save_config(_cfg)
                 console.print(
                     f"\n[bold green]✅ Done! Please restart your terminal or run `source {config_display}` "
                     f"for the changes to take effect, then run `termstory ui` again.[/bold green]\n"

--- a/termstory/config.py
+++ b/termstory/config.py
@@ -131,7 +131,8 @@ def load_config() -> dict:
                 "model_name": "llama3"
             }
         },
-        "has_seen_onboarding": False
+        "has_seen_onboarding": False,
+        "has_seen_timestamp_prompt": False
     }
     
     # 1. Read existing config file

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -132,6 +132,8 @@ def test_cli_ui_onboarding_missing_timestamps_yes(tmp_path, monkeypatch):
     db_file = tmp_path / "test_cli_ui.db"
     monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
     monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("termstory.config.get_config_path", lambda: str(config_file))
     
     # Mock run_ingestion to do nothing
     monkeypatch.setattr("termstory.cli.run_ingestion", lambda db: None)
@@ -155,10 +157,19 @@ def test_cli_ui_onboarding_missing_timestamps_yes(tmp_path, monkeypatch):
     content = zshrc_file.read_text()
     assert "setopt EXTENDED_HISTORY" in content
 
+    # Verify config flag was saved
+    import json
+    assert config_file.exists()
+    with open(config_file, "r") as f:
+        cfg = json.load(f)
+    assert cfg.get("has_seen_timestamp_prompt") is True
+
 def test_cli_ui_onboarding_missing_timestamps_no(tmp_path, monkeypatch):
     db_file = tmp_path / "test_cli_ui.db"
     monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
     monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("termstory.config.get_config_path", lambda: str(config_file))
     
     # Mock run_ingestion
     monkeypatch.setattr("termstory.cli.run_ingestion", lambda db: None)
@@ -178,12 +189,21 @@ def test_cli_ui_onboarding_missing_timestamps_no(tmp_path, monkeypatch):
     assert "Continuing with legacy history fallback" in result.stdout
     assert len(workspace_runs) == 1
 
+    # Verify config flag was saved
+    import json
+    assert config_file.exists()
+    with open(config_file, "r") as f:
+        cfg = json.load(f)
+    assert cfg.get("has_seen_timestamp_prompt") is True
+
 
 def test_cli_ui_onboarding_bash_shell(tmp_path, monkeypatch):
     """On a bash shell, onboarding should write HISTTIMEFORMAT to ~/.bashrc."""
     db_file = tmp_path / "test_cli_ui.db"
     monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
     monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("termstory.config.get_config_path", lambda: str(config_file))
     monkeypatch.setattr("termstory.cli.run_ingestion", lambda db: None)
     monkeypatch.setenv("TERMSTORY_MISSING_TIMESTAMPS", "1")
     monkeypatch.setenv("SHELL", "/bin/bash")
@@ -207,6 +227,13 @@ def test_cli_ui_onboarding_bash_shell(tmp_path, monkeypatch):
     content = bashrc_file.read_text()
     assert 'HISTTIMEFORMAT="%F %T "' in content
     assert "setopt EXTENDED_HISTORY" not in content
+
+    # Verify config flag was saved
+    import json
+    assert config_file.exists()
+    with open(config_file, "r") as f:
+        cfg = json.load(f)
+    assert cfg.get("has_seen_timestamp_prompt") is True
 
 
 def test_run_ingestion_no_history_files(tmp_path, monkeypatch, capsys):

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -196,6 +196,12 @@ def test_cli_ui_onboarding_missing_timestamps_no(tmp_path, monkeypatch):
         cfg = json.load(f)
     assert cfg.get("has_seen_timestamp_prompt") is True
 
+    # Second run should not re-prompt once flag is set
+    result2 = runner.invoke(app, ["ui"])
+    assert result2.exit_code == 0
+    assert "automatically enable history timestamps" not in result2.stdout
+    assert len(workspace_runs) == 2
+
 
 def test_cli_ui_onboarding_bash_shell(tmp_path, monkeypatch):
     """On a bash shell, onboarding should write HISTTIMEFORMAT to ~/.bashrc."""


### PR DESCRIPTION
This PR resolves the issue where the zsh/bash extended history timestamp consent onboarding prompt is repeatedly displayed on every run of `termstory ui`. Since old history commands remain timestamp-less even after enabling it, the parser continues to flag them as legacy. This fix adds a `has_seen_timestamp_prompt` flag to the config to ensure the prompt is only shown once.