### PR TITLE
[TUI] Make tool keywords list configurable via config

### DIFF
--- a/termstory/config.py
+++ b/termstory/config.py
@@ -162,7 +162,12 @@ def load_config() -> dict:
         "has_seen_timestamp_prompt": False,
         "has_seen_onboarding_reminder": False,
         "max_history_age": 5,
-        "max_query_log": 10000
+        "max_query_log": 10000,
+        "tool_keywords": [
+            "rustc", "cargo", "go", "python3", "python", "pip", "npm", "yarn",
+            "node", "docker", "docker-compose", "kubectl", "pytest", "git",
+            "clang", "gcc", "make", "cmake", "mvn", "gradle", "java", "sqlite3", "psql"
+        ]
     }
     
     config = {}

--- a/termstory/tui.py
+++ b/termstory/tui.py
@@ -2612,7 +2612,8 @@ class TermStoryWorkspace(App):
         found_tools = set()
         total_commands = 0
         
-        tool_keywords = set(self.config.get("tool_keywords") or [])
+        _kw = self.config.get("tool_keywords") or []
+        tool_keywords = set(k.strip() for k in _kw.split(",")) if isinstance(_kw, str) else set(_kw)
         editor_executables = {"vim", "vi", "nano", "emacs", "code"}
         
         for s in matched_sessions:

--- a/termstory/tui.py
+++ b/termstory/tui.py
@@ -2612,7 +2612,7 @@ class TermStoryWorkspace(App):
         found_tools = set()
         total_commands = 0
         
-        tool_keywords = ['rustc', 'cargo', 'go', 'python3', 'python', 'pip', 'npm', 'yarn', 'node', 'docker', 'docker-compose', 'kubectl', 'pytest', 'git', 'clang', 'gcc', 'make', 'cmake', 'mvn', 'gradle', 'java', 'sqlite3', 'psql']
+        tool_keywords = set(self.config.get("tool_keywords") or [])
         editor_executables = {"vim", "vi", "nano", "emacs", "code"}
         
         for s in matched_sessions:


### PR DESCRIPTION
## Description
Closes #155

  The tool keywords list in \`get_month_wrapped_telemetry\` was hardcoded as a Python literal, meaning users who use tools like \`bun\`, \`deno\`, \`poetry\`, \`uv\`, or \`terraform\` would never see them appear
  in their Wrapped report without editing source code.

  **Changes:**
  - \`termstory/config.py\` — added \`tool_keywords\` to the \`defaults\` dict with the current list as the default value; \`merge_defaults\` will auto-populate it in existing user configs on next run without
  overwriting customizations
  - \`termstory/tui.py\` — replaced the hardcoded literal at line 2615 with \`self.config.get(\"tool_keywords\")\`, consistent with how all other config values are read in the class

Fixes # (issue)

## Type of Change
Please delete options that are not relevant.

- [-] New feature (non-breaking change which adds functionality)

## Checklist:
- [-] My code follows the "density over decoration" philosophy.
- [-] I have not used `rich.panel.Panel` in my code.
- [-] I have performed a self-review of my own code.
- [-] I have commented my code, particularly in hard-to-understand areas.
- [-] I have made corresponding changes to the documentation.
- [-] My changes generate no new warnings.
- [-] I have added tests that prove my fix is effective or that my feature works.
- [-] New and existing unit tests pass locally with my changes.
