### PR TITLE
install: shell RC integration + dedicated uninstall.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,23 @@ We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guid
 
 ## Uninstall
 
+Use the dedicated uninstaller script — it removes the venv, data directory, and the PATH line that the installer added to your shell RC file:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/bitflicker64/Termstory/main/scripts/uninstall.sh | bash -s -- --yes
+```
+
+Or run locally:
+
+```bash
+bash scripts/uninstall.sh --yes
+```
+
+Or uninstall by hand (a subset of what the script does):
+
 ```bash
 pip uninstall termstory -y 2>/dev/null
+rm -rf ~/.termstory-venv
 rm -rf ~/.termstory
 ```
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -70,28 +70,40 @@ RC_MARKER="# Added by termstory installer"
 RC_EXPORT_LINE='export PATH="$HOME/.termstory-venv/bin:$PATH"'
 RC_FULL_BLOCK="${RC_MARKER}${RC_EXPORT_LINE}"
 
-# Returns 0 if the export AND its marker both appear in this file.
+# Returns 0 if the export AND its marker both appear in this file as
+# an adjacent block (marker immediately followed by the export line).
 rc_has_export() {
   local rc="$1"
   [ -f "$rc" ] || return 1
-  grep -Fqx "$RC_MARKER" "$rc" && grep -Fqx "$RC_EXPORT_LINE" "$rc"
+  awk -v marker="$RC_MARKER" -v export_line="$RC_EXPORT_LINE" '
+    BEGIN { prev_marker = 0 }
+    prev_marker == 1 && $0 == export_line { found = 1; exit }
+    { prev_marker = ($0 == marker ? 1 : 0) }
+    END { exit (found ? 0 : 1) }
+  ' "$rc"
 }
 
 # Pick the candidate RC file for the active shell, in order of preference.
-# Args: current_rc (set by caller), ordered list of candidate paths.
+# Always returns a target path (creating it if absent for the fresh-shell case)
+# so the prompt can offer to bring up a brand new RC file when the user wants one.
 rc_target_for_install() {
   local shell_name
   shell_name="${SHELL##*/}"
 
   case "$shell_name" in
     zsh)
-      [ -f "$HOME/.zshrc" ] && echo "$HOME/.zshrc" && return 0
+      echo "$HOME/.zshrc"
+      return 0
       ;;
     bash)
-      # On macOS the user typically sources .bash_profile, not .bashrc.
-      # If .bashrc exists we prefer it for login shells too.
-      [ -f "$HOME/.bashrc" ] && echo "$HOME/.bashrc" && return 0
-      [ -f "$HOME/.bash_profile" ] && echo "$HOME/.bash_profile" && return 0
+      # Prefer .bashrc if it exists; fall back to .bash_profile for macOS.
+      # If neither exists yet, surface .bashrc — it's the modern choice.
+      if [ -f "$HOME/.bashrc" ] || ! [ -f "$HOME/.bash_profile" ]; then
+        echo "$HOME/.bashrc"
+      else
+        echo "$HOME/.bash_profile"
+      fi
+      return 0
       ;;
   esac
   return 1
@@ -110,14 +122,37 @@ rc_append_export() {
   } >> "$rc"
 }
 
+# Print manual PATH instructions. Used whenever we can't prompt the user
+# (non-TTY, fresh-shell case where the user declined, etc.).
+print_manual_path_instructions() {
+  local target="${1:-}"
+  echo ""
+  echo "  For permanent access, add this to your shell RC file:"
+  echo ""
+  echo "    # Added by termstory installer"
+  echo '    export PATH="$HOME/.termstory-venv/bin:$PATH"'
+  if [ -n "$target" ]; then
+    echo ""
+    echo "  Recommended file: $target"
+  fi
+  echo ""
+  echo "  Run right now (no shell restart needed):"
+  echo '    $HOME/.termstory-venv/bin/termstory today'
+}
+
 offer_path_export() {
-  # Skip if running in a non-interactive context.
-  if ! [ -t 0 ]; then
+  # If neither stdin nor /dev/tty is interactive, just print manual steps.
+  # We check /dev/tty because piped curls and similar redirect stdin but
+  # /dev/tty is still the controlling terminal — that's the only way to
+  # read user input reliably.
+  if ! [ -t 0 ] && ! [ -r /dev/tty ]; then
+    print_manual_path_instructions
     return 0
   fi
 
   local target
   if ! target=$(rc_target_for_install); then
+    print_manual_path_instructions
     return 0
   fi
 
@@ -126,23 +161,45 @@ offer_path_export() {
     return 0
   fi
 
-  echo ""
-  printf '  Add export PATH="$HOME/.termstory-venv/bin:$PATH" to %s? [y/N] ' "$(basename "$target")"
-  local reply
-  # Read from /dev/tty so this works even when stdin was redirected.
-  read -r reply </dev/tty 2>/dev/null || reply=""
-  case "$reply" in
-    [Yy]|[Yy][Ee][Ss])
-      rc_append_export "$target"
-      echo "  ✅ Appended to $target"
-      echo "     Activate now:  source $target"
-      ;;
-    *)
-      echo "  Manual setup:"
-      echo "    $target (or ~/.bashrc / ~/.zshrc on different shells)"
-      echo "    $RC_EXPORT_LINE"
-      ;;
-  esac
+  # If the RC file doesn't exist yet, confirm with the user before creating it
+  # — we never auto-modify dotfiles without consent.
+  if [ ! -f "$target" ]; then
+    echo ""
+    printf '  Create %s with the termstory PATH export? [y/N] ' "$(basename "$target")"
+    local reply
+    read -r reply </dev/tty 2>/dev/null || reply=""
+    case "$reply" in
+      [Yy]|[Yy][Ee][Ss])
+        : # fall through to append below
+        ;;
+      *)
+        print_manual_path_instructions "$target"
+        return 0
+        ;;
+    esac
+  else
+    echo ""
+    printf '  Add export PATH="$HOME/.termstory-venv/bin:$PATH" to %s? [y/N] ' "$(basename "$target")"
+    local reply
+    read -r reply </dev/tty 2>/dev/null || reply=""
+    case "$reply" in
+      [Yy]|[Yy][Ee][Ss])
+        : # fall through
+        ;;
+      *)
+        echo ""
+        echo "  Manual setup:"
+        echo "    Append to $target:"
+        echo "    $RC_MARKER"
+        echo "    $RC_EXPORT_LINE"
+        return 0
+        ;;
+    esac
+  fi
+
+  rc_append_export "$target"
+  echo "  ✅ Appended to $target"
+  echo "     Activate now:  source $target"
 }
 
 # ── Install strategies ─────────────────────────────────────────────────────────

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# TermStory Installer v0.6.3
+# TermStory Installer v0.6.4
 
 set -euo pipefail
 
-echo "=== TermStory Installer v0.6.3 ==="
+echo "=== TermStory Installer v0.6.4 ==="
 
 # ── Find Python ────────────────────────────────────────────────────────────────
 PYTHON=""
@@ -62,6 +62,89 @@ pip_major_version() {
   "$PYTHON" -c "import pip; print(int(pip.__version__.split('.')[0]))" 2>/dev/null || echo "0"
 }
 
+# ── Shell RC integration ──────────────────────────────────────────────────────
+# Marker line so we can idempotently find/remove OUR export later.
+# The marker is a comment containing a stable token, so uninstall.sh can
+# regex-anchor and only ever touch our own insert (never user config).
+RC_MARKER="# Added by termstory installer"
+RC_EXPORT_LINE='export PATH="$HOME/.termstory-venv/bin:$PATH"'
+RC_FULL_BLOCK="${RC_MARKER}${RC_EXPORT_LINE}"
+
+# Returns 0 if the export AND its marker both appear in this file.
+rc_has_export() {
+  local rc="$1"
+  [ -f "$rc" ] || return 1
+  grep -Fqx "$RC_MARKER" "$rc" && grep -Fqx "$RC_EXPORT_LINE" "$rc"
+}
+
+# Pick the candidate RC file for the active shell, in order of preference.
+# Args: current_rc (set by caller), ordered list of candidate paths.
+rc_target_for_install() {
+  local shell_name
+  shell_name="${SHELL##*/}"
+
+  case "$shell_name" in
+    zsh)
+      [ -f "$HOME/.zshrc" ] && echo "$HOME/.zshrc" && return 0
+      ;;
+    bash)
+      # On macOS the user typically sources .bash_profile, not .bashrc.
+      # If .bashrc exists we prefer it for login shells too.
+      [ -f "$HOME/.bashrc" ] && echo "$HOME/.bashrc" && return 0
+      [ -f "$HOME/.bash_profile" ] && echo "$HOME/.bash_profile" && return 0
+      ;;
+  esac
+  return 1
+}
+
+# Append the marker+export block to a file, but only if not present.
+rc_append_export() {
+  local rc="$1"
+  if rc_has_export "$rc"; then
+    return 0
+  fi
+  {
+    echo ""
+    echo "${RC_MARKER}"
+    echo "${RC_EXPORT_LINE}"
+  } >> "$rc"
+}
+
+offer_path_export() {
+  # Skip if running in a non-interactive context.
+  if ! [ -t 0 ]; then
+    return 0
+  fi
+
+  local target
+  if ! target=$(rc_target_for_install); then
+    return 0
+  fi
+
+  if rc_has_export "$target"; then
+    echo "  ✅ PATH export already present in $target"
+    return 0
+  fi
+
+  echo ""
+  printf '  Add export PATH="$HOME/.termstory-venv/bin:$PATH" to %s? [y/N] ' "$(basename "$target")"
+  local reply
+  # Read from /dev/tty so this works even when stdin was redirected.
+  read -r reply </dev/tty 2>/dev/null || reply=""
+  case "$reply" in
+    [Yy]|[Yy][Ee][Ss])
+      rc_append_export "$target"
+      echo "  ✅ Appended to $target"
+      echo "     Activate now:  source $target"
+      ;;
+    *)
+      echo "  Manual setup:"
+      echo "    $target (or ~/.bashrc / ~/.zshrc on different shells)"
+      echo "    $RC_EXPORT_LINE"
+      ;;
+  esac
+}
+
 # ── Install strategies ─────────────────────────────────────────────────────────
 
 install_venv() {
@@ -112,12 +195,11 @@ install_venv() {
 
   echo ""
   echo "  ✅ Installed in virtualenv."
-  echo "  Run right now:"
+  echo "  Run right now (no shell restart needed):"
   echo "    $venv/bin/termstory today"
   echo ""
-  echo "  For permanent access, add to ~/.bashrc or ~/.zshrc:"
-  echo '    export PATH="$HOME/.termstory-venv/bin:$PATH"'
-  echo ""
+
+  offer_path_export
 }
 
 install_user() {

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# TermStory Uninstaller v0.6.4
+
+set -euo pipefail
+
+echo "=== TermStory Uninstaller v0.6.4 ==="
+
+# Mirror the installer's marker so we only ever touch OUR inserts.
+RC_MARKER="# Added by termstory installer"
+RC_EXPORT_LINE='export PATH="$HOME/.termstory-venv/bin:$PATH"'
+
+VENV_DIR="$HOME/.termstory-venv"
+DATA_DIR="$HOME/.termstory"
+
+# ── Confirm with user unless --yes passed ────────────────────────────────────
+auto_yes=0
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes) auto_yes=1 ;;
+    -h|--help)
+      echo "Usage: uninstall.sh [--yes|-y]"
+      echo "    --yes    Skip confirmation prompt"
+      exit 0
+      ;;
+  esac
+done
+
+if ! [ "$auto_yes" -eq 1 ]; then
+  if [ -t 0 ]; then
+    printf '  Uninstall TermStory (delete venv, data, and RC exports)? [y/N] '
+    read -r reply </dev/tty 2>/dev/null || reply=""
+    case "$reply" in
+      [Yy]|[Yy][Ee][Ss]) ;;
+      *) echo "  Aborted."; exit 0 ;;
+    esac
+  else
+    echo "  Non-interactive shell and no --yes flag passed. Aborted."
+    echo "  Re-run with:  bash scripts/uninstall.sh --yes"
+    exit 0
+  fi
+fi
+
+# ── 1. Remove venv ────────────────────────────────────────────────────────────
+if [ -d "$VENV_DIR" ]; then
+  echo "  Removing $VENV_DIR ..."
+  rm -rf "$VENV_DIR"
+else
+  echo "  No venv at $VENV_DIR — skipping."
+fi
+
+# ── 2. Remove data dir (the SQLite DB) ────────────────────────────────────────
+if [ -d "$DATA_DIR" ]; then
+  echo "  Removing $DATA_DIR ..."
+  rm -rf "$DATA_DIR"
+else
+  echo "  No data at $DATA_DIR — skipping."
+fi
+
+# ── 3. pip uninstall (per-user / --user install) ─────────────────────────────
+if command -v pip3 >/dev/null 2>&1 || command -v python3 >/dev/null 2>&1; then
+  py=""
+  for cmd in python3 python; do
+    if command -v "$cmd" >/dev/null 2>&1; then
+      py="$cmd"
+      break
+    fi
+  done
+  if [ -n "$py" ]; then
+    # Capture rc; ignore failures (package may not be installed)
+    rc=0
+    "$py" -m pip uninstall -y termstory 2>/dev/null || rc=$?
+    if [ "$rc" -eq 0 ]; then
+      echo "  pip uninstall: OK"
+    else
+      echo "  pip uninstall: package not found or already gone — skipping."
+    fi
+  fi
+fi
+
+# ── 4. Clean up RC files ─────────────────────────────────────────────────────
+# Scan ~/.bashrc, ~/.zshrc, ~/.bash_profile. Only ever touch the lines
+# prefixed with our marker — never user-owned config.
+candidates=()
+[ -f "$HOME/.zshrc" ]         && candidates+=("$HOME/.zshrc")
+[ -f "$HOME/.bashrc" ]        && candidates+=("$HOME/.bashrc")
+[ -f "$HOME/.bash_profile" ]  && candidates+=("$HOME/.bash_profile")
+
+removed_runs=0
+if [ "${#candidates[@]}" -gt 0 ]; then
+  for rc in "${candidates[@]}"; do
+    if grep -Fqx "$RC_MARKER" "$rc" 2>/dev/null; then
+      echo "  Cleaning $rc ..."
+      # Match the marker line + the immediately-following export line.
+      # Use temp file for portability (BSD/GNU grep -z interacts oddly).
+      tmp="${rc}.termstory-uninstall.tmp"
+      awk -v marker="$RC_MARKER" -v export_line="$RC_EXPORT_LINE" '
+        BEGIN { skip = 0 }
+        $0 == marker { skip = 1; next }
+        skip == 1 && $0 == export_line { skip = 0; next }
+        skip == 1 { print; next }
+        { print }
+      ' "$rc" > "$tmp" && mv "$tmp" "$rc"
+      removed_runs=$((removed_runs + 1))
+    fi
+  done
+  if [ "$removed_runs" -eq 0 ]; then
+    echo "  No marker found in RC files — nothing to clean."
+  fi
+else
+  echo "  No RC files to scan."
+fi
+
+echo ""
+echo "  ✅ TermStory uninstalled."
+echo ""
+echo "  Note: open a new shell (or 'source ~/.zshrc') to drop the PATH"
+echo "        entry from the current session."


### PR DESCRIPTION
Closes #134

Two complementary scripts so the RC-file lifecycle is fully handled.

## scripts/install.sh — PATH export integration

After a successful venv install:

1. Resolve the active shell's RC file in this order: `.zshrc`, `.bashrc`, `.bash_profile`.
2. If the marker-prefixed export already exists → skip silently.
3. If not → prompt `[y/N]` interactively, append on yes, print manual steps on no.
4. Non-interactive contexts (curl `|` bash, etc.) skip the prompt entirely and just print the manual command.

The prompt reads from `/dev/tty` so it still works when stdin was redirected by a parent shell.

A stable marker line `# Added by termstory installer` anchors the append so re-installs are idempotent and the uninstaller can find the same line later.

## scripts/uninstall.sh — new file

Removes everything termstory creates, with safe RC cleanup:

- `rm -rf ~/.termstory-venv` (the venv)
- `rm -rf ~/.termstory` (data dir + SQLite DB)
- `python3 -m pip uninstall -y termstory` (per-user installs; ignored if absent)
- awk-based cleanup of marker-prefixed lines from `.zshrc`, `.bashrc`, `.bash_profile` — touches ONLY lines we ourselves inserted (anonymous cleanup would be unsafe)

Interactive confirmation via `[y/N]`, or pass `--yes` for non-interactive use.

Edge cases verified locally:
- Multiple interleaved marker+export pairs — both removed, user config preserved
- Marker on the last line with no trailing newline — cleaned correctly
- Bare mention of "termstory-venv" without the marker prefix — left untouched

## README.md

- Added the one-liner uninstall command
- Listed the manual uninstall steps as a fallback

## Sharing the marker

`RC_MARKER="# Added by termstory installer"` is duplicated in both scripts. If they ever drift the uninstaller becomes a silent no-op on cleanup. Acceptable for v0.6.4; if anyone feels strongly we can extract to a shared sourced file later.