### PR TITLE
docs(ai): add docstring to clear_last_ai_error

### DIFF
--- a/termstory/ai.py
+++ b/termstory/ai.py
@@ -97,6 +97,7 @@ def get_last_ai_error() -> Optional[str]:
     return getattr(_local_ai_state, "last_error", None)
 
 def clear_last_ai_error() -> None:
+    """Reset the per-thread AI error cache to a clean state."""
     """Clear the last AI call error message for the current thread."""
     if hasattr(_local_ai_state, "last_error"):
         delattr(_local_ai_state, "last_error")


### PR DESCRIPTION
Second auto-area-label test PR. Touches only termstory/ai.py so .miku.yml should auto-apply just 'area/ai' on PR open.

## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of Change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [ ] My code follows the "density over decoration" philosophy.
- [ ] I have not used `rich.panel.Panel` in my code.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
