### PR TITLE
fix: log warning on DB errors in ai.py context lookups instead of silent pass

### DIFF
--- a/termstory/ai.py
+++ b/termstory/ai.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import urllib.request
 import urllib.error
 import threading
@@ -7,6 +8,7 @@ import socket
 from typing import List, Optional, Dict
 from termstory.sanitizer import sanitize_session_commands
 
+logger = logging.getLogger(__name__)
 _local_ai_state = threading.local()
 
 # Circuit Breaker Configuration
@@ -46,7 +48,12 @@ def _get_project_context_from_db(project_name: str) -> Optional[str]:
         if row:
             return row[0]
     except Exception:
-        pass
+        logger.warning(
+            "_get_project_context_from_db: failed to fetch project context for %r; "
+            "returning None.",
+            project_name,
+            exc_info=True,
+        )
     finally:
         if conn is not None:
             conn.close()
@@ -65,6 +72,11 @@ def _get_all_active_project_contexts() -> List[tuple]:
         rows = cursor.fetchall()
         return rows
     except Exception:
+        logger.warning(
+            "_get_all_active_project_contexts: failed to fetch project contexts; "
+            "returning empty list.",
+            exc_info=True,
+        )
         return []
     finally:
         if conn is not None:

--- a/tests/test_ai_error_surfacing.py
+++ b/tests/test_ai_error_surfacing.py
@@ -206,4 +206,61 @@ def test_http_error_whitespace_normalization(monkeypatch):
     assert res is None
     assert get_last_ai_error() == "HTTP Error 500: Something went wrong."
 
+def test_get_project_context_logs_warning_on_db_error(monkeypatch, caplog):
+    """When the DB lookup raises in _get_project_context_from_db,
+    the function returns None and logs a warning. Regression test for issue #109."""
+    from termstory.ai import _get_project_context_from_db
 
+    class BrokenCursor:
+        def execute(self, *args, **kwargs):
+            raise RuntimeError("simulated DB failure in fetch")
+
+    class BrokenConn:
+        def cursor(self):
+            return BrokenCursor()
+        def close(self):
+            pass
+
+    class BrokenDB:
+        def get_connection(self):
+            return BrokenConn()
+
+    monkeypatch.setattr("termstory.database.Database", lambda *args, **kwargs: BrokenDB())
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: "/tmp/fake.db")
+
+    with caplog.at_level("WARNING", logger="termstory.ai"):
+        result = _get_project_context_from_db("my-project")
+
+    assert result is None
+    assert any("_get_project_context_from_db" in r.message and "simulated DB failure" in str(r.exc_info[1])
+               for r in caplog.records if r.exc_info)
+
+
+def test_get_all_active_project_contexts_logs_warning_on_db_error(monkeypatch, caplog):
+    """When the DB lookup raises in _get_all_active_project_contexts,
+    the function returns an empty list and logs a warning. Regression test for issue #109."""
+    from termstory.ai import _get_all_active_project_contexts
+
+    class BrokenCursor:
+        def execute(self, *args, **kwargs):
+            raise RuntimeError("simulated DB failure in fetchall")
+
+    class BrokenConn:
+        def cursor(self):
+            return BrokenCursor()
+        def close(self):
+            pass
+
+    class BrokenDB:
+        def get_connection(self):
+            return BrokenConn()
+
+    monkeypatch.setattr("termstory.database.Database", lambda *args, **kwargs: BrokenDB())
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: "/tmp/fake.db")
+
+    with caplog.at_level("WARNING", logger="termstory.ai"):
+        result = _get_all_active_project_contexts()
+
+    assert result == []
+    assert any("_get_all_active_project_contexts" in r.message and "simulated DB failure" in str(r.exc_info[1])
+               for r in caplog.records if r.exc_info)


### PR DESCRIPTION

## Description
Replaces two bare except Exception blocks in termstory/ai.py with logger.warning(..., exc_info=True) calls so DB lookup failures during project context fetching are visible in logs instead of being silently discarded.
Changes:

Added import logging and a module-level logger = logging.getLogger(__name__)
_get_project_context_from_db (line 48): replaced except Exception: pass with a logged warning. Still returns None on failure to preserve existing callers' fallback behaviour.
_get_all_active_project_contexts (line 67): replaced except Exception: return [] with a logged warning followed by return []. Still returns an empty list to preserve existing callers' fallback behaviour.

Added two regression tests in tests/test_ai_error_surfacing.py that pass mock DBs whose cursors raise, then assert the functions return their safe defaults (None and []) and that warnings were logged via caplog.
All 10 tests in test_ai_error_surfacing.py pass locally.

Fixes #109

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] My code follows the "density over decoration" philosophy.
- [x] I have not used `rich.panel.Panel` in my code.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
