### PR TITLE
chore: expand .miku.yml area/kind label coverage

### DIFF
--- a/.miku.yml
+++ b/.miku.yml
@@ -6,21 +6,28 @@ area_labels:
     - "termstory/predict.py"
     - "termstory/insights.py"
     - "termstory/hermes_obs.py"
+    - "termstory/templates/**"
   area/storage:
     - "termstory/database.py"
     - "termstory/archive.py"
     - "termstory/backup.py"
     - "termstory/models.py"
     - "termstory/mcp_snapshot.py"
+    - "termstory/exporter.py"
+    - "termstory/git_integration.py"
+    - "termstory/project.py"
   area/cli:
     - "termstory/cli.py"
     - "termstory/__main__.py"
     - "main.py"
     - "termstory/session.py"
+    - "termstory/reminder.py"
   area/tui:
     - "termstory/tui.py"
     - "termstory/formatter.py"
     - "termstory/replay.py"
+    - "termstory/notebook.py"
+    - "termstory/stats.py"
     - "skills/**"
   area/search:
     - "termstory/search.py"
@@ -28,6 +35,10 @@ area_labels:
     - "termstory/timeline.py"
     - "termstory/parser.py"
     - "termstory/sanitizer.py"
+    - "termstory/date_utils.py"
+    - "termstory/timestamp_detective.py"
+  area/web:
+    - "termstory/web.py"
   area/config:
     - "termstory/config.py"
     - "pyproject.toml"
@@ -40,6 +51,8 @@ area_labels:
     - "README*"
     - "CHANGELOG*"
     - "CONTRIBUTING*"
+    - "DATA_PRIVACY*"
+    - "SECURITY*"
   kind/ci:
     - ".github/**"
     - "scripts/**"
@@ -48,3 +61,5 @@ area_labels:
     - "tests/**"
     - "tests/conftest.py"
     - "tests/fixtures/**"
+    - "tests/stress/**"
+    - "termstory/testing.py"


### PR DESCRIPTION
Add missing module paths and doc/ci/test patterns so auto-labeling covers everything in the repo.

**area/ai**
- `termstory/templates/**`

**area/storage**
- `termstory/exporter.py`
- `termstory/git_integration.py`
- `termstory/project.py`

**area/cli**
- `termstory/reminder.py`

**area/tui**
- `termstory/notebook.py`
- `termstory/stats.py`

**area/search**
- `termstory/date_utils.py`
- `termstory/timestamp_detective.py`

**area/web** (new group)
- `termstory/web.py`

**kind/docs**
- `DATA_PRIVACY*`
- `SECURITY*`

**kind/tests**
- `tests/stress/**`
- `termstory/testing.py`

54 entries across 10 labels. Validates as YAML.