### PR TITLE
fix: repair install script and cleanup project config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "termstory"
-version = "0.6.0"
+version = "0.6.1"
 description = "A personal developer memory engine that tracks terminal history to rebuild the story of your projects."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -14,7 +14,6 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [
@@ -29,6 +28,9 @@ dependencies = [
 test = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
+]
+rag = [
+    "sentence-transformers>=2.2.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.6.0"
 description = "A personal developer memory engine that tracks terminal history to rebuild the story of your projects."
 readme = "README.md"
 requires-python = ">=3.9"
-license = { text = "MIT" }
+license = "MIT"
 authors = [
     { name = "TermStory Contributors" }
 ]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,38 +1,131 @@
 #!/bin/bash
-set -e
+# TermStory Installer v0.6.0
+
+set -euo pipefail
 
 echo "=== TermStory Installer v0.6.0 ==="
 
-PYTHON=""; for cmd in python3 python; do command -v $cmd &>/dev/null && PYTHON=$cmd && break; done
-[ -z "$PYTHON" ] && { echo "Python 3 not found"; exit 1; }
-echo "  $($PYTHON --version)"
-echo "  pip: $($PYTHON -m pip --version 2>&1 | head -1)"
-
-TMPDIR=$(mktemp -d)
-echo "  Downloading..."
-curl -fsSL "https://github.com/bitflicker64/Termstory/archive/refs/heads/main.tar.gz" -o "$TMPDIR/termstory.tar.gz"
-tar -xzf "$TMPDIR/termstory.tar.gz" -C "$TMPDIR"
-cd "$TMPDIR/Termstory-main"
-
-echo "  Installing (may need sudo on some systems)..."
-$PYTHON -m pip install --break-system-packages -e . 2>&1 | tail -5
-
-cd /; rm -rf "$TMPDIR"
-
-# Verify
-if $PYTHON -c "import termstory" 2>/dev/null; then
-  BIN=$(find ~/.local/bin ~/Library/Python/*/bin /usr/local/bin -name "termstory" -type f 2>/dev/null | head -1)
-  if [ -n "$BIN" ]; then
-    echo "  ✅ Installed at: $BIN"
-    echo "  Run: $BIN today"
-  else
-    echo "  ✅ Installed! Run: $PYTHON -m termstory.cli today"
+# ── Find Python ────────────────────────────────────────────────────────────────
+PYTHON=""
+for cmd in python3 python; do
+  if command -v "$cmd" &>/dev/null; then
+    PYTHON="$cmd"
+    break
   fi
-else
-  echo "  ⚠️  Module not found after install. Trying venv..."
-  $PYTHON -m venv "$HOME/.termstory-venv"
-  "$HOME/.termstory-venv/bin/pip" install -e . 2>&1 | tail -3
-  echo "  ✅ Installed in venv. Add to ~/.zshrc:"
-  echo '    export PATH="$HOME/.termstory-venv/bin:$PATH"'
-  echo "  Then run: termstory today"
+done
+if [ -z "$PYTHON" ]; then
+  echo "❌ Python 3 not found. Please install it and re-run."
+  exit 1
+fi
+echo "  Python: $($PYTHON --version)"
+echo "  pip:    $($PYTHON -m pip --version 2>&1 | awk '{print $1, $2}')"
+
+# ── Download & extract ─────────────────────────────────────────────────────────
+WORK_DIR=$(mktemp -d)          # avoid shadowing the $TMPDIR env var
+
+cleanup() {
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT              # always clean up, success or failure
+
+echo "  Downloading TermStory..."
+if ! curl -fsSL \
+    "https://github.com/bitflicker64/Termstory/archive/refs/heads/main.tar.gz" \
+    -o "$WORK_DIR/termstory.tar.gz"; then
+  echo "❌ Download failed. Check your internet connection."
+  exit 1
+fi
+
+tar -xzf "$WORK_DIR/termstory.tar.gz" -C "$WORK_DIR"
+SRC_DIR="$WORK_DIR/Termstory-main"
+
+if [ ! -d "$SRC_DIR" ]; then
+  echo "❌ Extracted archive doesn't contain expected directory: $SRC_DIR"
+  exit 1
+fi
+
+# ── pip version helper ─────────────────────────────────────────────────────────
+pip_major_version() {
+  "$PYTHON" -c "import pip; print(int(pip.__version__.split('.')[0]))" 2>/dev/null || echo "0"
+}
+
+# ── Install strategies ─────────────────────────────────────────────────────────
+
+install_venv() {
+  local venv="$HOME/.termstory-venv"
+  echo "  Trying venv install at $venv ..."
+
+  # Remove a broken venv from a previous attempt
+  [ -d "$venv" ] && rm -rf "$venv"
+
+  if ! "$PYTHON" -m venv "$venv" 2>/dev/null; then
+    echo "  venv creation failed (missing venv module?)"
+    return 1
+  fi
+
+  "$venv/bin/pip" install --quiet "$SRC_DIR" 2>&1 | tail -3
+
+  if "$venv/bin/python" -c "import termstory" 2>/dev/null; then
+    echo ""
+    echo "  ✅ Installed in virtualenv."
+    echo "  Add this line to your ~/.bashrc or ~/.zshrc, then open a new terminal:"
+    echo ""
+    echo '    export PATH="$HOME/.termstory-venv/bin:$PATH"'
+    echo ""
+    echo "  Then run:  termstory today"
+    return 0
+  fi
+
+  echo "  venv install didn't produce a working package."
+  return 1
+}
+
+install_user() {
+  echo "  Trying --user install..."
+
+  local pip_ver
+  pip_ver=$(pip_major_version)
+
+  # --break-system-packages introduced in pip 23.0 (needed on Debian/Ubuntu 23+)
+  if [ "$pip_ver" -ge 23 ] 2>/dev/null; then
+    "$PYTHON" -m pip install --quiet --user --break-system-packages "$SRC_DIR" 2>&1 | tail -3
+  else
+    "$PYTHON" -m pip install --quiet --user "$SRC_DIR" 2>&1 | tail -3
+  fi
+
+  if ! "$PYTHON" -c "import termstory" 2>/dev/null; then
+    echo "  User install didn't produce a working package."
+    return 1
+  fi
+
+  # Locate the installed binary (Linux ~/.local/bin or macOS Library path)
+  local bin_path
+  bin_path=$(
+    find \
+      "$HOME/.local/bin" \
+      "$HOME/Library/Python" \
+      -name "termstory" -type f 2>/dev/null | head -1
+  ) || true
+
+  echo ""
+  echo "  ✅ Installed."
+  if [ -n "$bin_path" ]; then
+    echo "  Binary: $bin_path"
+    echo "  Run:    termstory today"
+    echo "  (Ensure $(dirname "$bin_path") is in your PATH)"
+  else
+    echo "  Binary not found in standard locations."
+    echo "  Run:    $PYTHON -m termstory.cli today"
+  fi
+  return 0
+}
+
+# ── Try venv first, then user, then give up ────────────────────────────────────
+if ! install_venv && ! install_user; then
+  echo ""
+  echo "❌ All install strategies failed."
+  echo "   Manual fallback:"
+  echo "     git clone https://github.com/bitflicker64/Termstory.git"
+  echo "     cd Termstory && pip install ."
+  exit 1
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# TermStory Installer v0.6.0
+# TermStory Installer v0.6.1
 
 set -euo pipefail
 
-echo "=== TermStory Installer v0.6.0 ==="
+echo "=== TermStory Installer v0.6.1 ==="
 
 # ── Find Python ────────────────────────────────────────────────────────────────
 PYTHON=""
@@ -49,35 +49,58 @@ pip_major_version() {
   "$PYTHON" -c "import pip; print(int(pip.__version__.split('.')[0]))" 2>/dev/null || echo "0"
 }
 
+# ── Helper: run pip and check its real exit code ───────────────────────────────
+pip_install() {
+  # Usage: pip_install <extra pip args...>
+  # Runs pip install with given args, outputs stderr, returns pip's exit code.
+  local pip_rc=0
+  "$PYTHON" -m pip install --quiet "$@" 2>&1 || pip_rc=$?
+  return $pip_rc
+}
+
 # ── Install strategies ─────────────────────────────────────────────────────────
 
 install_venv() {
-  local venv="$HOME/.termstory-venv"
-  echo "  Trying venv install at $venv ..."
+  local final_venv="$HOME/.termstory-venv"
+  local staging_venv
+  staging_venv=$(mktemp -d)/termstory-venv
+  echo "  Trying venv install at $final_venv ..."
 
-  # Remove a broken venv from a previous attempt
-  [ -d "$venv" ] && rm -rf "$venv"
-
-  if ! "$PYTHON" -m venv "$venv" 2>/dev/null; then
+  # Build replacement in a staging location so we never destroy a working venv
+  if ! "$PYTHON" -m venv "$staging_venv" 2>/dev/null; then
     echo "  venv creation failed (missing venv module?)"
+    rm -rf "$staging_venv"
     return 1
   fi
 
-  "$venv/bin/pip" install --quiet "$SRC_DIR" 2>&1 | tail -3
+  local pip_rc=0
+  "$staging_venv/bin/pip" install --quiet "$SRC_DIR" 2>&1 || pip_rc=$?
 
-  if "$venv/bin/python" -c "import termstory" 2>/dev/null; then
-    echo ""
-    echo "  ✅ Installed in virtualenv."
-    echo "  Add this line to your ~/.bashrc or ~/.zshrc, then open a new terminal:"
-    echo ""
-    echo '    export PATH="$HOME/.termstory-venv/bin:$PATH"'
-    echo ""
-    echo "  Then run:  termstory today"
-    return 0
+  if [ "$pip_rc" -ne 0 ]; then
+    echo "  pip install failed (exit $pip_rc)."
+    rm -rf "$staging_venv"
+    return 1
   fi
 
-  echo "  venv install didn't produce a working package."
-  return 1
+  if ! "$staging_venv/bin/python" -c "import termstory" 2>/dev/null; then
+    echo "  Package not importable after install."
+    rm -rf "$staging_venv"
+    return 1
+  fi
+
+  # Atomically swap — only now do we destroy the old one
+  rm -rf "$final_venv"
+  mv "$staging_venv" "$final_venv"
+
+  echo ""
+  echo "  ✅ Installed in virtualenv."
+  echo "  Run right now:"
+  echo "    $final_venv/bin/termstory today"
+  echo ""
+  echo "  For permanent access, add this line to ~/.bashrc or ~/.zshrc:"
+  echo '    export PATH="$HOME/.termstory-venv/bin:$PATH"'
+  echo ""
+  return 0
 }
 
 install_user() {
@@ -86,15 +109,22 @@ install_user() {
   local pip_ver
   pip_ver=$(pip_major_version)
 
+  local pip_rc=0
   # --break-system-packages introduced in pip 23.0 (needed on Debian/Ubuntu 23+)
   if [ "$pip_ver" -ge 23 ] 2>/dev/null; then
-    "$PYTHON" -m pip install --quiet --user --break-system-packages "$SRC_DIR" 2>&1 | tail -3
+    pip_install --user --break-system-packages "$SRC_DIR" || pip_rc=$?
   else
-    "$PYTHON" -m pip install --quiet --user "$SRC_DIR" 2>&1 | tail -3
+    pip_install --user "$SRC_DIR" || pip_rc=$?
   fi
 
-  if ! "$PYTHON" -c "import termstory" 2>/dev/null; then
-    echo "  User install didn't produce a working package."
+  if [ "$pip_rc" -ne 0 ]; then
+    echo "  pip install failed (exit $pip_rc)."
+    return 1
+  fi
+
+  # Verify import with the same Python that just installed it
+  if ! "$PYTHON" -c "import termstory; print(termstory.__version__)" 2>/dev/null; then
+    echo "  Package not importable after user install."
     return 1
   fi
 

--- a/setup.py
+++ b/setup.py
@@ -1,40 +1,5 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-setup(
-    name="termstory",
-    version="0.6.0",
-    author="TermStory Contributors",
-    description="Local shell history parsing, session grouping, and visual daily chronicle terminal dashboard",
-    long_description=open("README.md", encoding="utf-8").read(),
-    long_description_content_type="text/markdown",
-    url="https://github.com/bitflicker64/Termstory",
-    packages=find_packages(exclude=["tests", "tests.*"]),
-    include_package_data=True,
-    install_requires=[
-        "typer>=0.9.0",
-        "python-dateutil>=2.8.2",
-        "rich>=13.0.0",
-        "textual>=0.50.0",
-        "pillow>=10.0.0",
-     ],
-    extras_require={
-        "test": [
-            "pytest>=7.0.0",
-            "pytest-asyncio>=0.21.0",
-        ],
-        "rag": [
-            "sentence-transformers>=2.2.0",
-        ],
-    },
-    entry_points={
-        "console_scripts": [
-            "termstory=termstory.cli:cli",
-        ],
-    },
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-    ],
-    python_requires=">=3.9",
-)
+# Minimal setup.py for legacy pip compatibility.
+# All config lives in pyproject.toml.
+setup()


### PR DESCRIPTION
- Rewrote install.sh:
  - set -euo pipefail for safer execution
  - trap cleanup EXIT instead of fragile manual cleanup
  - Renamed TMPDIR -> WORK_DIR to avoid env var shadowing
  - pip_major_version() helper with safe fallback to 0
  - Stale venv removal before recreation
  - Explicit curl failure check with readable message
  - find wrapped with || true to avoid set -e kill on empty result
  - Manual git-clone fallback in final failure message

- Stripped setup.py to a pyproject.toml pass-through
- Fixed pyproject.toml license field from TOML table to string
