### PR TITLE
Replace broad exception handling when reading install log

### DIFF
--- a/termstory/timestamp_detective.py
+++ b/termstory/timestamp_detective.py
@@ -1069,7 +1069,7 @@ class TimestampDetective:
         try:
             with open(log_path, "r", encoding="utf-8", errors="ignore") as f:
                 lines = f.readlines()
-        except Exception:
+        except OSError:
             return None
 
         needle = package.lower()


### PR DESCRIPTION
## Summary

This PR replaces the overly broad `except Exception` block in `termstory/timestamp_detective.py` with `except OSError` when reading the macOS install log.

## Changes

* Replaced `except Exception:` with `except OSError:`
* Preserved the existing behavior by returning `None` when the install log cannot be read
* Kept the change focused and limited to the reported issue

Fixes #147
