### PR TITLE
fix: make SQLite connection timeout configurable (closes #123)

### DIFF
--- a/termstory/config.py
+++ b/termstory/config.py
@@ -165,6 +165,7 @@ def load_config() -> dict:
         "has_seen_onboarding_reminder": False,
         "max_history_age": 5,
         "max_query_log": 10000,
+        "db_timeout": 30.0,
         "tool_keywords": [
             "rustc", "cargo", "go", "python3", "python", "pip", "npm", "yarn",
             "node", "docker", "docker-compose", "kubectl", "pytest", "git",

--- a/termstory/database.py
+++ b/termstory/database.py
@@ -83,12 +83,20 @@ class SafeConnection(sqlite3.Connection):
 
 class Database:
     MAX_QUERY_LOG = 10000
+    DEFAULT_DB_TIMEOUT = 30.0
 
     def __init__(self, db_path: str):
         self.db_path = db_path
         self.query_logs = []
-        configured_max = get_config_value(load_config(), "max_query_log")
+        config = load_config()
+        configured_max = get_config_value(config, "max_query_log")
         self.max_query_log = configured_max if type(configured_max) is int and configured_max > 0 else self.MAX_QUERY_LOG
+        configured_timeout = get_config_value(config, "db_timeout")
+        self.db_timeout = (
+            configured_timeout
+            if type(configured_timeout) in (int, float) and configured_timeout > 0
+            else self.DEFAULT_DB_TIMEOUT
+        )
 
     def log_query(self, sql: str, duration: float):
         self.query_logs.append({
@@ -100,7 +108,7 @@ class Database:
         
     def get_connection(self) -> sqlite3.Connection:
         """Create and return a database connection with foreign key support enabled"""
-        conn = sqlite3.connect(self.db_path, timeout=30.0, factory=SafeConnection)
+        conn = sqlite3.connect(self.db_path, timeout=self.db_timeout, factory=SafeConnection)
         conn._db_instance = self
         conn.execute("PRAGMA foreign_keys = ON;")
         return conn

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -304,3 +304,99 @@ def test_database_query_logs_are_bounded():
 
 
 
+def test_database_uses_default_timeout_when_config_unset(tmp_path, monkeypatch):
+    """Database() must fall back to DEFAULT_DB_TIMEOUT (30.0) when config.json
+    has no db_timeout key."""
+    monkeypatch.setattr(
+        "termstory.database.load_config",
+        lambda: {"max_query_log": 10000},  # no db_timeout key present
+    )
+    db_file = tmp_path / "test_default_timeout.db"
+    db = Database(str(db_file))
+    assert db.db_timeout == Database.DEFAULT_DB_TIMEOUT
+    assert db.db_timeout == 30.0
+
+
+def test_database_reads_db_timeout_from_config(tmp_path, monkeypatch):
+    """Database() must read db_timeout from config.json instead of the
+    hardcoded 30.0 literal."""
+    monkeypatch.setattr(
+        "termstory.database.load_config",
+        lambda: {"max_query_log": 10000, "db_timeout": 90.0},
+    )
+    db_file = tmp_path / "test_custom_timeout.db"
+    db = Database(str(db_file))
+    assert db.db_timeout == 90.0
+
+
+def test_database_get_connection_passes_configured_timeout(tmp_path, monkeypatch):
+    """get_connection() must pass self.db_timeout to sqlite3.connect(),
+    not the old hardcoded 30.0 literal."""
+    import sqlite3
+
+    monkeypatch.setattr(
+        "termstory.database.load_config",
+        lambda: {"max_query_log": 10000, "db_timeout": 5.0},
+    )
+    db_file = tmp_path / "test_connect_timeout.db"
+    db = Database(str(db_file))
+
+    captured_kwargs = {}
+    real_connect = sqlite3.connect
+
+    def spy_connect(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr("termstory.database.sqlite3.connect", spy_connect)
+
+    conn = db.get_connection()
+    conn.close()
+
+    assert captured_kwargs.get("timeout") == 5.0
+
+
+def test_database_clamps_non_positive_db_timeout(tmp_path, monkeypatch):
+    """A zero or negative db_timeout in config must not be passed through
+    to sqlite3.connect(), it should fall back to DEFAULT_DB_TIMEOUT."""
+    monkeypatch.setattr(
+        "termstory.database.load_config",
+        lambda: {"max_query_log": 10000, "db_timeout": 0},
+    )
+    db_file = tmp_path / "test_zero_timeout.db"
+    db = Database(str(db_file))
+    assert db.db_timeout == Database.DEFAULT_DB_TIMEOUT
+
+
+def test_database_ignores_malformed_db_timeout(tmp_path, monkeypatch):
+    """A non-numeric db_timeout in config must not crash Database.__init__
+    and must fall back to DEFAULT_DB_TIMEOUT."""
+    monkeypatch.setattr(
+        "termstory.database.load_config",
+        lambda: {"max_query_log": 10000, "db_timeout": "not-a-number"},
+    )
+    db_file = tmp_path / "test_bad_timeout.db"
+    db = Database(str(db_file))
+    assert db.db_timeout == Database.DEFAULT_DB_TIMEOUT
+
+
+def test_database_still_works_end_to_end_with_custom_timeout(tmp_path, monkeypatch):
+    """Regression guard: a Database configured with a custom db_timeout
+    must still initialize and accept queries normally (existing tests
+    green, per the issue's acceptance criteria)."""
+    monkeypatch.setattr(
+        "termstory.database.load_config",
+        lambda: {"max_query_log": 10000, "db_timeout": 45.0},
+    )
+    db_file = tmp_path / "test_e2e_timeout.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    conn = db.get_connection()
+    cursor = conn.cursor()
+    cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    tables = {row[0] for row in cursor.fetchall()}
+    conn.close()
+
+    assert "projects" in tables
+    assert db.db_timeout == 45.0

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -359,13 +359,14 @@ def test_database_get_connection_passes_configured_timeout(tmp_path, monkeypatch
 def test_database_clamps_non_positive_db_timeout(tmp_path, monkeypatch):
     """A zero or negative db_timeout in config must not be passed through
     to sqlite3.connect(), it should fall back to DEFAULT_DB_TIMEOUT."""
-    monkeypatch.setattr(
-        "termstory.database.load_config",
-        lambda: {"max_query_log": 10000, "db_timeout": 0},
-    )
-    db_file = tmp_path / "test_zero_timeout.db"
-    db = Database(str(db_file))
-    assert db.db_timeout == Database.DEFAULT_DB_TIMEOUT
+    for bad_value in (0, -1.0):
+        monkeypatch.setattr(
+            "termstory.database.load_config",
+            lambda v=bad_value: {"max_query_log": 10000, "db_timeout": v},
+        )
+        db_file = tmp_path / f"test_bad_timeout_{bad_value}.db"
+        db = Database(str(db_file))
+        assert db.db_timeout == Database.DEFAULT_DB_TIMEOUT, f"expected default for db_timeout={bad_value!r}"
 
 
 def test_database_ignores_malformed_db_timeout(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
This PR makes the SQLite connection timeout configurable via a `db_timeout` config key (defaulting to 30.0 seconds), replacing the hardcoded `timeout=30.0` literal in `get_connection()`. The configuration is resolved once per `Database` instance in `__init__()`, following the existing pattern used for `max_query_log`, and includes validation to fall back to the default for non-numeric or non-positive values. This allows users to tune the timeout for busy or NFS-mounted filesystems without modifying code. 

## Changes

### Core
- **termstory/config.py**: Added `"db_timeout": 30.0` to the defaults dictionary in `load_config()` to ensure the key is always present in a freshly-loaded config. 
- **termstory/database.py**: 
  - Added `DEFAULT_DB_TIMEOUT = 30.0` class constant. 
  - Modified `__init__()` to load config once and resolve `db_timeout` with validation (checks for int/float type and positive value, falls back to default otherwise). 
  - Changed `get_connection()` to pass `timeout=self.db_timeout` instead of the hardcoded `30.0` literal. 

### Tests
- **tests/test_database.py**: Added 6 comprehensive test functions:
  - `test_database_uses_default_timeout_when_config_unset`: Verifies fallback to `DEFAULT_DB_TIMEOUT` when config key is missing. 
  - `test_database_reads_db_timeout_from_config`: Verifies custom timeout is read from config. 
  - `test_database_get_connection_passes_configured_timeout`: Spies on `sqlite3.connect()` to verify the configured timeout is passed through. 
  - `test_database_clamps_non_positive_db_timeout`: Verifies zero or negative values fall back to default. 
  - `test_database_ignores_malformed_db_timeout`: Verifies non-numeric values fall back to default without crashing. 
  - `test_database_still_works_end_to_end_with_custom_timeout`: Regression guard ensuring database initialization and queries work normally with a custom timeout. 

## Fixes
- Fixes #123 — SQLite connection timeout was hardcoded at 30.0 seconds with no way to tune it for different filesystem conditions (too short on busy/NFS-mounted filesystems, wastes time on fast local SSDs).

## Breaking Changes
None. The default value (30.0) matches the previous hardcoded behavior, and the config key is optional with a safe fallback.

## Testing
Run the database test suite to verify the new timeout configuration behavior:
```bash
pytest tests/test_database.py -v
```

The new tests specifically cover:
- Default timeout fallback when config is unset
- Custom timeout reading from config
- Timeout propagation to `sqlite3.connect()`
- Validation and clamping of invalid values
- End-to-end regression testing

## Notes
The implementation follows the existing pattern used for `max_query_log` configuration in the `Database` class, loading config once in `__init__()` rather than on every call to `get_connection()` (which has 28 call sites across the file). This approach is more efficient and consistent with the codebase's configuration resolution pattern.