### PR TITLE
fix: replace bare except blocks with specific types and logging in formatter

### DIFF
--- a/termstory/formatter.py
+++ b/termstory/formatter.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 import shlex
@@ -15,6 +16,7 @@ from rich.table import Table
 from rich.text import Text
 from rich.markup import escape
 
+logger = logging.getLogger(__name__)
 
 DISPLAY_NAMES = {
     "git": "Git",
@@ -67,7 +69,7 @@ def extract_files_from_commands(commands: List[Command]) -> Dict[str, int]:
     for cmd in commands:
         try:
             tokens = shlex.split(cmd.command)
-        except Exception:
+        except ValueError:
             tokens = cmd.command.split()
             
         if not tokens:
@@ -976,7 +978,7 @@ def get_operator_handle() -> str:
         if stored_user:
             return f"@{stored_user.strip().lstrip('@')}"
     except Exception:
-        pass
+        logger.debug("Could not load config for operator handle", exc_info=True)
 
     import subprocess
     try:
@@ -985,7 +987,7 @@ def get_operator_handle() -> str:
         if user:
             return f"@{user}"
     except Exception:
-        pass
+        logger.debug("Could not get github.user from git config", exc_info=True)
     try:
         res = subprocess.run(["git", "config", "remote.origin.url"], capture_output=True, text=True, check=False)
         url = res.stdout.strip()
@@ -994,14 +996,14 @@ def get_operator_handle() -> str:
             if match:
                 return f"@{match.group(1)}"
     except Exception:
-        pass
+        logger.debug("Could not get remote origin URL from git config", exc_info=True)
     try:
         res = subprocess.run(["git", "config", "user.name"], capture_output=True, text=True, check=False)
         name = res.stdout.strip()
         if name:
             return f"@{name.replace(' ', '-').lower()}"
     except Exception:
-        pass
+        logger.debug("Could not get user.name from git config", exc_info=True)
     try:
         import getpass
         return f"@{getpass.getuser()}"
@@ -1193,9 +1195,9 @@ def get_github_avatar_ascii(username: str, width: int = 12, height: int = 7, on_
                 with _avatar_lock:
                     _avatar_cache[cache_key] = lines
                 return lines
-        except Exception:
-            pass
-            
+        except OSError:
+            logger.warning("Failed to read avatar from disk cache", exc_info=True)
+
     with _avatar_lock:
         if cache_key in _avatar_fetching:
             return get_fallback_avatar_padded(width, height)
@@ -1298,9 +1300,10 @@ def get_github_avatar_ascii(username: str, width: int = 12, height: int = 7, on_
                 os.makedirs(db_dir, exist_ok=True)
                 with open(disk_path, "w", encoding="utf-8") as f:
                     f.write("\n".join(lines))
-            except Exception:
-                pass
+            except OSError:
+                logger.warning("Failed to save avatar to disk cache", exc_info=True)
         except Exception:
+            logger.exception("Avatar fetch failed, using fallback")
             with _avatar_lock:
                 _avatar_cache[cache_key] = get_fallback_avatar_padded(width, height)
         finally:
@@ -1310,7 +1313,7 @@ def get_github_avatar_ascii(username: str, width: int = 12, height: int = 7, on_
                 try:
                     on_resolved()
                 except Exception:
-                    pass
+                    logger.exception("on_resolved callback failed")
                     
     threading.Thread(target=fetch_thread, daemon=True).start()
     return get_fallback_avatar_padded(width, height)


### PR DESCRIPTION
## Summary
This PR replaces 10 bare `except Exception: pass` blocks in `termstory/formatter.py` with specific exception types and structured logging to improve debuggability and make silent failures visible across command parsing, operator handle detection, and avatar caching operations.

## Changes

### Logging Infrastructure
- Added `import logging` and module-level `logger = logging.getLogger(__name__)` to enable structured logging throughout `termstory/formatter.py`

### Command Parsing
- In `extract_files_from_commands`, narrowed exception handling for `shlex.split` from bare `except Exception` to `except ValueError`, which is the only documented exception from `shlex.split`

### Operator Handle Detection
- In `get_operator_handle`, replaced 4 bare `except Exception: pass` blocks in the fallback chain with `logger.debug(..., exc_info=True)` to make config loading and git config failures visible in debug logs:
  - Config loading failure (line 978-979)
  - `github.user` git config failure (line 987-988)
  - `remote.origin.url` git config failure (line 996-997)
  - `user.name` git config failure (line 1003-1004)

### Avatar Caching
- In `get_github_avatar_ascii`, changed disk cache read exception from bare `except Exception` to `except OSError` with `logger.warning(..., exc_info=True)` to properly handle file I/O errors

### Avatar Fetching
- In the `fetch_thread` function within `get_github_avatar_ascii`:
  - Changed disk cache save exception to `except OSError` with `logger.warning(..., exc_info=True)`
  - Changed general avatar fetch exception to `logger.exception("Avatar fetch failed, using fallback")` to make network/processing errors visible
  - Changed `on_resolved` callback exception to `logger.exception("on_resolved callback failed")` to surface UI refresh errors

## Fixes
- Fixes #189 — Replaced silent exception swallowing with specific exception types and structured logging to improve debuggability
- related #208 

## Breaking Changes
None

## Testing
To test the changes:
1. Run the test suite: `pytest tests/test_formatter_rich.py -v`
2. Enable debug logging and verify that fallback operations in `get_operator_handle` log appropriately when config/git config is unavailable
3. Test avatar fetching with network errors to verify `logger.exception` is called for fetch failures
4. Test avatar disk cache with permission errors to verify `OSError` handling and `logger.warning`

## Notes
- The Greptile review suggested narrowing exception types and adding structured logging, which has been incorporated in this PR
- All changes maintain backward compatibility while making previously silent failures visible in logs
- The `exc_info=True` parameter ensures full stack traces are available in debug logs for troubleshooting