### PR TITLE
fix: migrate FTS5 virtual tables whose column set drifted from current schema

### DIFF
--- a/termstory/database.py
+++ b/termstory/database.py
@@ -1237,6 +1237,36 @@ class Database:
         if not any('FTS5' in opt for opt in options):
             return
 
+        # FTS5 migration: older DBs may have drifted FTS column sets (e.g. sessions_fts
+        # used to have [content, session_id, project_id, timestamp]; current schema is
+        # [ai_summary]). CREATE VIRTUAL TABLE IF NOT EXISTS leaves drifted tables intact,
+        # so triggers/INSERTs hit "no such column" errors at runtime. Check actual
+        # column sets against expected and rebuild on drift. UNINDEXED is just a
+        # modifier — pragma_table_info still returns those columns.
+        #
+        # All drift checks MUST run before any FTS CREATE/INSERT below — otherwise
+        # a rebuild leaves the table absent and a subsequent CREATE IF NOT EXISTS
+        # has already run as a no-op.
+        def _rebuild_fts_if_drifted(table: str, triggers: list, expected_cols: set) -> None:
+            actual_cols = {r[0] for r in cursor.execute(
+                f"SELECT name FROM pragma_table_info('{table}')"
+            ).fetchall()}
+            if actual_cols != expected_cols:
+                cursor.execute(f"DROP TABLE IF EXISTS {table};")
+                for t in triggers:
+                    cursor.execute(f"DROP TRIGGER IF EXISTS {t};")
+
+        _rebuild_fts_if_drifted("search_index", [], {"content", "type", "ref_id", "project_id", "timestamp"})
+        _rebuild_fts_if_drifted("commands_fts",
+            ["commands_ai", "commands_ad", "commands_au"],
+            {"command", "exit_code"})
+        _rebuild_fts_if_drifted("sessions_fts",
+            ["sessions_ai", "sessions_ad", "sessions_au"],
+            {"ai_summary"})
+        _rebuild_fts_if_drifted("ai_summaries_fts",
+            ["macro_summaries_ai", "macro_summaries_ad", "macro_summaries_au"],
+            {"summary"})
+
         cursor.execute("""
         CREATE VIRTUAL TABLE IF NOT EXISTS search_index USING fts5(
             content,
@@ -1252,21 +1282,21 @@ class Database:
         if count == 0:
             cursor.execute("""
                 INSERT INTO search_index (content, type, ref_id, project_id, timestamp)
-                SELECT command, 'command', CAST(session_id AS TEXT), project_id, timestamp 
-                FROM commands 
+                SELECT command, 'command', CAST(session_id AS TEXT), project_id, timestamp
+                FROM commands
                 WHERE session_id IS NOT NULL;
             """)
-            
+
             cursor.execute("""
                 INSERT INTO search_index (content, type, ref_id, project_id, timestamp)
-                SELECT cleaned_message, 'commit', hash, project_id, timestamp 
+                SELECT cleaned_message, 'commit', hash, project_id, timestamp
                 FROM commits;
             """)
-            
+
             cursor.execute("""
                 INSERT INTO search_index (content, type, ref_id, project_id, timestamp)
-                SELECT ai_summary, 'session_summary', CAST(id AS TEXT), project_id, start_time 
-                FROM sessions 
+                SELECT ai_summary, 'session_summary', CAST(id AS TEXT), project_id, start_time
+                FROM sessions
                 WHERE ai_summary IS NOT NULL;
             """)
 
@@ -1286,27 +1316,6 @@ class Database:
                 SELECT id, command, exit_code FROM commands;
             """)
 
-        # FTS5 migration: older DBs may have drifted FTS column sets (e.g. sessions_fts
-        # used to have [content, session_id, project_id, timestamp]; current schema is
-        # [ai_summary]). CREATE VIRTUAL TABLE IF NOT EXISTS leaves drifted tables intact,
-        # so triggers/INSERTs hit "no such column" errors at runtime. Check the actual
-        # column set against the expected one and rebuild on drift.
-        def _rebuild_fts_if_drifted(table: str, triggers: list, expected_cols: set):
-            try:
-                actual_cols = {r[0] for r in cursor.execute(
-                    f"SELECT name FROM pragma_table_info('{table}')"
-                ).fetchall()}
-            except sqlite3.OperationalError:
-                return  # table doesn't exist yet — CREATE below handles it
-            if actual_cols != expected_cols:
-                cursor.execute(f"DROP TABLE IF EXISTS {table};")
-                for t in triggers:
-                    cursor.execute(f"DROP TRIGGER IF EXISTS {t};")
-
-        _rebuild_fts_if_drifted("sessions_fts",
-            ["sessions_ai", "sessions_ad", "sessions_au"],
-            {"ai_summary"})
-
         # Create and populate sessions_fts virtual table
         cursor.execute("""
         CREATE VIRTUAL TABLE IF NOT EXISTS sessions_fts USING fts5(
@@ -1321,16 +1330,6 @@ class Database:
                 INSERT INTO sessions_fts (rowid, ai_summary)
                 SELECT id, ai_summary FROM sessions WHERE ai_summary IS NOT NULL;
             """)
-
-        _rebuild_fts_if_drifted("commands_fts",
-            ["commands_ai", "commands_ad", "commands_au"],
-            {"command", "exit_code"})
-
-
-
-        _rebuild_fts_if_drifted("ai_summaries_fts",
-            ["macro_summaries_ai", "macro_summaries_ad", "macro_summaries_au"],
-            {"summary"})
 
         # Create and populate ai_summaries_fts virtual table (macro_summaries)
         cursor.execute("""

--- a/termstory/database.py
+++ b/termstory/database.py
@@ -1286,21 +1286,26 @@ class Database:
                 SELECT id, command, exit_code FROM commands;
             """)
 
-        # Migrate sessions_fts: drop and rebuild if column set drifted (e.g. older DBs
-        # where sessions_fts had content/session_id/project_id/timestamp instead of ai_summary).
-        # CREATE VIRTUAL TABLE IF NOT EXISTS doesn't update existing tables.
-        def _sessions_fts_columns():
+        # FTS5 migration: older DBs may have drifted FTS column sets (e.g. sessions_fts
+        # used to have [content, session_id, project_id, timestamp]; current schema is
+        # [ai_summary]). CREATE VIRTUAL TABLE IF NOT EXISTS leaves drifted tables intact,
+        # so triggers/INSERTs hit "no such column" errors at runtime. Check the actual
+        # column set against the expected one and rebuild on drift.
+        def _rebuild_fts_if_drifted(table: str, triggers: list, expected_cols: set):
             try:
-                rows = cursor.execute("SELECT name FROM pragma_table_info('sessions_fts')").fetchall()
-                return {r[0] for r in rows} - {'content'}  # 'content' is shadow, ignore
+                actual_cols = {r[0] for r in cursor.execute(
+                    f"SELECT name FROM pragma_table_info('{table}')"
+                ).fetchall()}
             except sqlite3.OperationalError:
-                return set()
+                return  # table doesn't exist yet — CREATE below handles it
+            if actual_cols != expected_cols:
+                cursor.execute(f"DROP TABLE IF EXISTS {table};")
+                for t in triggers:
+                    cursor.execute(f"DROP TRIGGER IF EXISTS {t};")
 
-        if _sessions_fts_columns() != {'ai_summary'}:
-            cursor.execute("DROP TABLE IF EXISTS sessions_fts;")
-            cursor.execute("DROP TRIGGER IF EXISTS sessions_ai;")
-            cursor.execute("DROP TRIGGER IF EXISTS sessions_ad;")
-            cursor.execute("DROP TRIGGER IF EXISTS sessions_au;")
+        _rebuild_fts_if_drifted("sessions_fts",
+            ["sessions_ai", "sessions_ad", "sessions_au"],
+            {"ai_summary"})
 
         # Create and populate sessions_fts virtual table
         cursor.execute("""
@@ -1316,6 +1321,16 @@ class Database:
                 INSERT INTO sessions_fts (rowid, ai_summary)
                 SELECT id, ai_summary FROM sessions WHERE ai_summary IS NOT NULL;
             """)
+
+        _rebuild_fts_if_drifted("commands_fts",
+            ["commands_ai", "commands_ad", "commands_au"],
+            {"command", "exit_code"})
+
+
+
+        _rebuild_fts_if_drifted("ai_summaries_fts",
+            ["macro_summaries_ai", "macro_summaries_ad", "macro_summaries_au"],
+            {"summary"})
 
         # Create and populate ai_summaries_fts virtual table (macro_summaries)
         cursor.execute("""

--- a/termstory/database.py
+++ b/termstory/database.py
@@ -1286,6 +1286,22 @@ class Database:
                 SELECT id, command, exit_code FROM commands;
             """)
 
+        # Migrate sessions_fts: drop and rebuild if column set drifted (e.g. older DBs
+        # where sessions_fts had content/session_id/project_id/timestamp instead of ai_summary).
+        # CREATE VIRTUAL TABLE IF NOT EXISTS doesn't update existing tables.
+        def _sessions_fts_columns():
+            try:
+                rows = cursor.execute("SELECT name FROM pragma_table_info('sessions_fts')").fetchall()
+                return {r[0] for r in rows} - {'content'}  # 'content' is shadow, ignore
+            except sqlite3.OperationalError:
+                return set()
+
+        if _sessions_fts_columns() != {'ai_summary'}:
+            cursor.execute("DROP TABLE IF EXISTS sessions_fts;")
+            cursor.execute("DROP TRIGGER IF EXISTS sessions_ai;")
+            cursor.execute("DROP TRIGGER IF EXISTS sessions_ad;")
+            cursor.execute("DROP TRIGGER IF EXISTS sessions_au;")
+
         # Create and populate sessions_fts virtual table
         cursor.execute("""
         CREATE VIRTUAL TABLE IF NOT EXISTS sessions_fts USING fts5(


### PR DESCRIPTION
Older databases can have FTS5 virtual tables whose column set no longer matches the current code. CREATE VIRTUAL TABLE IF NOT EXISTS leaves drifted schemas intact, so triggers and INSERTs hit:

```
OperationalError: table sessions_fts has no column named ai_summary
```

This is the runtime error that was blocking ingestion on first launch.

## Fix

`init_db` introduces `_rebuild_fts_if_drifted(table, triggers, expected_cols)` which:
1. Inspects the actual columns via `pragma_table_info('table')`.
2. Drops the FTS table + its triggers if columns don't match.
3. Lets existing CREATE IF NOT EXISTS repopulate.

Guards now cover all four FTS tables in `_migrate_fts5`:
- `search_index` ⟶ {content, type, ref_id, project_id, timestamp}
- `commands_fts` ⟶ {command, exit_code}
- `sessions_fts` ⟶ {ai_summary}
- `ai_summaries_fts` ⟶ {summary}

## Why it took multiple rounds

PR #133 went through several revisions flagged by Greptile and Dosu:

**Round 1**: Subtraction bug — code did `{cols} - {'content'}` as if 'content' were a shadow column, but FTS5 declares it as a real column. A schema with both 'content' and 'ai_summary' would have slipped past the guard.

**Round 2 / Dosu**: Same drift risk on commands_fts and ai_summaries_fts; no guard for search_index.

**Round 3 / Greptile T-Rex**: commands_fts guard was placed AFTER its CREATE/INSERT block, so a drifted schema hit 'no column named exit_code' during population before the rebuild ever ran.

**Round 4 / manual test**: search_index guard for the same ordering issue caused CREATE IF NOT EXISTS to no-op, leaving the rebuilt table absent.

**Final**: All four drift checks now run before any CREATE/INSERT. Dead except branch removed (pragma_table_info returns empty set, not error).

## Verification

Forced each of four drift states in a sandbox DB copy and ran `init_db`:

| Drift state | Result |
|--------------|--------|
| sessions_fts = content+session_id+project_id+timestamp | ✓ migrated to ai_summary |
| sessions_fts = content+ai_summary (Greptile case) | ✓ migrated to ai_summary |
| commands_fts = command (missing exit_code) | ✓ migrated to command+exit_code |
| search_index = content+type (drifted) | ✓ migrated to full set |