### PR TITLE
fix: replace self.dismiss() with call_after_refresh in message handlers

### DIFF
--- a/termstory/tui.py
+++ b/termstory/tui.py
@@ -401,10 +401,10 @@ class HelpScreen(ModalScreen[None]):
         
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "btn-close-help":
-            self.dismiss()
+            self.call_after_refresh(self.dismiss)
             
     def action_dismiss_none(self) -> None:
-        self.dismiss()
+        self.call_after_refresh(self.dismiss)
 
 
 class OnboardingScreen(ModalScreen[dict]):
@@ -531,10 +531,10 @@ class OnboardingScreen(ModalScreen[dict]):
         self.config["ai_enabled"] = False
         self.config["active_provider"] = "disabled"
         self.config["has_seen_onboarding"] = True
-        self.dismiss(self.config)
+        self.call_after_refresh(self.dismiss, self.config)
         
     def action_dismiss_none(self) -> None:
-        self.dismiss(None)
+        self.call_after_refresh(self.dismiss, None)
         
     def on_button_pressed(self, event: Button.Pressed) -> None:
         button_id = event.button.id
@@ -592,14 +592,14 @@ class OnboardingScreen(ModalScreen[dict]):
             self.config["active_provider"] = self.selected_provider
             self.config["has_seen_onboarding"] = True
             
-            self.dismiss(self.config)
+            self.call_after_refresh(self.dismiss, self.config)
         elif button_id == "btn-disable-ai":
             github_username = self.query_one("#input-github-username").value.strip().lstrip('@')
             self.config["github_username"] = github_username
             self.config["ai_enabled"] = False
             self.config["active_provider"] = "disabled"
             self.config["has_seen_onboarding"] = True
-            self.dismiss(self.config)
+            self.call_after_refresh(self.dismiss, self.config)
 
 
 
@@ -1624,10 +1624,10 @@ class ResetConfirmScreen(ModalScreen):
         )
     
     def action_confirm_reset(self) -> None:
-        self.dismiss(True)
+        self.call_after_refresh(self.dismiss, True)
     
     def action_cancel_reset(self) -> None:
-        self.dismiss(False)
+        self.call_after_refresh(self.dismiss, False)
 
 
 class MatrixDefragScreen(ModalScreen[None]):


### PR DESCRIPTION
Fixes Textual 0.87+ ScreenError on all screen dismiss calls during .

**Root cause:** Textual 0.87+ removed support for calling  directly inside action_* and on_button_pressed message handlers. The call now raises:

    ScreenError: Can't await screen.dismiss() from the screen's message handler

**Fix:** Replace all 8  calls with , which schedules the dismiss after the current handler returns and avoids the Textual error.

**Corrected:**
-  (line 404)
-  (line 407)
-  (line 534)
-  (line 537)
-  — both success and disable-ai branches (lines 595, 602)
-  (line 1627)
-  (line 1630)

All 5 existing tests pass.