### PR TITLE
docs: privacy documentation update — secret redaction parity fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-06-25
+
+### Security
+- **Secret redaction parity for `termstory ask` and Daily Chronicle**: `generate_answer()` in `ask.py` and `generate_daily_chronicle_prompt()` in `ai.py` now run session commands and git commit messages through the same local sanitizer (`sanitize_session_commands` / `redact_command`) already used by `generate_ai_summary()`. Previously, both functions built LLM prompts from completely raw, unredacted shell history and commit text.
+- **Commit message redaction across all AI surfaces**: `generate_ai_summary()` sanitized commands but never commit messages; fixed. Commit messages in all three AI-facing functions now pass through `redact_command()` before being embedded in any prompt.
+- **Defense-in-depth instruction in `termstory ask`**: The LLM prompt now includes an explicit instruction to never output credential values verbatim, as a secondary layer on top of the redaction pass.
+
 ## [0.6.0] - 2026-06-17
 ### Added
 - **RPG Classes Alter Ego (`termstory rpg-class`)**: Assigns and displays daily RPG class alter egos (e.g., *Regex Sorcerer*, *Docker Demolitionist*) based on shell history command distribution, including a custom LLM-generated biography.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,41 @@ TermStory is designed as a **personal developer memory engine** that prioritizes
 *   **Density over decoration**: Avoid rounded panels, double borders, or nested boxes. Use clean column alignment, simple tables, and minimal spacing.
 *   **Strictly banned**: The use of `rich.panel.Panel` is strictly banned in favor of dense text separators to maintain this philosophy.
 
+## Security: Sanitization Rule for LLM-Facing Code
+
+Any function that builds an LLM prompt using raw session data **must** sanitize before
+calling `_send_llm_request()`. This is a hard requirement, not a suggestion — functions
+that skip sanitization are a security bug regardless of how benign the context looks at
+the time.
+
+**The rule in two lines:**
+
+```python
+# For shell commands — always do this before embedding in a prompt:
+sanitized_cmds, is_blacklisted = sanitize_session_commands(raw_cmd_strings)
+if is_blacklisted:
+    # Replace the entire commands block — do NOT iterate sanitized_cmds (it's None)
+    block.append("  - [REDACTED: Security/Authentication Operations]")
+else:
+    for sc in sanitized_cmds:
+        block.append(f"  - {sc}")
+
+# For git commit messages — apply to every message string:
+safe_msg = redact_command(raw_commit_message)
+```
+
+**Why the `is_blacklisted` check must come first:** `sanitize_session_commands` returns
+`(None, True)` for blacklisted sessions. Iterating `None` raises `TypeError`. Always
+branch on the flag before touching the list.
+
+**Adding a new LLM-context function? Add a regression test.** The pattern is in
+`tests/test_ask.py` (`test_generate_answer_redacts_secrets_in_commands`): mock
+`urllib.request.urlopen`, capture `req.data.decode("utf-8")`, assert a known fake
+secret (`AKIAIO...MPLE`) is not in the captured payload.
+
+Existing reference implementations: `generate_ai_summary()` and `generate_rpg_bio()`
+in `termstory/ai.py`.
+
 ## Submitting PRs
 
 *   **Branch naming**: Use descriptive branch names like `feature/new-cli-command`, `bugfix/issue-123`, or `docs/update-readme`.

--- a/DATA_PRIVACY.md
+++ b/DATA_PRIVACY.md
@@ -10,13 +10,15 @@ Out of the box, TermStory is completely offline. The CLI parses your local `.zsh
 
 ### 2. The Optional AI Engine
 
-To make your timeline read like a true work diary, TermStory offers an **opt-in** AI categorization engine. When enabled, TermStory sends small batches of your terminal commands to an LLM (like Groq) to generate a short, human-readable summary of what you were working on.
+To make your timeline read like a true work diary, TermStory offers an **opt-in** AI categorization engine. When enabled, TermStory sends small batches of your terminal commands and git commit messages to an LLM (like Groq) to generate a short, human-readable summary of what you were working on.
+
+Three features send data to the LLM when enabled: **auto-summaries** (background, per session), the **Daily Chronicle** (`termstory chronicle`), and **natural language queries** (`termstory ask`). All three pass your history through the Local Sanitization Engine before making any network request.
 
 **If you enable this feature, we do not just blindly send your terminal logs to the cloud.** Your data must pass through our Local Sanitization Engine first.
 
 ### 3. The Local Sanitization Engine
 
-Before a single byte of data is sent to the AI API, TermStory runs your session commands through a rigid Python pre-processor right on your laptop.
+Before a single byte of data is sent to the AI API, TermStory runs your session commands and git commit messages through a rigid Python pre-processor right on your laptop.
 
 #### Open-Source Secret Detection
 
@@ -27,11 +29,13 @@ We do not reinvent the wheel when it comes to security. TermStory's redaction en
 
 #### Blacklisted Workflows
 
-If a session contains commands associated with deep infrastructure management or vault unlocking, TermStory aborts the AI request entirely. We will never send sessions containing commands like:
+If a session contains commands associated with deep infrastructure management or secret vaulting, TermStory removes that session's raw command list from the LLM context entirely and replaces it with `[REDACTED: Security/Authentication Operations]`. Session metadata (date, project name, duration, cached AI summaries) remains visible — only raw command text is withheld. We will never send raw commands from sessions containing patterns like:
 
 * `vault *`
 * `aws configure`
-* `kubectl create secret`
+* `gh auth`
+* `kubectl create secret *`
+* Raw token strings: `github_pat_*`, `sk_live_*`, `sk-ant-*`, `npm_*` (36-char)
 
 #### Hardcoded Redactions
 
@@ -40,6 +44,27 @@ Even if a command passes the Regex database, we aggressively strip common vector
 * Everything following an equals sign in environment variables (e.g., `export DB_PASS=[REDACTED]`).
 * Everything following common password flags (e.g., `mysql -u root -p[REDACTED]`).
 * IP addresses and fully qualified domain names (FQDNs).
+
+#### Custom Redaction Rules (`.termstoryignore`)
+
+If your workflows produce secrets with no recognizable prefix (e.g., a company-internal token format), you can teach TermStory's sanitizer about them without modifying source code.
+
+Place additional regex patterns — one per line — in either of these files:
+* `~/.termstoryignore`
+* `~/.termstory/.termstoryignore`
+
+Lines starting with `#` are treated as comments. Patterns match case-insensitively; matched strings are replaced with `[REDACTED_CUSTOM]`.
+
+**Example `~/.termstoryignore`:**
+```
+# Redact internal Vault paths
+secret/data/.*
+
+# Redact custom internal API token format
+acme_tok_[a-z0-9]{32}
+```
+
+> **Note:** Custom patterns are loaded once at TermStory startup. If you edit `.termstoryignore` while TermStory is running, restart it to apply the changes.
 
 ### 4. Run It Entirely Offline (Ollama Support)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.6.x   | ✅        |
+| < 0.6   | ❌        |
+
+## Reporting a Vulnerability
+
+If you discover a security issue in TermStory, **do not open a public GitHub issue** — this gives potential attackers advance notice before a fix is available.
+
+Instead, use GitHub's private security advisory system:
+
+1. Navigate to the repository **Security** tab.
+2. Click **"Report a vulnerability"**.
+3. Describe the issue, steps to reproduce, and potential impact.
+
+Expected response time: initial acknowledgement within **48 hours**, fix within **14 days** for confirmed vulnerabilities.
+
+---
+
+## Trust Model and Known Limitations
+
+TermStory's privacy guarantee is: **no raw data leaves your machine without passing through `termstory/sanitizer.py` first.** Understanding the limits of that guarantee is important.
+
+### What the sanitizer does well
+- **Named-prefix secrets** (AWS `AKIA*`, OpenAI `sk-*`, Anthropic `sk-ant-*`, Slack `xoxb-*`, Google `AIzaSy*`, etc.) are caught by specific regex patterns.
+- **Structural patterns** (`--password=`, `export KEY=***) are redacted regardless of the specific value.
+- **Blacklisted workflows** (`vault`, `aws configure`, `gh auth`, raw token strings, `kubectl create secret`) gate the entire COMMANDS block — none of those raw command strings reach the LLM.
+
+### Known gaps (by design — documented here, not hidden)
+
+| Limitation | Detail |
+|------------|--------|
+| **Short / low-entropy secrets** | `redact_high_entropy()` requires ≥ 24 characters and Shannon entropy > 4.3 bits/char. A short or predictable secret with no recognizable prefix (e.g., a 12-character password) will not be flagged. |
+| **Novel token formats** | Blacklist and named-pattern detection is structural. A company-internal token format with no known prefix silently passes through unless you add it to `~/.termstoryignore`. |
+| **Commit message prose** | `redact_command()` was designed for shell syntax. A secret embedded in natural-language commit text with no `=`, flag, or prefix cue may not be detected. |
+| **`.termstoryignore` not live-reloaded** | Custom patterns load once at process startup. Edits require a TermStory restart to take effect. |
+| **Model refusal is not a control** | TermStory adds an instruction in `termstory ask` prompts asking the LLM never to output credentials verbatim. This is a secondary layer; the redaction pass is the actual control. |
+
+### Recommended mitigations
+- **Use `HISTCONTROL=ignorespace`** in your shell and prefix any command containing a plaintext secret with a space — the shell will refuse to write it to history, and TermStory will never see it.
+- **Use Ollama** for fully local inference if you work with highly sensitive codebases.
+- **Maintain `~/.termstoryignore`** with patterns for any proprietary token formats your workflows produce.

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -17,3 +17,16 @@
 | **Ollama** | `llama3` | Fully local, no key needed |
 | **Custom** | any | Any OpenAI-compatible endpoint |
 
+### Pre-LLM Sanitization
+
+Every LLM call is preceded by a local sanitization pass through `termstory/sanitizer.py`.
+No raw session data reaches `_send_llm_request()` directly.
+
+**Commands** go through `sanitize_session_commands()`:
+1. If any command matches a blacklist pattern (`vault`, `aws configure`, `gh auth`, raw token strings, etc.), the function returns `(None, True)` — the calling code replaces the entire COMMANDS block with `"[REDACTED: Security/Authentication Operations]"`.
+2. Otherwise, every command string is run through `redact_command()` (named-prefix patterns → entropy heuristic → custom user rules) and the sanitized list is embedded in the prompt.
+
+**Git commit messages** pass through `redact_command()` individually before being appended to the prompt — the same regex pipeline used for commands, applied to commit text.
+
+This is enforced across all three AI-facing surfaces: `generate_ai_summary()`, `generate_daily_chronicle_prompt()` (both in `ai.py`), and `generate_answer()` (in `ask.py`). See `docs/privacy.md` for the complete redaction rule table.
+

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -7,6 +7,8 @@ Use semantic Q&A and search over your developer history. `termstory ask` retriev
 - `termstory ask "What did I work on last Monday?"`
 - `termstory ask "When did I fix the database deadlocks?"`
 
+Session commands and commit messages are sanitized through the local redaction engine before being sent to the LLM — no raw secrets leave your machine. See [Privacy Sanitizer](privacy.md) for details.
+
 ### 🔮 Predict (Pre-Cognitive Workspace)
 The pre-cognitive workspace predicts what project or workspace you will work on next based on historical transition probabilities and time-of-day patterns.
 - `termstory predict`

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -4,7 +4,7 @@ All data passes through `sanitizer.py` **locally** before any AI call. Nothing s
 
 ### Session Blacklist
 
-If any command in a session matches these patterns, the entire session is short-circuited to return `"Security/Authentication Operations"` — no commands are sent to the LLM at all:
+If any command in a session matches these patterns, the entire COMMANDS block for that session is replaced with `"[REDACTED: Security/Authentication Operations]"` in the LLM context — no raw commands leave the machine. Session metadata (date, project name, cached AI summary) remains visible.
 
 ```python
 BLACKLIST_PATTERNS = [
@@ -12,6 +12,11 @@ BLACKLIST_PATTERNS = [
     r'\baws\s+configure\b',
     r'\bgh\s+auth\b',
     r'\bkubectl\s+.*?\bcreate\s+secret\b',
+    # Raw token strings (these trigger if they appear literally in a command)
+    r'\bgithub_pat_[a-zA-Z0-9_]+\b',
+    r'\bsk_live_[a-zA-Z0-9_]+\b',
+    r'\bnpm_[a-zA-Z0-9]{36}\b',
+    r'\bsk-(?:proj-|ant-api03-)?[a-zA-Z0-9]{20,}\b',
 ]
 ```
 
@@ -20,13 +25,47 @@ BLACKLIST_PATTERNS = [
 | Type | Pattern | Replacement |
 |---|---|---|
 | Private keys | `-----BEGIN ... PRIVATE KEY-----` | `[REDACTED_PRIVATE_KEY]` |
-| AWS keys | `AKIA[A-Z0-9]{16}` | `[REDACTED_AWS_KEY]` |
+| AWS access keys | `AKIA[A-Z0-9]{16}`, `ASIA[A-Z0-9]{16}` | `[REDACTED_AWS_KEY]` |
+| Slack tokens | `xoxb-<digits>-<chars>` | `[REDACTED_SLACK_TOKEN]` |
 | Bearer tokens | `bearer <token>` | `Bearer [REDACTED_TOKEN]` |
-| Flag values | `--password`, `--token`, `--api-key`, `-p` | `--password=[REDACTED]` |
+| OpenAI keys | `sk-[a-zA-Z0-9_-]{32,}` | `[REDACTED_OPENAI_KEY]` |
+| Anthropic keys | `sk-ant-[a-zA-Z0-9_-]{40,}` | `[REDACTED_ANTHROPIC_KEY]` |
+| Google API keys | `AIzaSy[a-zA-Z0-9_-]{30,45}` | `[REDACTED_GOOGLE_KEY]` |
+| DeepSeek keys | `sk-[a-zA-Z0-9_-]{32}` | `[REDACTED_DEEPSEEK_KEY]` |
+| Named API key flags | `OPENAI_API_KEY=value`, `--anthropic-api-key=value`, etc. | `KEY=[REDACTED]` |
+| Flag values | `--password`, `--token`, `--api-key`, `-p` (mysql/mongo) | `--flag=[REDACTED]` |
+| Env var exports | `export SECRET_NAME=value` | `export SECRET_NAME=[REDACTED]` |
+| Inline env vars | `ANY_KEY_LIKE_NAME=value` | `KEY=[REDACTED]` |
 | IPv4/IPv6 | standard address patterns | `[REDACTED_IP]` |
-| Hostnames/FQDNs | `host.domain.tld` | `[REDACTED_HOST]` |
-| Exports | `export KEY=value` | `export KEY=[REDACTED]` |
+| Hostnames/FQDNs | `host.domain.tld` (file extensions excluded) | `[REDACTED_HOST]` |
+| URL hosts | `https://hostname` | `https://[REDACTED_HOST]` |
+| SSH targets | `user@host` | `user@[REDACTED_HOST]` |
+| High-entropy strings | ≥ 24 base64-like chars, Shannon entropy > 4.3 | `[REDACTED_ENTROPY]` |
+| Custom user rules | patterns from `~/.termstoryignore` | `[REDACTED_CUSTOM]` |
 
 **File extension whitelist:** Paths ending in `.py`, `.json`, `.sh`, `.yml`, `.ts`, `.go`, etc. are never redacted even if they look like FQDNs — preserving filenames like `config.json` and `api.ts`.
+
+**Commit messages are subject to the same rules.** `redact_command()` operates on any string, not only shell commands. Git commit messages pass through the same regex pipeline before being embedded in any LLM prompt.
+
+### Custom Rules (`.termstoryignore`)
+
+Place additional regex patterns (one per line) in `~/.termstoryignore` or `~/.termstory/.termstoryignore`. Comment lines start with `#`. Patterns match case-insensitively; matched text is replaced with `[REDACTED_CUSTOM]`.
+
+```ini
+# Company-internal token format
+acme_tok_[a-z0-9]{32}
+```
+
+> **Note on live-reload:** Patterns are loaded once at process startup via `load_custom_ignore_rules()`. Restart TermStory after editing this file for changes to take effect.
+
+#### Known Sanitizer Limitations
+
+The redaction engine is defense-in-depth, not a guarantee:
+
+* **Entropy heuristic has a floor:** `redact_high_entropy()` only catches strings ≥ 24 characters with Shannon entropy > 4.3 bits/char. A short or low-entropy secret with no recognized prefix (e.g., a predictable 8-character password) will not be caught.
+* **Blacklist is structural, not semantic:** If a tool invocation is obfuscated or aliased in a way that doesn't match the blacklist regex, it won't be blocked.
+* **Regex on commit text is best-effort:** `redact_command()` was built for shell command syntax. A secret embedded in a natural-language commit message with no surrounding structural cue (no `=`, no `--flag`, no known prefix) may pass through undetected.
+
+For maximally sensitive workflows, prefix commands containing plaintext secrets with a space (`HISTCONTROL=ignorespace`) — the shell will not write them to history, and TermStory will never ingest them.
 
 ---

--- a/termstory/ai.py
+++ b/termstory/ai.py
@@ -289,7 +289,12 @@ def generate_ai_summary(
     commits: Optional[List[str]] = None,
     timeout: Optional[float] = None
 ) -> Optional[str]:
-    """Scrub commands and query the configured LLM API (Groq or Ollama) to generate a summary."""
+    """Scrub commands and query the configured LLM API (Groq or Ollama) to generate a summary.
+
+    Security: commands are sanitized via sanitize_session_commands() (blacklist gate +
+    per-command redact_command()). Git commit messages are sanitized via redact_command().
+    Neither raw commands nor raw commit text is ever passed to _send_llm_request().
+    """
     if not commands:
         return None
         
@@ -482,7 +487,13 @@ def generate_daily_chronicle_prompt(
     sessions: List,
     projects: List
 ) -> str:
-    """Generate the Daily Chronicle AI prompt detailing sessions, commands, and inferred gaps."""
+    """Generate the Daily Chronicle AI prompt detailing sessions, commands, and inferred gaps.
+
+    Security: session commands are sanitized via sanitize_session_commands() (blacklist
+    gate + per-command redact_command()). Git commit messages are sanitized via
+    redact_command(). Neither raw command text nor raw commit text is embedded in the
+    returned prompt string.
+    """
     import os
     from datetime import datetime
     from termstory.models import format_duration

--- a/termstory/ask.py
+++ b/termstory/ask.py
@@ -259,6 +259,12 @@ def generate_answer(query: str, sessions: List[Session], ai_client) -> Optional[
     """
     Constructs a contextual Q&A prompt using the given query and matched sessions,
     and runs it against the configured LLM client.
+
+    Security: session commands are sanitized via sanitize_session_commands() before
+    being embedded in the prompt. Sessions containing blacklisted commands (vault,
+    aws configure, gh auth, raw token strings, etc.) have their entire COMMANDS block
+    replaced with '[REDACTED: Security/Authentication Operations]'.
+    Git commit messages are sanitized via redact_command() on each message string.
     """
     if not query.strip():
         return "Please provide a valid query."

--- a/termstory/sanitizer.py
+++ b/termstory/sanitizer.py
@@ -4,6 +4,9 @@ import math
 from typing import List, Tuple, Optional
 
 # Load custom redaction patterns from .termstoryignore
+# IMPORTANT: This loads once at module import time (called at the bottom of this file).
+# Edits to ~/.termstoryignore take effect only after restarting TermStory — there is no
+# live-reload. This is a known limitation documented in SECURITY.md.
 CUSTOM_REDACTION_PATTERNS = []
 def load_custom_ignore_rules():
     global CUSTOM_REDACTION_PATTERNS
@@ -118,6 +121,12 @@ def calculate_entropy(s: str) -> float:
     return entropy
 
 def redact_high_entropy(cmd: str) -> str:
+    # NOTE: This is a best-effort heuristic, NOT a guarantee.
+    # Strings shorter than 24 chars, or with Shannon entropy <= 4.3 bits/char,
+    # will NOT be caught here — even if they are real secrets.
+    # Named-prefix patterns (AWS_KEY_PATTERN, OPENAI_API_KEY_PATTERN, etc.)
+    # defined above are the primary defense for known secret formats.
+    # For unknown/custom formats, add patterns to ~/.termstoryignore.
     def replacer(match):
         s = match.group(0)
         # Avoid redacting git commit hashes and normal text by requiring entropy > 4.3


### PR DESCRIPTION
## What this PR does
Documentation companion to the code fix in #<insert code fix PR number here>. No source logic changes — only documentation, comments, and docstrings.

## Why each file changed

**`DATA_PRIVACY.md`** had two factual errors after the code fix lands:
1. Only mentioned "commands" being sent to LLMs — commit messages were omitted entirely from the trust story.
2. Said blacklisted sessions cause TermStory to "abort the AI request entirely" — the real behavior is replacing the COMMANDS block, not aborting. Session metadata still goes through. Fixed.
Also: named all three AI surfaces (auto-summaries, chronicle, ask), added missing blacklist token patterns, added `.termstoryignore` section.

**`docs/privacy.md`** had the same blacklist description inaccuracy, a BLACKLIST_PATTERNS code block that only showed 4 of the 8 actual patterns in `sanitizer.py`, and a redaction table with 7 of 17 implemented pattern types. All expanded to match real source.

**`SECURITY.md`** created from scratch — GitHub displays it in the Security tab and it's the standard location for vulnerability disclosure and honest known-limitations documentation. The "known gaps" table explicitly documents what the entropy heuristic misses, so users can make informed decisions rather than assuming total coverage.

**`CONTRIBUTING.md`** — the root cause of this bug was that sanitization is opt-in per function. Added a section that states the rule explicitly, shows the code pattern, and points to the existing test as a template. Future contributors now have no excuse for missing it.

**`docs/ai-integration.md`** — described the LLM transport layer but said nothing about sanitization. Added a "Pre-LLM Sanitization" section so the data flow is fully documented.

**`docs/cli-reference.md`** — `termstory ask` had no privacy disclosure in its description.

**`sanitizer.py` comments** — two inline notes about the entropy heuristic's floor (so developers don't treat it as a guarantee) and the `.termstoryignore` no-live-reload behavior (so no one files a bug when their edits don't immediately take effect).

**Docstrings** (`ask.py`, `ai.py`) — existing docstrings had zero mention of the security behavior. Updated to include the sanitization contract so it's visible at the function definition.

## Testing
No code logic changes — no new tests needed. All existing tests pass unchanged (58/58 in tested modules).