### PR TITLE
fix: make cosine clustering threshold configurable (closes #119)

### DIFF
--- a/termstory/config.py
+++ b/termstory/config.py
@@ -171,6 +171,7 @@ def load_config() -> dict:
             "clang", "gcc", "make", "cmake", "mvn", "gradle", "java", "sqlite3", "psql"
         ],
         "reminder_poll_interval": 300,
+        "clustering_threshold": 0.6,
         "default_branch_names": ["main"]
     }
     

--- a/termstory/reminder.py
+++ b/termstory/reminder.py
@@ -5,7 +5,7 @@ import os
 import time
 import re
 from typing import List, Dict, Optional, Tuple
-from termstory.config import get_app_dir
+from termstory.config import get_app_dir, load_config
 
 logger = logging.getLogger(__name__)
 
@@ -148,8 +148,35 @@ def complete_reminder(reminder_id: int) -> bool:
     return updated
 
 
-def cluster_commands(commands: List[str]) -> List[List[str]]:
-    """Cluster similar commands using sentence-transformers embeddings."""
+_DEFAULT_CLUSTERING_THRESHOLD = 0.6
+
+
+def _resolve_clustering_threshold() -> float:
+    """Read ``clustering_threshold`` from config.json.
+
+    Falls back to :data:`_DEFAULT_CLUSTERING_THRESHOLD` if config is
+    unavailable, malformed, or the value cannot be coerced to float.
+    Shared by :func:`cluster_commands` (per-call default) and
+    :func:`consolidate_sleep_contexts` (resolved once per run).
+    """
+    try:
+        cfg = load_config()
+        return float(cfg.get("clustering_threshold", _DEFAULT_CLUSTERING_THRESHOLD))
+    except Exception:
+        return _DEFAULT_CLUSTERING_THRESHOLD
+
+
+def cluster_commands(commands: List[str], threshold: Optional[float] = None) -> List[List[str]]:
+    """Cluster similar commands using sentence-transformers embeddings.
+
+    Args:
+        commands: Commands to cluster.
+        threshold: Cosine similarity threshold above which two commands are
+            merged into the same cluster. Lower values over-merge unrelated
+            commands; higher values split related ones. Defaults to the
+            ``clustering_threshold`` config value (falls back to
+            ``_DEFAULT_CLUSTERING_THRESHOLD`` if config is unavailable).
+    """
     if not commands:
         return []
         
@@ -201,7 +228,8 @@ def cluster_commands(commands: List[str]) -> List[List[str]]:
     # Simple leader clustering
     clusters = []
     cluster_embs = []
-    threshold = 0.6
+    if threshold is None:
+        threshold = _resolve_clustering_threshold()
     
     for cmd, emb in zip(unique_cmds, emb_list):
         placed = False
@@ -341,13 +369,14 @@ def consolidate_sleep_contexts(db, force: bool = False) -> int:
         return 0
 
     # 5. Consolidate each chunk
+    clustering_threshold = _resolve_clustering_threshold()
     consolidated_count = 0
     for chunk in chunks_to_consolidate:
         start_time = chunk[0]["timestamp"]
         end_time = chunk[-1]["timestamp"]
         cmd_strs = [c["command"] for c in chunk]
         
-        clusters = cluster_commands(cmd_strs)
+        clusters = cluster_commands(cmd_strs, threshold=clustering_threshold)
         cluster_summaries = []
         for cluster in clusters:
             summ = generate_cluster_summary(cluster)

--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -14,7 +14,10 @@ from termstory.reminder import (
     complete_reminder,
     load_reminders,
     save_reminders,
-    get_reminders_file_path
+    get_reminders_file_path,
+    cluster_commands,
+    _DEFAULT_CLUSTERING_THRESHOLD,
+    consolidate_sleep_contexts
 )
 
 def test_parse_reminder_text():
@@ -299,3 +302,133 @@ def test_add_reminder_days_validation(tmp_path, monkeypatch):
      # Test parsed phrase that yields an invalid range
     with pytest.raises(ValueError, match="Days must be between 0 and 3650."):
         add_reminder("do something in 4000 days")
+
+
+def _fake_get_embeddings(monkeypatch, mapping):
+    import termstory.rag as rag
+
+    def fake(texts, model_name="all-MiniLM-L6-v2"):
+        return [mapping[t] for t in texts]
+
+    monkeypatch.setattr(rag, "get_embeddings", fake)
+    monkeypatch.setattr(rag, "SENTENCE_TRANSFORMERS_AVAILABLE", True)
+
+
+def test_cluster_commands_merges_above_threshold(monkeypatch):
+    embeddings = {
+        "git status": [1.0, 0.0],
+        "git status -s": [0.99, 0.14107],  # cos sim with [1,0] ≈ 0.99
+    }
+    _fake_get_embeddings(monkeypatch, embeddings)
+
+    clusters = cluster_commands(list(embeddings.keys()), threshold=0.6)
+
+    assert len(clusters) == 1
+    assert set(clusters[0]) == set(embeddings.keys())
+
+
+def test_cluster_commands_splits_below_threshold(monkeypatch):
+    embeddings = {
+        "git status": [1.0, 0.0],
+        "docker ps": [0.0, 1.0],  # cos sim = 0.0, well below 0.6
+    }
+    _fake_get_embeddings(monkeypatch, embeddings)
+
+    clusters = cluster_commands(list(embeddings.keys()), threshold=0.6)
+
+    assert len(clusters) == 2
+
+
+def test_cluster_commands_respects_explicit_threshold_override(monkeypatch):
+    embeddings = {
+        "a": [1.0, 0.0],
+        "b": [0.7, 0.7141],  # cos sim ≈ 0.7 — merges at 0.6, splits at 0.9
+    }
+    _fake_get_embeddings(monkeypatch, embeddings)
+
+    # Lower threshold (0.5): merges
+    merged = cluster_commands(list(embeddings.keys()), threshold=0.5)
+    assert len(merged) == 1
+
+    # Higher threshold (0.9): splits
+    split = cluster_commands(list(embeddings.keys()), threshold=0.9)
+    assert len(split) == 2
+
+
+def test_cluster_commands_reads_threshold_from_config_when_unset(monkeypatch):
+    embeddings = {
+        "a": [1.0, 0.0],
+        "b": [0.7, 0.7141],  # cos sim ≈ 0.7
+    }
+    _fake_get_embeddings(monkeypatch, embeddings)
+
+    # Config sets a high threshold (0.9) — must split even though the old
+    # hardcoded 0.6 default would have merged these.
+    monkeypatch.setattr(
+        "termstory.reminder.load_config",
+        lambda: {"clustering_threshold": 0.9},
+    )
+    clusters = cluster_commands(list(embeddings.keys()))
+    assert len(clusters) == 2
+
+
+def test_cluster_commands_falls_back_to_default_when_config_raises(monkeypatch):
+    embeddings = {
+        "git status": [1.0, 0.0],
+        "git status -s": [0.99, 0.14107],
+    }
+    _fake_get_embeddings(monkeypatch, embeddings)
+
+    monkeypatch.setattr(
+        "termstory.reminder.load_config",
+        lambda: (_ for _ in ()).throw(OSError("no config")),
+    )
+    clusters = cluster_commands(list(embeddings.keys()))
+    # _DEFAULT_CLUSTERING_THRESHOLD (0.6) merges these — fallback succeeded
+    assert len(clusters) == 1
+    assert _DEFAULT_CLUSTERING_THRESHOLD == 0.6
+
+
+def test_consolidate_sleep_contexts_reads_config_once_not_per_chunk(tmp_path, monkeypatch):
+    import termstory.rag as rag
+
+    db_file = tmp_path / "test_consolidate.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    now = int(time.time())
+    p = Project(id=1, name="termstory", path="~/projects/termstory", first_seen=now, last_seen=now, session_count=1, total_time=100)
+
+    # 3 chunks separated by >= 1800s idle gaps, 2 commands each.
+    commands = []
+    for chunk_idx in range(3):
+        base = now - (3 - chunk_idx) * 3600
+        commands.append(Command(timestamp=base, command=f"git status {chunk_idx}", session_id=1, project_id=1))
+        commands.append(Command(timestamp=base + 10, command=f"git log {chunk_idx}", session_id=1, project_id=1))
+
+    s = Session(id=1, start_time=commands[0].timestamp, end_time=commands[-1].timestamp, duration_seconds=3600, project_id=1, commands=commands)
+    db.save_data([p], [s], commands)
+
+    # Force the embeddings path (not the verb-fallback path) so cluster_commands
+    # actually reaches the threshold-resolution / load_config() call.
+    def fake_get_embeddings(texts, model_name="all-MiniLM-L6-v2"):
+        return [[1.0, 0.0] for _ in texts]
+
+    monkeypatch.setattr(rag, "get_embeddings", fake_get_embeddings)
+    monkeypatch.setattr(rag, "SENTENCE_TRANSFORMERS_AVAILABLE", True)
+
+    call_count = [0]
+    real_defaults = {"clustering_threshold": 0.6}
+
+    def counting_load_config():
+        call_count[0] += 1
+        return real_defaults
+
+    monkeypatch.setattr("termstory.reminder.load_config", counting_load_config)
+
+    consolidate_sleep_contexts(db, force=True)
+
+    assert call_count[0] == 1, (
+        f"load_config() was called {call_count[0]} times for 3 chunks — "
+        "expected exactly 1 (resolved once per run, not once per chunk)"
+    )


### PR DESCRIPTION
## Summary
This PR makes the hardcoded clustering threshold (0.6) in `cluster_commands()` configurable via a new `clustering_threshold` config key, allowing users to tune command deduplication behavior. It optimizes config resolution to read once per `consolidate_sleep_contexts()` run instead of per chunk, reducing redundant disk I/O during daemon operation.

## Changes

### Core
- **termstory/config.py**: Added `clustering_threshold: 0.6` to the default configuration dictionary in `load_config()` 
- **termstory/reminder.py**: 
  - Added `_DEFAULT_CLUSTERING_THRESHOLD = 0.6` constant as the fallback value 
  - Added `_resolve_clustering_threshold()` helper function to read threshold from config with exception-safe fallback to the default 
  - Modified `cluster_commands()` signature to accept optional `threshold: Optional[float] = None` parameter, with docstring explaining the threshold behavior 
  - Updated `cluster_commands()` to resolve threshold from config when not explicitly provided 
  - Modified `consolidate_sleep_contexts()` to resolve threshold once per run before the chunk loop, passing it to each `cluster_commands()` call 
  - Added import for `load_config` from `termstory.config` 

### Tests
- **tests/test_reminder.py**:
  - Added imports for `cluster_commands`, `_DEFAULT_CLUSTERING_THRESHOLD`, and `consolidate_sleep_contexts` 
  - Added `_fake_get_embeddings()` helper to mock sentence-transformers embeddings for testing 
  - Added `test_cluster_commands_merges_above_threshold()` to verify commands with cosine similarity ≥ threshold are merged 
  - Added `test_cluster_commands_splits_below_threshold()` to verify commands with cosine similarity < threshold are split 
  - Added `test_cluster_commands_respects_explicit_threshold_override()` to verify explicit threshold parameter overrides config 
  - Added `test_cluster_commands_reads_threshold_from_config_when_unset()` to verify config-backed default behavior 
  - Added `test_cluster_commands_falls_back_to_default_when_config_raises()` to verify fallback on config errors 
  - Added `test_consolidate_sleep_contexts_reads_config_once_not_per_chunk()` to verify the optimization that config is read once per run, not per chunk 

## Fixes
- Fixes #119 — Makes the hardcoded clustering threshold configurable to allow users to tune command deduplication behavior

## Breaking Changes
None

## Testing
Run the test suite with pytest:
```bash
pytest tests/test_reminder.py -v
```
The new tests specifically cover:
- Threshold-based merging and splitting behavior
- Config-backed defaults
- Fallback behavior on config errors
- Config read optimization (once per consolidation run)

## Notes
- The documentation checkbox in the PR checklist is unchecked, indicating documentation updates may be needed for the new `clustering_threshold` config option.
- The PR was classified with labels `area/config` and `kind/tests` during triage.
- The default value of 0.6 maintains backward compatibility with the previous hardcoded behavior.