### PR TITLE
test(tui): add docstring to is_worker_cancelled

### DIFF
--- a/termstory/tui.py
+++ b/termstory/tui.py
@@ -51,6 +51,7 @@ from termstory.ai import generate_ai_summary, generate_timeframe_summary, genera
 from termstory.insights import calculate_focus_score, calculate_time_of_day_distribution
 
 def is_worker_cancelled() -> bool:
+    """Return True if the current Textual worker has been cancelled, False otherwise."""
     try:
         from textual.worker import get_current_worker, NoActiveWorker
         try:


### PR DESCRIPTION
Test PR for the new Miku auto area-label feature.

Touches only `termstory/tui.py` so `.miku.yml` should auto-apply **just** `area/tui` and nothing else. Clean isolated test.

If this works, the bot should add the `area/tui` label within a few seconds of opening — no `:miku /classify` needed.