### PR TITLE
refactor: extract magic numbers to named constants in replay.py

### DIFF
--- a/termstory/replay.py
+++ b/termstory/replay.py
@@ -10,6 +10,10 @@ from termstory.models import Session, Command, Project, format_duration
 
 console = Console()
 
+MAX_REPLAY_GAP_SECONDS = 2.0
+INITIAL_REPLAY_PAUSE_SECONDS = 0.5
+
+
 def format_relative_time(seconds: int) -> str:
     sign = "+"
     if seconds < 0:
@@ -126,12 +130,12 @@ def run_replay(db: Database, session_id: Optional[int] = None, speed: float = 1.
                 dt = cmd.timestamp - prev_timestamp
                 # Calculate sleep duration, scale by speed, and cap at max delay
                 wait_time = max(0.0, float(dt)) / speed
-                wait_time = min(wait_time, 2.0) # max 2 seconds delay
+                wait_time = min(wait_time, MAX_REPLAY_GAP_SECONDS)
                 if wait_time > 0:
                     time.sleep(wait_time)
             else:
                 # Small initial pause
-                time.sleep(min(0.5 / speed, 2.0))
+                time.sleep(min(INITIAL_REPLAY_PAUSE_SECONDS / speed, MAX_REPLAY_GAP_SECONDS))
 
             # Calculate relative offset
             offset_sec = cmd.timestamp - session.start_time


### PR DESCRIPTION
## Summary

This PR improves code readability in the replay module by extracting hardcoded timing magic numbers from `run_replay()` into module-level named constants. The refactor maintains identical behavior while making the timing parameters more discoverable and easier to maintain.

## Changes

### Core
- **termstory/replay.py**: Added two module-level constants to replace hardcoded timing values in `run_replay()`:
  - `MAX_REPLAY_GAP_SECONDS = 2.0` - caps the maximum inter-command sleep delay to prevent excessively long pauses during playback 
  - `INITIAL_REPLAY_PAUSE_SECONDS = 0.5` - defines the initial pause before the first command is typed 
- **termstory/replay.py**: Updated `run_replay()` to use the new constants:
  - Replaced `min(wait_time, 2.0)` with `min(wait_time, MAX_REPLAY_GAP_SECONDS)` at line 129 
  - Replaced `min(0.5 / speed, 2.0)` with `min(INITIAL_REPLAY_PAUSE_SECONDS / speed, MAX_REPLAY_GAP_SECONDS)` at line 134 

## Fixes

- Fixes #193 — resolves hardcoded magic numbers in replay timing logic

## Breaking Changes

None

## Testing

Run the existing replay test suite to verify behavior is unchanged:
```bash
pytest tests/test_replay.py -v
```

The `test_run_replay_successful_playback` test specifically validates the timing logic, including the initial delay calculation and the capped wait time .

## Notes

- Two additional timing magic numbers remain inline in `run_replay()`: the character typing delay (`0.04`) at line 144 and the post-typing pause (`0.15`) at line 151 . These were not extracted in this PR as they were not part of the original issue scope.
- The numeric values are identical to the original hardcoded values, ensuring no behavioral change.