### PR TITLE
fix: replace bare except in _handle_exception with logged warning (#112)

### DIFF
--- a/termstory/tui.py
+++ b/termstory/tui.py
@@ -15,12 +15,16 @@ def _handle_exception(exc_type, exc, tb):
     import traceback
     console = Console(stderr=True)
     console.print("[bold red]An unexpected error occurred. Please try again.[/bold red]")
+    log_path = os.path.expanduser("~/.termstory.error.log")
     try:
-        with open(os.path.expanduser("~/.termstory.error.log"), "a") as f:
+        with open(log_path, "a") as f:
             f.write(f"\n--- {datetime.now()} ---\n")
             traceback.print_exception(exc_type, exc, tb, file=f)
-    except Exception:
-        pass
+    except Exception as log_exc:
+        console.print(
+            f"[yellow]Warning: could not write error log to {log_path}: "
+            f"{type(log_exc).__name__}: {log_exc}[/yellow]"
+        )
 
 sys.excepthook = _handle_exception
 

--- a/termstory/tui.py
+++ b/termstory/tui.py
@@ -22,7 +22,7 @@ def _handle_exception(exc_type, exc, tb):
             traceback.print_exception(exc_type, exc, tb, file=f)
     except Exception as log_exc:
         console.print(
-            f"[yellow]Warning: could not write error log to {log_path}: "
+            f"[yellow]Warning: could not write error log to {escape(str(log_path))}: "
             f"{type(log_exc).__name__}: {escape(str(log_exc))}[/yellow]"
         )
 

--- a/termstory/tui.py
+++ b/termstory/tui.py
@@ -23,7 +23,7 @@ def _handle_exception(exc_type, exc, tb):
     except Exception as log_exc:
         console.print(
             f"[yellow]Warning: could not write error log to {log_path}: "
-            f"{type(log_exc).__name__}: {log_exc}[/yellow]"
+            f"{type(log_exc).__name__}: {escape(str(log_exc))}[/yellow]"
         )
 
 sys.excepthook = _handle_exception

--- a/termstory/tui.py
+++ b/termstory/tui.py
@@ -13,6 +13,7 @@ import sys
 def _handle_exception(exc_type, exc, tb):
     """Friendly global exception handler to avoid raw tracebacks."""
     import traceback
+    from textual.markup import escape
     console = Console(stderr=True)
     console.print("[bold red]An unexpected error occurred. Please try again.[/bold red]")
     log_path = os.path.expanduser("~/.termstory.error.log")

--- a/termstory/tui.py
+++ b/termstory/tui.py
@@ -13,7 +13,11 @@ import sys
 def _handle_exception(exc_type, exc, tb):
     """Friendly global exception handler to avoid raw tracebacks."""
     import traceback
-    from textual.markup import escape
+
+    def _safe_str(value):
+        """Escape Rich markup characters without depending on Textual."""
+        return str(value).replace("[", "\\[").replace("]", "\\]")
+
     console = Console(stderr=True)
     console.print("[bold red]An unexpected error occurred. Please try again.[/bold red]")
     log_path = os.path.expanduser("~/.termstory.error.log")
@@ -23,8 +27,8 @@ def _handle_exception(exc_type, exc, tb):
             traceback.print_exception(exc_type, exc, tb, file=f)
     except Exception as log_exc:
         console.print(
-            f"[yellow]Warning: could not write error log to {escape(str(log_path))}: "
-            f"{type(log_exc).__name__}: {escape(str(log_exc))}[/yellow]"
+            f"[yellow]Warning: could not write error log to {_safe_str(log_path)}: "
+            f"{type(log_exc).__name__}: {_safe_str(log_exc)}[/yellow]"
         )
 
 sys.excepthook = _handle_exception


### PR DESCRIPTION
## Description
Replaces the bare except Exception: pass in _handle_exception with a logged warning so secondary log-write failures are visible to the user instead of being silently discarded.

The _handle_exception function is set as sys.excepthook to handle unhandled exceptions gracefully. When it tries to write to ~/.termstory.error.log and that write fails (permission denied, disk full, encoding error), the bare except Exception: pass silently discards the secondary failure. The user sees the generic red error message but has no indication the log write failed.

Fixes #112


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] My code follows the "density over decoration" philosophy.
- [x] I have not used `rich.panel.Panel` in my code.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
