### PR TITLE
Narrow timestamp date parse exceptions

### DIFF
--- a/termstory/timestamp_detective.py
+++ b/termstory/timestamp_detective.py
@@ -1021,7 +1021,7 @@ class TimestampDetective:
                 for fmt in ("%a %b %d %H:%M:%S %Y %z", "%Y-%m-%d %H:%M:%S %z"):
                     try:
                         return int(datetime.strptime(date_str, fmt).timestamp())
-                    except Exception:
+                    except ValueError:
                         continue
         return None
 
@@ -1044,7 +1044,7 @@ class TimestampDetective:
         date_str = re.sub(r'\s+', ' ', m.group(1)).strip()
         try:
             dt = datetime.strptime(date_str, "%a %b %d %H:%M")
-        except Exception:
+        except ValueError:
             return None
         now = datetime.now()
         dt = dt.replace(year=now.year)

--- a/tests/test_timestamp_detective.py
+++ b/tests/test_timestamp_detective.py
@@ -34,6 +34,12 @@ from termstory.timestamp_detective import TimestampDetective
 # Helpers
 # ---------------------------------------------------------------------------
 
+class ParserBugDateTime:
+    @staticmethod
+    def strptime(*_args, **_kwargs):
+        raise TypeError("unexpected parser bug")
+
+
 NOW = int(datetime.now().timestamp())
 FOUR_YEARS_AGO = NOW - (4 * 365 * 24 * 60 * 60)
 SIX_YEARS_AGO  = NOW - (6 * 365 * 24 * 60 * 60)
@@ -857,6 +863,20 @@ class TestDetectMacosSystemLog(unittest.TestCase):
         iso = dt.astimezone().strftime("%Y-%m-%d %H:%M:%S %z")
         ts = self.d._parse_git_log_date(f"commit x\nDate:   {iso}\n\n    msg\n")
         self.assertEqual(ts, FOUR_YEARS_AGO)
+
+    def test_parse_git_log_date_ignores_format_mismatches_only(self):
+        self.assertIsNone(self.d._parse_git_log_date("commit x\nDate:   not a date\n"))
+
+        with patch("termstory.timestamp_detective.datetime", ParserBugDateTime):
+            with self.assertRaises(TypeError):
+                self.d._parse_git_log_date("commit x\nDate:   not a date\n")
+
+    def test_parse_last_login_ignores_format_mismatches_only(self):
+        self.assertIsNone(self.d._parse_last_login("alice ttys000 Tue Jun 99 09:14 still logged in"))
+
+        with patch("termstory.timestamp_detective.datetime", ParserBugDateTime):
+            with self.assertRaises(TypeError):
+                self.d._parse_last_login("alice ttys000 Thu Jun 5 09:14 still logged in")
 
     def test_detect_macos_syslog_missing_file(self):
         """When install.log doesn't exist (e.g. on Linux), return None."""


### PR DESCRIPTION
## Summary
- catch only `ValueError` for git log date format fallbacks
- catch only `ValueError` for macOS `last` timestamp parsing
- add regression coverage that preserves format-mismatch handling while surfacing unexpected parser errors

Closes #145.
Closes #146.

## Verification
- `.\.venv\Scripts\python.exe -m pytest tests\test_timestamp_detective.py::TestDetectMacosSystemLog::test_parse_git_log_date_iso tests\test_timestamp_detective.py::TestDetectMacosSystemLog::test_parse_git_log_date_ignores_format_mismatches_only tests\test_timestamp_detective.py::TestDetectMacosSystemLog::test_parse_last_login_ignores_format_mismatches_only -q`
- `python -m py_compile termstory\timestamp_detective.py tests\test_timestamp_detective.py`
- `git diff --check`

Note: the full `tests\test_timestamp_detective.py` file still has unrelated Windows path expectation failures in virtual-CWD tests in this checkout.