### PR TITLE
Handle date parsing errors with specific exceptions

### DIFF
--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -179,16 +179,16 @@ def search_history(
     if since:
         try:
             since_ts = int(date_parser.parse(since).timestamp())
-        except Exception:
-            Console(stderr=True).print(f"[bold red]Error: Could not parse date '{since}'[/]")
+        except (ValueError, OverflowError) as e:
+            Console(stderr=True).print(f"[bold red]Error: Could not parse date '{since}': {e}[/]")
             raise typer.Exit(code=1)
             
     until_ts = None
     if until:
         try:
             until_ts = int(date_parser.parse(until).timestamp())
-        except Exception:
-            Console(stderr=True).print(f"[bold red]Error: Could not parse date '{until}'[/]")
+        except (ValueError, OverflowError) as e:
+            Console(stderr=True).print(f"[bold red]Error: Could not parse date '{until}': {e}[/]")
             raise typer.Exit(code=1)
             
     tag_list = None


### PR DESCRIPTION
close #149 
## Summary

This PR replaces broad `except Exception` handlers used during `--since` and `--until` date parsing with more specific exception handling.

### Changes

* Replace `except Exception` with `except (ValueError, OverflowError) as e` for `--since` date parsing.
* Replace `except Exception` with `except (ValueError, OverflowError) as e` for `--until` date parsing.
* Include the original exception in the error message to improve diagnostics.
* Preserve the existing exit behavior (`typer.Exit(code=1)`).

### Testing

* Verified invalid `--since` values return an error and exit with code 1.
* Verified invalid `--until` values return an error and exit with code 1.
* Confirmed unexpected exceptions are no longer swallowed.
