### PR TITLE
fix: formal PR — 10 bug fixes (stats/db/exporter/sanitizer/predict/archive/session/search/replay)

### DIFF
--- a/termstory/archive.py
+++ b/termstory/archive.py
@@ -198,7 +198,8 @@ def archive_old_data(main_db_path: str, archive_db_path: str, days: int) -> Dict
                 INSERT OR IGNORE INTO archive.commits (hash, timestamp, message, cleaned_message, project_id, created_at)
                 VALUES (?, ?, ?, ?, ?, ?)
             """, (c_hash, c_ts, c_msg, c_cl_msg, new_c_proj_id, c_ca))
-            stats["commits"] += 1
+            if cursor.rowcount > 0:
+                stats["commits"] += 1
 
             if has_archive_fts5:
                 # Check if it already exists in search_index

--- a/termstory/database.py
+++ b/termstory/database.py
@@ -639,7 +639,7 @@ class Database:
                         FROM commits
                         WHERE project_id = ? AND timestamp >= ? AND timestamp <= ?
                         ORDER BY timestamp ASC
-                    """, (p_id, start - 300, end + 600))
+                    """, (p_id, start - 300, (end or start) + 600))
                     for c_row in cursor.fetchall():
                         commits.append({
                             "hash": c_row[0],
@@ -760,7 +760,7 @@ class Database:
                         FROM commits
                         WHERE project_id = ? AND timestamp >= ? AND timestamp <= ?
                         ORDER BY timestamp ASC
-                    """, (p_id, start - 300, end + 600))
+                    """, (p_id, start - 300, (end or start) + 600))
                     for c_row in cursor.fetchall():
                         commits.append({
                             "hash": c_row[0],
@@ -835,7 +835,7 @@ class Database:
                         FROM commits
                         WHERE project_id = ? AND timestamp >= ? AND timestamp <= ?
                         ORDER BY timestamp ASC
-                    """, (p_id, start - 300, end + 600))
+                    """, (p_id, start - 300, (end or start) + 600))
                     for c_row in cursor.fetchall():
                         commits.append({
                             "hash": c_row[0],
@@ -910,7 +910,7 @@ class Database:
                         FROM commits
                         WHERE project_id = ? AND timestamp >= ? AND timestamp <= ?
                         ORDER BY timestamp ASC
-                    """, (p_id, start - 300, end + 600))
+                    """, (p_id, start - 300, (end or start) + 600))
                     for c_row in cursor.fetchall():
                         commits.append({
                             "hash": c_row[0],

--- a/termstory/exporter.py
+++ b/termstory/exporter.py
@@ -81,7 +81,7 @@ def serialize_sessions_to_dict(sessions: List[Session], db: Database) -> List[Di
             "start_time": s.start_time,
             "start_time_iso": datetime.fromtimestamp(s.start_time).isoformat(),
             "end_time": s.end_time,
-            "end_time_iso": datetime.fromtimestamp(s.end_time).isoformat(),
+            "end_time_iso": datetime.fromtimestamp(s.end_time).isoformat() if s.end_time is not None else None,
             "duration_seconds": s.duration_seconds,
             "duration_readable": s.duration_readable,
             "project_id": s.project_id,

--- a/termstory/predict.py
+++ b/termstory/predict.py
@@ -17,6 +17,8 @@ from datetime import datetime, timedelta
 from collections import Counter, defaultdict
 from typing import List, Dict, Optional, Tuple
 
+from termstory.database import Database
+
 # ---------------------------------------------------------------------------
 # Noise commands that are excluded from prediction signals
 # (mirrors formatter.py's _is_noise_command heuristic)
@@ -100,7 +102,7 @@ class Predictor:
         Load all non-legacy sessions with their project names, commands, and
         session boundaries directly from SQLite — no ORM overhead.
         """
-        conn = sqlite3.connect(self.db_path, timeout=10.0)
+        conn = Database(self.db_path).get_connection()
         try:
             cursor = conn.cursor()
 

--- a/termstory/replay.py
+++ b/termstory/replay.py
@@ -127,7 +127,7 @@ def run_replay(db: Database, session_id: Optional[int] = None, speed: float = 1.
                     time.sleep(wait_time)
             else:
                 # Small initial pause
-                time.sleep(0.5 / speed)
+                time.sleep(min(0.5 / speed, 2.0))
 
             # Calculate relative offset
             offset_sec = cmd.timestamp - session.start_time

--- a/termstory/sanitizer.py
+++ b/termstory/sanitizer.py
@@ -54,7 +54,7 @@ PASSWORD_FLAG_PATTERN = re.compile(
     re.IGNORECASE
 )
 
-IP_ADDRESS_PATTERN = re.compile(r'\b(?:\d{1,3}\.){3}\d{1,3}\b')
+IP_ADDRESS_PATTERN = re.compile(r'(?<![\d\.])(?:\d{1,3}\.){3}\d{1,3}(?![\d\.])')
 IPV6_ADDRESS_PATTERN = re.compile(
     r'\b(?:[0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F]{1,4}\b|'
     r'\b(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}\b|'

--- a/termstory/search.py
+++ b/termstory/search.py
@@ -211,7 +211,7 @@ def _search_standard(
             LEFT JOIN commands c ON s.id = c.session_id
             LEFT JOIN commits co ON s.project_id = co.project_id 
                 AND co.timestamp >= s.start_time - 300 
-                AND co.timestamp <= s.end_time + 600
+                AND co.timestamp <= COALESCE(s.end_time, s.start_time) + 600
             WHERE (
                 p.name LIKE ?
                 OR c.command LIKE ?

--- a/termstory/session.py
+++ b/termstory/session.py
@@ -23,7 +23,7 @@ def create_sessions(commands: List[Command], gap_threshold: int = 1800) -> List[
             # Create session for the accumulated commands
             start_time = current_commands[0].timestamp
             end_time = current_commands[-1].timestamp
-            duration_seconds = max(60, end_time - start_time)
+            duration_seconds = end_time - start_time
             
             # A session is considered a legacy archive if ALL its commands are legacy
             all_legacy = all(getattr(c, "is_legacy", False) for c in current_commands)
@@ -51,7 +51,7 @@ def create_sessions(commands: List[Command], gap_threshold: int = 1800) -> List[
     if current_commands:
         start_time = current_commands[0].timestamp
         end_time = current_commands[-1].timestamp
-        duration_seconds = max(60, end_time - start_time)
+        duration_seconds = end_time - start_time
         
         all_legacy = all(getattr(c, "is_legacy", False) for c in current_commands)
         

--- a/termstory/stats.py
+++ b/termstory/stats.py
@@ -205,7 +205,8 @@ def language_detection(db: Database) -> Dict[str, float]:
         cursor.execute("SELECT id, path FROM projects")
         projects = cursor.fetchall()
         
-        cursor.execute("SELECT project_id, command FROM commands")
+        cutoff = int((get_current_time() - timedelta(days=90)).timestamp())
+        cursor.execute("SELECT project_id, command FROM commands WHERE timestamp >= ?", (cutoff,))
         commands = cursor.fetchall()
     finally:
         conn.close()
@@ -264,7 +265,8 @@ def peak_hours(db: Database) -> Dict[int, int]:
     conn = db.get_connection()
     try:
         cursor = conn.cursor()
-        cursor.execute("SELECT timestamp FROM commands")
+        cutoff = int((get_current_time() - timedelta(days=90)).timestamp())
+        cursor.execute("SELECT timestamp FROM commands WHERE timestamp >= ?", (cutoff,))
         rows = cursor.fetchall()
     finally:
         conn.close()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -40,7 +40,7 @@ def test_create_sessions_multiple():
     assert sessions[0].id == 1
     assert sessions[0].start_time == 1000
     assert sessions[0].end_time == 1000
-    assert sessions[0].duration_seconds == 60
+    assert sessions[0].duration_seconds == 0
     assert len(sessions[0].commands) == 1
     
     # Session 2
@@ -54,7 +54,7 @@ def test_create_sessions_multiple():
     assert sessions[2].id == 3
     assert sessions[2].start_time == 4900
     assert sessions[2].end_time == 4900
-    assert sessions[2].duration_seconds == 60
+    assert sessions[2].duration_seconds == 0
     assert len(sessions[2].commands) == 1
 
 def test_create_sessions_no_cwd_fragmentation():


### PR DESCRIPTION
This PR formally tracks the 10-bug fix batch that was previously pushed directly to main.

Bugs fixed:
- stats.py: unbounded queries in peak_hours and language_detection (90-day cutoff)
- database.py: NULL end_time crashes in commit queries (4 locations)
- exporter.py: null end_time ISO formatting
- sanitizer.py: IP_ADDRESS_PATTERN version-string false positives
- predict.py: raw sqlite3 bypassing WAL/SafeConnection
- archive.py: stats commmit increment on duplicate INSERT IGNORE
- session.py: single-command sessions forced to 60s minimum
- search.py: NULL end_time silently dropping commits
- replay.py: unbounded initial pause at very low speed