### PR TITLE
fix: catch specific ValueError instead of broad Exception in shlex split

### DIFF
--- a/termstory/tui.py
+++ b/termstory/tui.py
@@ -2658,7 +2658,7 @@ class TermStoryWorkspace(App):
                 if base in editor_executables:
                     try:
                         shlex_tokens = shlex.split(cmd_str)
-                    except Exception:
+                    except ValueError:
                         shlex_tokens = tokens
                     files = [t for t in shlex_tokens[1:] if not t.startswith('-')]
                     for f in files:


### PR DESCRIPTION
## Description
This PR resolves issue #148 by catching a specific `ValueError` instead of using a broad `except Exception:` block during `shlex.split()`. This prevents the code from swallowing unrelated runtime errors or bugs.

Fixes #148

