### PR TITLE
fix: log warning on DB error in add_reminder instead of silent pass

### DIFF
--- a/termstory/reminder.py
+++ b/termstory/reminder.py
@@ -1,9 +1,12 @@
 import json
+import logging
 import os
 import time
 import re
 from typing import List, Dict, Optional, Tuple
 from termstory.config import get_app_dir
+
+logger = logging.getLogger(__name__)
 
 def get_reminders_file_path() -> str:
     """Return path to reminders JSON file"""
@@ -96,8 +99,12 @@ def add_reminder(
             if row:
                 session_id = row[0]
                 project_name = row[1] or "Other"
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning(
+                "add_reminder: failed to fetch latest session from DB; "
+                "reminder will be created without project association. Error: %s",
+                exc,
+            )
         finally:
             conn.close()
 

--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -77,6 +77,39 @@ def test_add_and_complete_reminder(tmp_path, monkeypatch):
     # Try completing non-existent
     assert complete_reminder(999) is False
 
+def test_add_reminder_logs_warning_on_db_error(tmp_path, monkeypatch, caplog):
+    """When the DB lookup raises, the reminder is still saved with defaults
+    and a warning is logged. Regression test for issue #111."""
+    reminders_file = tmp_path / "reminders.json"
+    monkeypatch.setattr("termstory.reminder.get_reminders_file_path", lambda: str(reminders_file))
+
+    class BrokenCursor:
+        def execute(self, *args, **kwargs):
+            raise RuntimeError("simulated DB failure")
+
+    class BrokenConn:
+        def cursor(self):
+            return BrokenCursor()
+        def close(self):
+            pass
+
+    class BrokenDB:
+        def get_connection(self):
+            return BrokenConn()
+
+    with caplog.at_level("WARNING", logger="termstory.reminder"):
+        rem = add_reminder("review code in 2 days", db=BrokenDB())
+
+    # Reminder is still created with default fallback values
+    assert rem["about"] == "review code"
+    assert rem["days"] == 2
+    assert rem["session_id"] is None
+    assert rem["project_name"] == "Other"
+
+    # Warning was emitted with the simulated error context
+    assert any("add_reminder" in r.message and "simulated DB failure" in r.message
+               for r in caplog.records)
+
 def test_cli_remind_commands(tmp_path, monkeypatch):
     reminders_file = tmp_path / "reminders.json"
     monkeypatch.setattr("termstory.reminder.get_reminders_file_path", lambda: str(reminders_file))


### PR DESCRIPTION

## Description
Replaces the bare except Exception: pass at line 99 in add_reminder with a logger.warning(...) call that captures the exception and includes context, keeping the non-fatal fallback behaviour (session_id=None, project_name="Other") but making DB failures visible in logs.
Added import logging and a module-level logger = logging.getLogger(__name__) per the maintainer's note in the issue.
Also added a regression test test_add_reminder_logs_warning_on_db_error in tests/test_reminder.py that passes a mock DB whose cursor raises, then asserts the reminder is still returned with default values and that a warning was logged via caplog.
All 6 reminder tests pass locally.

Fixes #111


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] My code follows the "density over decoration" philosophy.
- [x] I have not used `rich.panel.Panel` in my code.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
