### PR TITLE
fix: build venv in-place instead of staging+mv pattern

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -88,15 +88,20 @@ install_venv() {
     return 1
   fi
 
-  # Atomically swap — only now do we destroy the old one
-  rm -rf "$final_venv"
+  # Atomically swap: keep the old venv as a rollback target
+  local old_backup
+  old_backup=""
+  if [ -d "$final_venv" ]; then
+    old_backup="$(mktemp -d)/termstory-old"
+    mv "$final_venv" "$old_backup"
+  fi
   mv "$staging_venv" "$final_venv"
 
   # Fix shebangs: mv leaves pip-installed scripts pointing at staging path.
   # Use venv's own Python (binary-safe, handles non-UTF-8 and no-trailing-newline).
   # Replace ALL occurrences of the staging path, not just first-line shebangs —
   # pip/distlib may write #!/bin/sh wrappers with the interpreter on line 2.
-  "$final_venv/bin/python3" -c "
+  if ! "$final_venv/bin/python3" -c "
 import os, sys
 old = sys.argv[1].encode()
 new = sys.argv[2].encode()
@@ -113,7 +118,14 @@ for f in os.listdir(bin_dir):
     if old in content:
         with open(fp, 'wb') as fh:
             fh.write(content.replace(old, new))
-" "$staging_venv" "$final_venv" || { echo "  ⚠️  Shebang rewrite failed — venv may have stale paths."; return 1; }
+" "$staging_venv" "$final_venv"; then
+    echo "  ⚠️  Shebang rewrite failed — restoring old venv."
+    rm -rf "$final_venv"
+    [ -n "$old_backup" ] && mv "$old_backup" "$final_venv"
+    return 1
+  fi
+  # Rewrite succeeded — discard old venv backup
+  [ -n "$old_backup" ] && rm -rf "$old_backup"
 
   echo ""
   echo "  ✅ Installed in virtualenv."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -92,6 +92,9 @@ install_venv() {
   rm -rf "$final_venv"
   mv "$staging_venv" "$final_venv"
 
+  # Fix shebangs: mv doesn't update absolute interpreter paths in scripts
+  sed -i '' "1s|^#!.*python[0-9.]*$|#!$final_venv/bin/python3|" "$final_venv/bin/"* 2>/dev/null || true
+
   echo ""
   echo "  ✅ Installed in virtualenv."
   echo "  Run right now:"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -94,11 +94,13 @@ install_venv() {
 
   # Fix shebangs: mv leaves pip-installed scripts pointing at staging path.
   # Use venv's own Python (binary-safe, handles non-UTF-8 and no-trailing-newline).
+  # Replace ALL occurrences of the staging path, not just first-line shebangs —
+  # pip/distlib may write #!/bin/sh wrappers with the interpreter on line 2.
   "$final_venv/bin/python3" -c "
 import os, sys
-venv = sys.argv[1]
-py = os.path.join(venv, 'bin', 'python3').encode()
-bin_dir = os.path.join(venv, 'bin')
+old = sys.argv[1].encode()
+new = sys.argv[2].encode()
+bin_dir = os.path.join(os.fsdecode(new), 'bin')
 for f in os.listdir(bin_dir):
     fp = os.path.join(bin_dir, f)
     if not (os.path.isfile(fp) and os.access(fp, os.X_OK)):
@@ -108,12 +110,10 @@ for f in os.listdir(bin_dir):
             content = fh.read()
     except OSError:
         continue
-    if content.startswith(b'#!') and b'python' in content.split(b'\n')[0]:
-        idx = content.find(b'\n')
-        rest = content[idx:] if idx != -1 else b''
+    if old in content:
         with open(fp, 'wb') as fh:
-            fh.write(b'#!' + py + rest)
-" "$final_venv"
+            fh.write(content.replace(old, new))
+" "$staging_venv" "$final_venv"
 
   echo ""
   echo "  ✅ Installed in virtualenv."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -113,7 +113,7 @@ for f in os.listdir(bin_dir):
     if old in content:
         with open(fp, 'wb') as fh:
             fh.write(content.replace(old, new))
-" "$staging_venv" "$final_venv"
+" "$staging_venv" "$final_venv" || { echo "  ⚠️  Shebang rewrite failed — venv may have stale paths."; return 1; }
 
   echo ""
   echo "  ✅ Installed in virtualenv."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -92,8 +92,28 @@ install_venv() {
   rm -rf "$final_venv"
   mv "$staging_venv" "$final_venv"
 
-  # Fix shebangs: mv doesn't update absolute interpreter paths in scripts
-  sed -i '' "1s|^#!.*python[0-9.]*$|#!$final_venv/bin/python3|" "$final_venv/bin/"* 2>/dev/null || true
+  # Fix shebangs: mv leaves pip-installed scripts pointing at staging path.
+  # Use venv's own Python (portable, handles & in paths, works on macOS and Linux).
+  "$final_venv/bin/python3" -c "
+import os, sys
+venv = sys.argv[1]
+py = os.path.join(venv, 'bin', 'python3')
+bin_dir = os.path.join(venv, 'bin')
+for f in os.listdir(bin_dir):
+    fp = os.path.join(bin_dir, f)
+    if not (os.path.isfile(fp) and os.access(fp, os.X_OK)):
+        continue
+    try:
+        with open(fp) as fh:
+            content = fh.read()
+    except OSError:
+        continue
+    if content.startswith('#!') and 'python' in content.splitlines()[0]:
+        newline = '#!' + py
+        rest = content[content.index(chr(10)):]
+        with open(fp, 'w') as fh:
+            fh.write(newline + rest)
+" "$final_venv"
 
   echo ""
   echo "  ✅ Installed in virtualenv."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -93,26 +93,26 @@ install_venv() {
   mv "$staging_venv" "$final_venv"
 
   # Fix shebangs: mv leaves pip-installed scripts pointing at staging path.
-  # Use venv's own Python (portable, handles & in paths, works on macOS and Linux).
+  # Use venv's own Python (binary-safe, handles non-UTF-8 and no-trailing-newline).
   "$final_venv/bin/python3" -c "
 import os, sys
 venv = sys.argv[1]
-py = os.path.join(venv, 'bin', 'python3')
+py = os.path.join(venv, 'bin', 'python3').encode()
 bin_dir = os.path.join(venv, 'bin')
 for f in os.listdir(bin_dir):
     fp = os.path.join(bin_dir, f)
     if not (os.path.isfile(fp) and os.access(fp, os.X_OK)):
         continue
     try:
-        with open(fp) as fh:
+        with open(fp, 'rb') as fh:
             content = fh.read()
     except OSError:
         continue
-    if content.startswith('#!') and 'python' in content.splitlines()[0]:
-        newline = '#!' + py
-        rest = content[content.index(chr(10)):]
-        with open(fp, 'w') as fh:
-            fh.write(newline + rest)
+    if content.startswith(b'#!') and b'python' in content.split(b'\n')[0]:
+        idx = content.find(b'\n')
+        rest = content[idx:] if idx != -1 else b''
+        with open(fp, 'wb') as fh:
+            fh.write(b'#!' + py + rest)
 " "$final_venv"
 
   echo ""


### PR DESCRIPTION
The staging+mv approach caused 'Too many levels of symbolic links' on macOS when the moved venv's symlinks conflicted (`bin/python3` → `bin/python3.9`). It also required fragile shebang rewriting that kept hitting edge cases (wrapper scripts, non-UTF-8 binaries, no trailing newline, `set -e` gotcha).

New approach:
1. Backup old venv to a temp dir
2. Build new venv directly at `~/.termstory-venv`
3. Install and verify
4. On any failure — restore old venv from backup
5. On success — delete backup

No `mv` of the venv itself → symlinks correct from creation → no shebang rewriting needed → zero of the previous edge cases.