### PR TITLE
test(cli): add docstring to safe_init_db

### DIFF
--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -27,6 +27,7 @@ import re
 console = Console()
 
 def safe_init_db(db: Database) -> None:
+    """Initialize the SQLite database, tolerating transient lock/IO errors."""
     try:
         db.init_db()
     except sqlite3.DatabaseError as e:


### PR DESCRIPTION
Test PR for Miku auto-area-label feature with webhook permissions enabled.

Touches only `termstory/cli.py` so `.miku.yml` should auto-apply **just** `area/cli` within seconds of opening — no `:miku /classify` comment needed.

If this works, the webhook event `pull_request opened` should reach Miku and the bot should silently add `area/cli` to this PR.