### PR TITLE
Bound database query logs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,7 @@ Config lives at `~/.termstory/config.json`:
     "ai_enabled": true,
     "active_provider": "groq",
     "request_timeout_seconds": 30,
+    "max_query_log": 10000,
     "has_seen_onboarding": true,
     "providers": {
         "groq": {
@@ -39,6 +40,7 @@ Key configuration parameters:
 - `ai_enabled` (bool): Toggle AI summaries on/off.
 - `active_provider` (string): Set to `"groq"`, `"openai"`, `"ollama"`, `"custom"`, or `"disabled"`.
 - `request_timeout_seconds` (int): HTTP request timeout (in seconds) for LLM API calls. Defaults to `30`.
+- `max_query_log` (int): Maximum number of captured database query profiler entries before older entries are trimmed. Defaults to `10000`.
 - `providers.<name>.<param>`: Provider-specific endpoints, API keys, and model names.
 
 ---

--- a/termstory/config.py
+++ b/termstory/config.py
@@ -161,7 +161,8 @@ def load_config() -> dict:
         "has_seen_onboarding": False,
         "has_seen_timestamp_prompt": False,
         "has_seen_onboarding_reminder": False,
-        "max_history_age": 5
+        "max_history_age": 5,
+        "max_query_log": 10000
     }
     
     config = {}

--- a/termstory/database.py
+++ b/termstory/database.py
@@ -3,6 +3,7 @@ import json
 from datetime import datetime
 from typing import List, Dict, Optional
 from termstory.models import Command, Session, Project
+from termstory.config import get_config_value, load_config
 import time
 def safe_execute(cursor_or_conn, sql, *args, **kwargs):
     """A reusable helper to safely execute SQL queries."""
@@ -50,15 +51,21 @@ class SafeConnection(sqlite3.Connection):
         return safe_execute(self, sql, *args, **kwargs)
 
 class Database:
+    MAX_QUERY_LOG = 10000
+
     def __init__(self, db_path: str):
         self.db_path = db_path
         self.query_logs = []
+        configured_max = get_config_value(load_config(), "max_query_log")
+        self.max_query_log = configured_max if type(configured_max) is int and configured_max > 0 else self.MAX_QUERY_LOG
 
     def log_query(self, sql: str, duration: float):
         self.query_logs.append({
             "sql": sql,
             "duration": duration
         })
+        if len(self.query_logs) > self.max_query_log:
+            self.query_logs = self.query_logs[len(self.query_logs) // 2:]
         
     def get_connection(self) -> sqlite3.Connection:
         """Create and return a database connection with foreign key support enabled"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,6 +29,7 @@ def test_load_config_missing_file(tmp_path):
         assert config["ai_enabled"] is False
         assert config["active_provider"] == "disabled"
         assert config["max_history_age"] == 5
+        assert config["max_query_log"] == 10000
 
 def test_save_config_error_handling(tmp_path):
     # If open fails, save_config should not raise an exception

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -291,5 +291,16 @@ def test_database_profiler_logs_queries(tmp_path):
     assert all(isinstance(log["duration"], float) for log in db.query_logs)
 
 
+def test_database_query_logs_are_bounded():
+    db = Database(":memory:")
+    db.max_query_log = 10
+
+    for i in range(16):
+        db.log_query(f"SELECT {i}", 0.001)
+
+    assert len(db.query_logs) <= db.max_query_log
+    assert db.query_logs[0]["sql"] == "SELECT 10"
+    assert db.query_logs[-1]["sql"] == "SELECT 15"
+
 
 


### PR DESCRIPTION
## Summary
- Add a configurable `max_query_log` default to bound in-memory database profiler logs
- Trim older query log entries when the cap is exceeded, keeping recent profiler data
- Document the new config value and cover it with database/config tests

Fixes #117

## Tests
- `conda run -n haystack-learn python -m pytest tests/test_database.py tests/test_config.py -q`