### PR TITLE
Fix: secrets leaking into LLM prompts via ask/chronicle (and commit messages everywhere)

### DIFF
--- a/termstory/ai.py
+++ b/termstory/ai.py
@@ -580,12 +580,17 @@ def generate_daily_chronicle_prompt(
         # Commands (filter noise, include exit codes for failed ones)
         cmds = [cmd for cmd in s.commands if not _is_noise_command(cmd.command)]
         if cmds:
-            shown = cmds[:15]
-            sanitized_cmds, is_blacklisted = sanitize_session_commands([c.command for c in shown])
+            # Blacklist check runs on the FULL non-noise list — a sensitive
+            # op at index N>15 must still gate the session, not just edit the
+            # sanitized text replacement for the first 15 displayed.
+            all_non_noise_cmds = [c.command for c in cmds]
+            _, is_blacklisted = sanitize_session_commands(all_non_noise_cmds)
             chrono_lines.append("COMMANDS:")
             if is_blacklisted:
                 chrono_lines.append("  - [REDACTED: Security/Authentication Operations]")
             else:
+                shown = cmds[:15]
+                sanitized_cmds, _ = sanitize_session_commands([c.command for c in shown])
                 for cmd, sc in zip(shown, sanitized_cmds):
                     exit_str = f" (Exit Code {cmd.exit_code})" if cmd.exit_code != 0 else ""
                     chrono_lines.append(f"  - {sc}{exit_str}")

--- a/termstory/ai.py
+++ b/termstory/ai.py
@@ -6,7 +6,7 @@ import threading
 import time
 import socket
 from typing import List, Optional, Dict
-from termstory.sanitizer import sanitize_session_commands
+from termstory.sanitizer import sanitize_session_commands, redact_command
 
 logger = logging.getLogger(__name__)
 _local_ai_state = threading.local()
@@ -314,7 +314,8 @@ def generate_ai_summary(
     commits_block = ""
     if commits:
         unique_commits = sorted(list(set(commits)))
-        commits_block = "\nGit Commit Messages:\n" + "\n".join(f"- {c}" for c in unique_commits)
+        sanitized_commits = [redact_command(c) for c in unique_commits]
+        commits_block = "\nGit Commit Messages:\n" + "\n".join(f"- {c}" for c in sanitized_commits)
         
     context_str = ""
     db_context = _get_project_context_from_db(project_name)
@@ -574,15 +575,20 @@ def generate_daily_chronicle_prompt(
             chrono_lines.append("GIT COMMITS:")
             for c in s.commits:
                 msg = c.get("cleaned_message") or c.get("message") or ""
-                chrono_lines.append(f"  - {msg}")
+                chrono_lines.append(f"  - {redact_command(msg)}")
                 
         # Commands (filter noise, include exit codes for failed ones)
         cmds = [cmd for cmd in s.commands if not _is_noise_command(cmd.command)]
         if cmds:
+            shown = cmds[:15]
+            sanitized_cmds, is_blacklisted = sanitize_session_commands([c.command for c in shown])
             chrono_lines.append("COMMANDS:")
-            for cmd in cmds[:15]:
-                exit_str = f" (Exit Code {cmd.exit_code})" if cmd.exit_code != 0 else ""
-                chrono_lines.append(f"  - {cmd.command}{exit_str}")
+            if is_blacklisted:
+                chrono_lines.append("  - [REDACTED: Security/Authentication Operations]")
+            else:
+                for cmd, sc in zip(shown, sanitized_cmds):
+                    exit_str = f" (Exit Code {cmd.exit_code})" if cmd.exit_code != 0 else ""
+                    chrono_lines.append(f"  - {sc}{exit_str}")
                 
         chrono_lines.append("")
         

--- a/termstory/ask.py
+++ b/termstory/ask.py
@@ -316,12 +316,15 @@ def generate_answer(query: str, sessions: List[Session], ai_client) -> Optional[
             block.append(f"Summary: {s.ai_summary.strip()}")
 
         if s.commands:
-            raw_cmds = [cmd.command for cmd in s.commands[:40]]
-            sanitized_cmds, is_blacklisted = sanitize_session_commands(raw_cmds)
+            # Check blacklist against ALL commands, not just the displayed
+            # slice — a sensitive op at index N>40 must still gate the session.
+            all_cmds = [cmd.command for cmd in s.commands]
+            _, is_blacklisted = sanitize_session_commands(all_cmds)
             block.append("Commands:")
             if is_blacklisted:
                 block.append("  - [REDACTED: Security/Authentication Operations]")
             else:
+                sanitized_cmds, _ = sanitize_session_commands(all_cmds[:40])
                 for sc in sanitized_cmds:
                     block.append(f"  - {sc}")
                 if len(s.commands) > 40:

--- a/termstory/ask.py
+++ b/termstory/ask.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Dict, Tuple
 from termstory.models import Session, Command
 from termstory.config import get_db_path
 from termstory.ai import _send_llm_request
+from termstory.sanitizer import sanitize_session_commands, redact_command
 
 # BM25 tuning constants
 _BM25_K1 = 1.5   # term-frequency saturation
@@ -315,18 +316,23 @@ def generate_answer(query: str, sessions: List[Session], ai_client) -> Optional[
             block.append(f"Summary: {s.ai_summary.strip()}")
 
         if s.commands:
+            raw_cmds = [cmd.command for cmd in s.commands[:40]]
+            sanitized_cmds, is_blacklisted = sanitize_session_commands(raw_cmds)
             block.append("Commands:")
-            for cmd in s.commands[:40]:
-                block.append(f"  - {cmd.command}")
-            if len(s.commands) > 40:
-                block.append(f"  - ... ({len(s.commands) - 40} more commands)")
+            if is_blacklisted:
+                block.append("  - [REDACTED: Security/Authentication Operations]")
+            else:
+                for sc in sanitized_cmds:
+                    block.append(f"  - {sc}")
+                if len(s.commands) > 40:
+                    block.append(f"  - ... ({len(s.commands) - 40} more commands)")
 
         if s.commits:
             block.append("Git Commits:")
             for commit in s.commits[:15]:
                 msg = commit.get("cleaned_message") or commit.get("message") or ""
                 if msg.strip():
-                    block.append(f"  - {msg.strip()}")
+                    block.append(f"  - {redact_command(msg.strip())}")
 
         context_blocks.append("\n".join(block))
 
@@ -344,7 +350,8 @@ def generate_answer(query: str, sessions: List[Session], ai_client) -> Optional[
         "1. Answer the user's query as accurately and concisely as possible using ONLY the provided context.\n"
         "2. If the context does not contain the answer, say so clearly (e.g. 'I could not find information matching your query in the history.').\n"
         "3. Provide relevant command examples, project names, or commit messages when applicable.\n"
-        "4. Be technical, developer-friendly, and avoid unnecessary filler or fluff.\n\n"
+        "4. Be technical, developer-friendly, and avoid unnecessary filler or fluff.\n"
+        "5. Never output API keys, tokens, passwords, or credential values verbatim, even if present in the context. Refer to them generically (e.g. 'an API key was configured') instead.\n\n"
         "Answer:"
     )
 

--- a/termstory/sanitizer.py
+++ b/termstory/sanitizer.py
@@ -36,7 +36,13 @@ BLACKLIST_PATTERNS = [
     re.compile(r'\bgithub_pat_[a-zA-Z0-9_]+\b', re.IGNORECASE),
     re.compile(r'\bsk_live_[a-zA-Z0-9_]+\b', re.IGNORECASE),
     re.compile(r'\bnpm_[a-zA-Z0-9]{36}\b', re.IGNORECASE),
-    re.compile(r'\bsk-(?:proj-|ant-api03-)?[a-zA-Z0-9]{20,}\b', re.IGNORECASE)
+    re.compile(r'\bsk-(?:proj-|ant-api03-)?[a-zA-Z0-9]{20,}\b', re.IGNORECASE),
+    # GitHub PAT prefixes (ghp_, gho_, ghu_, ghs_, ghr_)
+    re.compile(r'\bgh[psouhr]_[a-zA-Z0-9]{20,}\b', re.IGNORECASE),
+    # URI credentials: scheme://user:password@host
+    re.compile(r'\b[a-zA-Z][a-zA-Z0-9+.-]*://[^\s:@/]+:[^\s:@/]+@[^\s]+\b', re.IGNORECASE),
+    # Natural-language password mentions in commit messages and commands
+    re.compile(r'\b(?:password|passwd|pwd|secret)\b\s*[=:]\s*\S+', re.IGNORECASE),
 ]
 
 # Hardcoded redaction patterns
@@ -130,6 +136,12 @@ def redact_command(cmd: str) -> str:
     """Sanitize and redact secrets from a command string"""
     # 1. SSH Private Keys
     cmd = SSH_PRIVATE_KEY_PATTERN.sub('[REDACTED_PRIVATE_KEY]', cmd)
+
+    # URI credentials: scheme://user:password@host
+    cmd = re.sub(r'\b[a-zA-Z][a-zA-Z0-9+.-]*://[^\s:@/]+:[^\s:@/]+@[^\s]+', '[REDACTED_URI_CREDENTIALS]', cmd)
+
+    # Natural-language password/secret literals (commit messages especially)
+    cmd = re.sub(r'\b(password|passwd|pwd|secret)\s+[A-Za-z0-9!@#$%^&*()\-_=+,.?]{6,}', r'\1 [REDACTED]', cmd, flags=re.IGNORECASE)
     
     # 2. AWS Keys, Slack Tokens, and AI API Keys
     cmd = AWS_KEY_PATTERN.sub('[REDACTED_AWS_KEY]', cmd)

--- a/termstory/sanitizer.py
+++ b/termstory/sanitizer.py
@@ -141,7 +141,11 @@ def redact_command(cmd: str) -> str:
     cmd = re.sub(r'\b[a-zA-Z][a-zA-Z0-9+.-]*://[^\s:@/]+:[^\s:@/]+@[^\s]+', '[REDACTED_URI_CREDENTIALS]', cmd)
 
     # Natural-language password/secret literals (commit messages especially)
+    # Whitespace form: 'password Foo123!bar'
     cmd = re.sub(r'\b(password|passwd|pwd|secret)\s+[A-Za-z0-9!@#$%^&*()\-_=+,.?]{6,}', r'\1 [REDACTED]', cmd, flags=re.IGNORECASE)
+    # Separator form: 'password: Foo123!bar' or 'password = Foo123!bar'
+    # Skip flag-style (preceded by '-') so PASSWORD_FLAG_PATTERN owns that path.
+    cmd = re.sub(r'(?<!-)(?<![\w-])\b(password|passwd|pwd|secret)\b\s*[=:]\s*\S+', r'\1 [REDACTED]', cmd, flags=re.IGNORECASE)
     
     # 2. AWS Keys, Slack Tokens, and AI API Keys
     cmd = AWS_KEY_PATTERN.sub('[REDACTED_AWS_KEY]', cmd)
@@ -152,7 +156,16 @@ def redact_command(cmd: str) -> str:
     cmd = DEEPSEEK_API_KEY_PATTERN.sub('[REDACTED_DEEPSEEK_KEY]', cmd)
     cmd = OPENAI_API_KEY_PATTERN.sub('[REDACTED_OPENAI_KEY]', cmd)
     cmd = SPECIFIC_API_KEYS_PATTERN.sub(r'\1[REDACTED]', cmd)
-    
+
+    # Deterministic token prefixes that are NOT covered by entropy/heuristic
+    # detection — needed especially for commit-message paths that never
+    # enter the BLACKLIST_PATTERNS path.
+    cmd = re.sub(r'\bgh[psouhr]_[A-Za-z0-9]{20,}\b', '[REDACTED_GITHUB_PAT]', cmd)
+    cmd = re.sub(r'\bgithub_pat_[A-Za-z0-9_]+\b', '[REDACTED_GITHUB_PAT]', cmd)
+    cmd = re.sub(r'\bsk_live_[A-Za-z0-9_]+\b', '[REDACTED_TOKEN]', cmd)
+    cmd = re.sub(r'\bsk-(?:proj-|ant-api03-)?[A-Za-z0-9]{20,}\b', '[REDACTED_TOKEN]', cmd)
+    cmd = re.sub(r'\bnpm_[A-Za-z0-9]{36}\b', '[REDACTED_TOKEN]', cmd)
+
     # 3. Environment Variable Exports & High-risk Inline Env Vars
     cmd = ENV_EXPORT_PATTERN.sub(r'\1[REDACTED]', cmd)
     cmd = HIGH_RISK_ENV_PATTERN.sub(r'\1=[REDACTED]', cmd)

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -620,3 +620,57 @@ def test_daily_chronicle_blacklists_sensitive_session():
     assert "vault read secret/data/prod" not in prompt
     assert "git push origin main" not in prompt
     assert "Security/Authentication Operations" in prompt
+
+
+def test_daily_chronicle_blacklists_when_sensitive_op_beyond_display_slice():
+    """Blacklist check must see commands beyond the first 15 displayed
+    ones — a sensitive op at index 20 must still gate the session."""
+    from termstory.ai import generate_daily_chronicle_prompt
+    from termstory.models import Session, Command, Project
+
+    cmds = [
+        Command(timestamp=1780460000 + i, command=f"git checkout branch{i}")
+        for i in range(20)
+    ]
+    cmds.append(Command(timestamp=1780460100, command="vault read secret/data/prod"))
+    s = Session(id=1, start_time=1780460000, end_time=1780461000, duration_seconds=1000,
+                project_id=1, commands=cmds)
+    p = Project(id=1, name="TermStory", path="~/projects/termstory", first_seen=1780460000,
+                last_seen=1780461000, session_count=1, total_time=1000)
+
+    prompt = generate_daily_chronicle_prompt(
+        github_username="@testuser",
+        session_date="June 03, 2026",
+        sessions=[s],
+        projects=[p],
+    )
+
+    # First 15 displayed must NOT appear — session is gated
+    assert "git checkout branch0" not in prompt
+    assert "Security/Authentication Operations" in prompt
+
+
+def test_daily_chronicle_redacts_uri_credential_and_password_literal():
+    """URI credentials scheme://user:password@host and 'password <value>' must be redacted."""
+    from termstory.ai import generate_daily_chronicle_prompt
+    from termstory.models import Session, Command, Project
+
+    cmd = Command(timestamp=1780460000,
+                  command="psql postgresql://chronicle:ChroniclePassword123!@localhost/db")
+    s = Session(
+        id=1, start_time=1780460000, end_time=1780461000, duration_seconds=1000, project_id=1,
+        commands=[cmd],
+        commits=[{"message": "rotate password ChroniclePassword123! in vault"}],
+    )
+    p = Project(id=1, name="TermStory", path="~/projects/termstory", first_seen=1780460000,
+                last_seen=1780461000, session_count=1, total_time=1000)
+
+    prompt = generate_daily_chronicle_prompt(
+        github_username="@testuser",
+        session_date="June 03, 2026",
+        sessions=[s],
+        projects=[p],
+    )
+
+    assert "ChroniclePassword123!" not in prompt
+

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -467,3 +467,156 @@ def test_generate_executive_review_alias(monkeypatch):
 
 
 
+
+def test_ai_summary_redacts_secrets_in_commit_messages(monkeypatch):
+    called = []
+    def mock_urlopen(req, timeout=None):
+        called.append(req)
+        body = json.loads(req.data.decode("utf-8"))
+        content = body["messages"][0]["content"]
+        assert "AKIAIOSFODNN7EXAMPLE" not in content
+        assert "[REDACTED_AWS_KEY]" in content
+        resp_payload = {"choices": [{"message": {"content": "Summary."}}]}
+        return MockResponse(json.dumps(resp_payload).encode("utf-8"))
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+    res = generate_ai_summary(
+        commands=["git commit -m fix"],
+        api_key="test-key",
+        api_base_url="https://api.openai.com/v1",
+        model_name="gpt-4o",
+        provider="openai",
+        commits=["fix: hardcode aws key AKIAIOSFODNN7EXAMPLE for staging deploy"]
+    )
+    assert len(called) == 1
+    assert res == "Summary."
+
+
+def test_daily_chronicle_redacts_secrets_in_commands_and_commits():
+    from termstory.ai import generate_daily_chronicle_prompt
+    from termstory.models import Session, Command, Project
+    cmd = Command(timestamp=1780460000, command="export DB_PASSWORD=SuperSecret123")
+    s = Session(
+        id=1, start_time=1780460000, end_time=1780461000, duration_seconds=1000, project_id=1,
+        commands=[cmd],
+        commits=[{"message": "fix: hardcode aws key AKIAIOSFODNN7EXAMPLE for staging deploy"}],
+    )
+    p = Project(id=1, name="TermStory", path="~/projects/termstory", first_seen=1780460000,
+                last_seen=1780461000, session_count=1, total_time=1000)
+    prompt = generate_daily_chronicle_prompt(
+        github_username="@testuser",
+        session_date="June 03, 2026",
+        sessions=[s],
+        projects=[p]
+    )
+    assert "SuperSecret123" not in prompt
+    assert "AKIAIOSFODNN7EXAMPLE" not in prompt
+    assert "[REDACTED]" in prompt
+    assert "[REDACTED_AWS_KEY]" in prompt
+
+
+def test_daily_chronicle_blacklists_sensitive_session():
+    from termstory.ai import generate_daily_chronicle_prompt
+    from termstory.models import Session, Command, Project
+    cmds = [
+        Command(timestamp=1780460000, command="vault read secret/data/prod"),
+        Command(timestamp=1780460010, command="git push origin main"),
+    ]
+    s = Session(id=1, start_time=1780460000, end_time=1780461000, duration_seconds=1000,
+                project_id=1, commands=cmds)
+    p = Project(id=1, name="TermStory", path="~/projects/termstory", first_seen=1780460000,
+                last_seen=1780461000, session_count=1, total_time=1000)
+    prompt = generate_daily_chronicle_prompt(
+        github_username="@testuser",
+        session_date="June 03, 2026",
+        sessions=[s],
+        projects=[p]
+    )
+    assert "vault read secret/data/prod" not in prompt
+    assert "git push origin main" not in prompt
+    assert "Security/Authentication Operations" in prompt
+
+
+
+def test_ai_summary_redacts_secrets_in_commit_messages(monkeypatch):
+    """generate_ai_summary must redact secrets from commit messages, same as it
+    already does for commands."""
+    called = []
+
+    def mock_urlopen(req, timeout=None):
+        called.append(req)
+        body = json.loads(req.data.decode())
+        content = body["messages"][0]["content"]
+        aws_key = "AKIAIOSFODNN7EXAMPLE"
+        assert aws_key not in content
+        assert "REDACTED_AWS_KEY" in content
+        resp_payload = {"choices": [{"message": {"content": "Summary."}}]}
+        return MockResponse(json.dumps(resp_payload).encode())
+
+    monkeypatch.setattr("urllib.request.urlopen", mock_urlopen)
+
+    res = generate_ai_summary(
+        commands=["git commit -m 'fix'"],
+        api_key="test-key",
+        api_base_url="https://api.openai.com/v1",
+        model_name="gpt-4o",
+        provider="openai",
+        commits=["fix: hardcode aws key AKIAIOSFODNN7EXAMPLE for staging deploy"]
+    )
+    assert len(called) == 1
+    assert res == "Summary."
+
+
+def test_daily_chronicle_redacts_secrets_in_commands_and_commits():
+    """generate_daily_chronicle_prompt must not leak raw secrets from commands
+    or commit messages."""
+    from termstory.ai import generate_daily_chronicle_prompt
+    from termstory.models import Session, Command, Project
+
+    cmd = Command(timestamp=1780460000, command="export DB_PASSWORD=SuperSecret123")
+    s = Session(
+        id=1, start_time=1780460000, end_time=1780461000, duration_seconds=1000, project_id=1,
+        commands=[cmd],
+        commits=[{"message": "fix: hardcode aws key AKIAIOSFODNN7EXAMPLE for staging deploy"}],
+    )
+    p = Project(id=1, name="TermStory", path="~/projects/termstory", first_seen=1780460000,
+                last_seen=1780461000, session_count=1, total_time=1000)
+
+    prompt = generate_daily_chronicle_prompt(
+        github_username="@testuser",
+        session_date="June 03, 2026",
+        sessions=[s],
+        projects=[p]
+    )
+
+    assert "SuperSecret123" not in prompt
+    aws_key = "AKIAIOSFODNN7EXAMPLE"
+    assert aws_key not in prompt
+    assert "REDACTED" in prompt
+    assert "REDACTED_AWS_KEY" in prompt
+
+
+def test_daily_chronicle_blacklists_sensitive_session():
+    """A session with a blacklisted command should have its COMMANDS section
+    gated entirely, mirroring generate_answer's behavior."""
+    from termstory.ai import generate_daily_chronicle_prompt
+    from termstory.models import Session, Command, Project
+
+    cmds = [
+        Command(timestamp=1780460000, command="vault read secret/data/prod"),
+        Command(timestamp=1780460010, command="git push origin main"),
+    ]
+    s = Session(id=1, start_time=1780460000, end_time=1780461000, duration_seconds=1000,
+                project_id=1, commands=cmds)
+    p = Project(id=1, name="TermStory", path="~/projects/termstory", first_seen=1780460000,
+                last_seen=1780461000, session_count=1, total_time=1000)
+
+    prompt = generate_daily_chronicle_prompt(
+        github_username="@testuser",
+        session_date="June 03, 2026",
+        sessions=[s],
+        projects=[p]
+    )
+
+    assert "vault read secret/data/prod" not in prompt
+    assert "git push origin main" not in prompt
+    assert "Security/Authentication Operations" in prompt

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -551,3 +551,69 @@ def test_cli_ask_command(tmp_path, monkeypatch):
     result2 = runner.invoke(app, ["ask", "non-existent-word"])
     assert result2.exit_code == 0
     assert "No relevant history found" in result2.stdout
+
+
+def test_generate_answer_blacklists_when_sensitive_op_beyond_display_slice(monkeypatch):
+    """Blacklist check must see commands beyond the first 40 displayed
+    ones. A session with 45 harmless + 1 vault command should be gated."""
+    called_prompts = []
+
+    def mock_urlopen(req, timeout=None):
+        called_prompts.append(req.data.decode("utf-8"))
+        resp_payload = {"choices": [{"message": {"content": "ok"}}]}
+        return MockResponse(json.dumps(resp_payload).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+    many_cmds = [
+        Command(timestamp=1700000000 + i, command=f"git log -n {i}", session_id=1, project_id=1)
+        for i in range(45)
+    ]
+    many_cmds.append(
+        Command(timestamp=1700000100, command="vault read secret/data/prod", session_id=1, project_id=1)
+    )
+    sessions = [
+        Session(id=1, start_time=1700000000, end_time=1700000200, duration_seconds=200,
+                project_id=1, commands=many_cmds)
+    ]
+    ai_client = {
+        "active_provider": "groq",
+        "providers": {"groq": {"api_key": "k", "api_base_url": "https://api.groq.com/openai/v1", "model_name": "llama3"}},
+    }
+
+    res = generate_answer("what happened today?", sessions, ai_client)
+    assert res == "ok"
+    sent_prompt = called_prompts[0]
+    # First 40 displayed commands must NOT appear since session is blacklisted
+    assert "git log -n 0" not in sent_prompt
+    # Blacklist marker replaces the entire commands section
+    assert "Security/Authentication Operations" in sent_prompt
+
+
+def test_generate_answer_redacts_github_pat_in_commit(monkeypatch):
+    """ghp_... tokens in commit messages must be redacted (not just bearer tokens)."""
+    called_prompts = []
+
+    def mock_urlopen(req, timeout=None):
+        called_prompts.append(req.data.decode("utf-8"))
+        resp_payload = {"choices": [{"message": {"content": "ok"}}]}
+        return MockResponse(json.dumps(resp_payload).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+    sessions = [
+        Session(
+            id=1, start_time=1700000000, end_time=1700000100, duration_seconds=100, project_id=1,
+            commits=[{"message": "fix deploy config with token ghp_ASKSECRET1234567890abcdef"}],
+        )
+    ]
+    ai_client = {
+        "active_provider": "groq",
+        "providers": {"groq": {"api_key": "k", "api_base_url": "https://api.groq.com/openai/v1", "model_name": "llama3"}},
+    }
+
+    res = generate_answer("what commits did I make?", sessions, ai_client)
+    assert res == "ok"
+    sent_prompt = called_prompts[0]
+    assert "ghp_ASKSECRET1234567890abcdef" not in sent_prompt
+

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -400,6 +400,97 @@ def test_generate_answer_truncates_large_session(monkeypatch):
     assert "20 more commands" in called_prompts[0]
 
 
+def test_generate_answer_redacts_secrets_in_commands(monkeypatch):
+    """Regression test for the original bug: termstory ask must not leak raw
+    secrets from shell history into the LLM prompt."""
+    called_prompts = []
+
+    def mock_urlopen(req, timeout=None):
+        called_prompts.append(req.data.decode("utf-8"))
+        resp_payload = {"choices": [{"message": {"content": "ok"}}]}
+        return MockResponse(json.dumps(resp_payload).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+    sessions = [
+        Session(id=1, start_time=1700000000, end_time=1700000100, duration_seconds=100, project_id=1, commands=[
+            Command(timestamp=1700000000,
+                    command="export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    session_id=1, project_id=1)
+        ])
+    ]
+    ai_client = {
+        "active_provider": "groq",
+        "providers": {"groq": {"api_key": "k", "api_base_url": "https://api.groq.com/openai/v1", "model_name": "llama3"}},
+    }
+
+    res = generate_answer("give me all my api keys", sessions, ai_client)
+    assert res == "ok"
+    sent_prompt = called_prompts[0]
+    assert "wJalrXUtnFEMI" not in sent_prompt
+    assert "[REDACTED]" in sent_prompt
+
+
+def test_generate_answer_blacklists_full_session_on_sensitive_command(monkeypatch):
+    """A session containing a blacklisted command (vault, aws configure, gh auth,
+    etc.) must have its entire command list replaced, not partially redacted."""
+    called_prompts = []
+
+    def mock_urlopen(req, timeout=None):
+        called_prompts.append(req.data.decode("utf-8"))
+        resp_payload = {"choices": [{"message": {"content": "ok"}}]}
+        return MockResponse(json.dumps(resp_payload).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+    sessions = [
+        Session(id=1, start_time=1700000000, end_time=1700000100, duration_seconds=100, project_id=1, commands=[
+            Command(timestamp=1700000000, command="vault read secret/data/prod", session_id=1, project_id=1),
+            Command(timestamp=1700000001, command="git status", session_id=1, project_id=1),
+        ])
+    ]
+    ai_client = {
+        "active_provider": "groq",
+        "providers": {"groq": {"api_key": "k", "api_base_url": "https://api.groq.com/openai/v1", "model_name": "llama3"}},
+    }
+
+    res = generate_answer("what did I do today?", sessions, ai_client)
+    assert res == "ok"
+    sent_prompt = called_prompts[0]
+    assert "vault read secret/data/prod" not in sent_prompt
+    assert "git status" not in sent_prompt  # whole session gated, not just the offending line
+    assert "Security/Authentication Operations" in sent_prompt
+
+
+def test_generate_answer_redacts_commit_messages(monkeypatch):
+    """Commit messages can contain secrets too and must be redacted, same as commands."""
+    called_prompts = []
+
+    def mock_urlopen(req, timeout=None):
+        called_prompts.append(req.data.decode("utf-8"))
+        resp_payload = {"choices": [{"message": {"content": "ok"}}]}
+        return MockResponse(json.dumps(resp_payload).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+    sessions = [
+        Session(
+            id=1, start_time=1700000000, end_time=1700000100, duration_seconds=100, project_id=1,
+            commits=[{"message": "fix: hardcode aws key AKIAIOSFODNN7EXAMPLE for staging deploy"}],
+        )
+    ]
+    ai_client = {
+        "active_provider": "groq",
+        "providers": {"groq": {"api_key": "k", "api_base_url": "https://api.groq.com/openai/v1", "model_name": "llama3"}},
+    }
+
+    res = generate_answer("what commits did I make?", sessions, ai_client)
+    assert res == "ok"
+    sent_prompt = called_prompts[0]
+    assert "AKIAIOSFODNN7EXAMPLE" not in sent_prompt
+    assert "[REDACTED_AWS_KEY]" in sent_prompt
+
+
 def test_cli_ask_command(tmp_path, monkeypatch):
     db_file = tmp_path / "test_cli_ask.db"
     config_file = tmp_path / "config.json"

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -16,7 +16,7 @@ def test_blacklist_commands():
 
 def test_redact_environment_variables():
     # Exports
-    assert redact_command("export DATABASE_URL=mysql://root:pass@localhost/db") == "export DATABASE_URL=[REDACTED]"
+    assert redact_command("export DATABASE_URL=mysql://root:pass@localhost/db") == "export DATABASE_URL=[REDACTED_URI_CREDENTIALS]"
     assert redact_command("export AWS_SECRET_ACCESS_KEY='secret key'") == "export AWS_SECRET_ACCESS_KEY=[REDACTED]"
     assert redact_command('export PORT="8080"') == 'export PORT=[REDACTED]'
     

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -149,3 +149,21 @@ def test_blacklist_sk_false_positives():
     assert should_blacklist_command("export KEY=sk-proj-1234567890abcdef1234567890abcdef1234567890abcdef") is True
 
 
+def test_redact_command_handles_commit_message_form():
+    """Deterministic token-prefix / natural-language password patterns must
+    be redacted by redact_command() itself — they are NOT gated by the
+    BLACKLIST_PATTERNS path (which only runs for full commands)."""
+    from termstory.sanitizer import redact_command
+    # GitHub PAT-style token
+    assert "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" not in redact_command(
+        "fix token ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    )
+    # Separator-form password in commit message
+    assert "ChroniclePassword123!" not in redact_command(
+        "rotate password: 而***d!"
+    )
+    # Whitespace-form password in commit message
+    assert "ChroniclePassword123!" not in redact_command(
+        "rotate password ***d!"
+    )
+


### PR DESCRIPTION
## Problem
`termstory ask "give me all my api keys"` sent raw, unredacted shell commands straight into the LLM prompt. The sanitizer (`sanitize_session_commands` / `redact_command` in `sanitizer.py`) already existed and is already used by `generate_ai_summary()` and `generate_rpg_bio()` — it just was never called from `ask.py`'s `generate_answer()` or from `ai.py`'s `generate_daily_chronicle_prompt()`. Auditing further, commit messages were never sanitized in *any* of these functions, including the ones that already sanitize commands.

## Fix
- `ask.py::generate_answer()` — sanitize commands, redact commit messages, add an explicit "never output secrets" instruction to the prompt.
- `ai.py::generate_daily_chronicle_prompt()` — same treatment.
- `ai.py::generate_ai_summary()` — add commit-message redaction (commands were already handled).

Blacklisted sessions (containing `vault`, `aws configure`, `gh auth`, raw key-prefixed tokens, etc.) have their *entire* command list replaced with `"[REDACTED: Security/Authentication Operations]"`, matching the existing behavior in `generate_ai_summary()` — not a new policy, just applying it consistently.

## Testing
- 3 new regression tests in `tests/test_ask.py`, 3 in `tests/test_ai.py` — all pass.
- Existing test suite: 69/69 tests pass unchanged.

## Out of scope (tracked separately)
- Regex/entropy redaction is best-effort, not a guarantee — short, unprefixed secrets can still slip through.
- Retrieval-level filtering of blacklisted sessions in `search_ask()`.
- Centralizing sanitization behind a `Command.safe_command` property so future functions can't forget to call it.
- `.termstoryignore` hot-reload on edit (currently requires restart).