### PR TITLE
[Reminder] Add type and range validation to add_reminder

### DIFF
--- a/termstory/reminder.py
+++ b/termstory/reminder.py
@@ -71,8 +71,11 @@ def add_reminder(
     else:
         about, days = parse_reminder_text(text)
         
-    if days < 0:
-        raise ValueError("Days must be a non-negative integer.")
+    if type(days) is not int:
+        raise TypeError("Days must be an integer.")
+
+    if not 0 <= days <= 3650:
+        raise ValueError("Days must be between 0 and 3650.")
 
     created_at = int(time.time())
     due_at = created_at + (days * 86400)

--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -173,3 +173,29 @@ def test_add_reminder_explicit_days_prefix_suffix_stripping(tmp_path, monkeypatc
     
     rem3 = add_reminder("deploy application in 3 days", days=10)
     assert rem3["about"] == "deploy application"
+
+
+def test_add_reminder_days_validation(tmp_path, monkeypatch):
+    reminders_file = tmp_path / "reminders.json"
+    monkeypatch.setattr("termstory.reminder.get_reminders_file_path", lambda: str(reminders_file))
+    
+    # Test invalid types
+    with pytest.raises(TypeError, match="Days must be an integer."):
+        add_reminder("do something", days=2.5)
+    
+    with pytest.raises(TypeError, match="Days must be an integer."):
+        add_reminder("do something", days="5")
+
+    with pytest.raises(TypeError, match="Days must be an integer."):
+        add_reminder("do something", days=True)
+
+    # Test invalid boundary values
+    with pytest.raises(ValueError, match="Days must be between 0 and 3650."):
+        add_reminder("do something", days=-1)
+    
+    with pytest.raises(ValueError, match="Days must be between 0 and 3650."):
+        add_reminder("do something", days=3651)
+
+     # Test parsed phrase that yields an invalid range
+    with pytest.raises(ValueError, match="Days must be between 0 and 3650."):
+        add_reminder("do something in 4000 days")


### PR DESCRIPTION
## Description
This pull request adds input validation for the `days` parameter in `add_reminder()`. It ensures that `days` is strictly an integer and falls within the range of `0` to `3650` days (inclusive), fixing a validation gap when scheduling reminders through both parsed text and direct arguments.

Fixes #120

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the "density over decoration" philosophy.
- [x] I have not used `rich.panel.Panel` in my code.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.