### PR TITLE
fix(date_utils): chain exception in parse_date_range_helper

### DIFF
--- a/termstory/date_utils.py
+++ b/termstory/date_utils.py
@@ -97,7 +97,7 @@ def parse_date_range_helper(date_range_str: str) -> Tuple[int, int]:
             end = datetime.combine(end_dt.date(), time.max)
             return int(start.timestamp()), int(end.timestamp())
         except Exception as e:
-            raise ValueError(f"Invalid date range format: {e}")
+            raise ValueError(f"Invalid date range format: {e}") from e
             
     # Try parsing as a single date
     try:
@@ -105,6 +105,6 @@ def parse_date_range_helper(date_range_str: str) -> Tuple[int, int]:
         start = datetime.combine(dt.date(), time.min)
         end = datetime.combine(dt.date(), time.max)
         return int(start.timestamp()), int(end.timestamp())
-    except Exception:
-        raise ValueError(f"Unknown date range format '{date_range_str}'")
+    except Exception as e:
+        raise ValueError(f"Unknown date range format '{date_range_str}'") from e
 

--- a/tests/test_date_utils.py
+++ b/tests/test_date_utils.py
@@ -1,3 +1,4 @@
+import pytest
 import os
 from datetime import datetime
 from termstory.date_utils import get_current_time, get_today_range, get_week_range, get_month_range, format_date_range
@@ -96,3 +97,10 @@ def test_timezone_aware_override(monkeypatch):
     monkeypatch.setenv("TERMSTORY_DATE_OVERRIDE", "2026-06-19T12:00:00+05:30")
     ct = get_current_time()
     assert ct.tzinfo is None
+
+def test_parse_date_range_helper_chains_underlying_error():
+    """Invalid input must raise ValueError with the original parse error chained via __cause__."""
+    from termstory.date_utils import parse_date_range_helper
+    with pytest.raises(ValueError) as exc:
+        parse_date_range_helper("not-a-real-date-at-all-zzzzz")
+    assert exc.value.__cause__ is not None, "ValueError must chain the underlying parse error"


### PR DESCRIPTION
## Summary
This PR improves exception handling in `parse_date_range_helper` by adding exception chaining (`from e`) to preserve the original `dateutil` parsing error in the traceback when date parsing fails. The change applies to both the colon-range parsing branch and the single-date fallback path, making error handling consistent across the function and improving debuggability by maintaining the full error context. 

## Changes
- **Core**: Updated exception handling in `parse_date_range_helper` in `termstory/date_utils.py` to use `raise ValueError(...) from e` at both error-raise sites:
  - Colon-range branch (line 100): Added `from e` to preserve the original `dateutil` parse error when colon-separated date parsing fails 
  - Single-date fallback path (lines 108-109): Changed `except Exception:` to `except Exception as e:` and added `from e` to preserve the original parse error when single-date parsing fails 
- **Tests**: Added `test_parse_date_range_helper_chains_underlying_error` in `tests/test_date_utils.py` to verify that the `ValueError` raised by `parse_date_range_helper` correctly chains the underlying `dateutil` parse error via `__cause__` 

## Fixes
- Fixes #197 — Improves exception handling in date parsing to preserve original error context

## Breaking Changes
None

## Testing
Run the date utils tests to verify the changes:
```bash
pytest tests/test_date_utils.py -v
```
The existing `test_parse_date_range_flexible` test covers the `parse_date_range_helper` function with various date formats, and the new `test_parse_date_range_helper_chains_underlying_error` test specifically verifies the exception chaining behavior. 

## Notes
- This PR standardizes exception handling across both parsing branches in `parse_date_range_helper`, ensuring that the original `dateutil` parsing errors are always preserved in the traceback for easier debugging.
- The review thread initially identified an inconsistency where the colon-range branch lacked `from e` chaining; this PR resolves that by adding exception chaining to both branches.