### PR TITLE
[AI] Share LLM error state across threads

### DIFF
--- a/termstory/ai.py
+++ b/termstory/ai.py
@@ -9,7 +9,10 @@ from typing import List, Optional, Dict
 from termstory.sanitizer import sanitize_session_commands, redact_command
 
 logger = logging.getLogger(__name__)
+# Per-thread error state — each caller (archive, dashboard, etc.)
+# keeps its own last error so switching screens doesn't lose context.
 _last_ai_error_lock = threading.Lock()
+_local_ai_state = threading.local()
 _last_ai_error: Optional[str] = None
 
 # Circuit Breaker Configuration

--- a/termstory/ai.py
+++ b/termstory/ai.py
@@ -9,7 +9,8 @@ from typing import List, Optional, Dict
 from termstory.sanitizer import sanitize_session_commands, redact_command
 
 logger = logging.getLogger(__name__)
-_local_ai_state = threading.local()
+_last_ai_error_lock = threading.Lock()
+_last_ai_error: Optional[str] = None
 
 # Circuit Breaker Configuration
 _circuit_breaker_lock = threading.Lock()
@@ -92,14 +93,19 @@ def reload_circuit_breaker_config(
         _cb_max_failures = max(1, max_failures) if max_failures is not None else None
         _cb_cooldown_seconds = max(1.0, cooldown_seconds) if cooldown_seconds is not None else None
 
+def _set_last_ai_error(error: Optional[str]) -> None:
+    global _last_ai_error
+    with _last_ai_error_lock:
+        _last_ai_error = error
+
 def get_last_ai_error() -> Optional[str]:
-    """Retrieve the last AI call error message, if any, for the current thread."""
-    return getattr(_local_ai_state, "last_error", None)
+    """Retrieve the most recent AI call error message, if any."""
+    with _last_ai_error_lock:
+        return _last_ai_error
 
 def clear_last_ai_error() -> None:
-    """Clear the last AI call error message for the current thread."""
-    if hasattr(_local_ai_state, "last_error"):
-        delattr(_local_ai_state, "last_error")
+    """Clear the most recent AI call error message."""
+    _set_last_ai_error(None)
 
 def _get_project_context_from_db(project_name: str) -> Optional[str]:
     conn = None
@@ -170,7 +176,7 @@ def _send_llm_request(
     timeout: float = 30.0
 ) -> Optional[str]:
     """Shared helper to construct and send the OpenAI-compatible chat completion request."""
-    _local_ai_state.last_error = None
+    clear_last_ai_error()
 
     if _is_current_worker_cancelled():
         return None
@@ -181,7 +187,7 @@ def _send_llm_request(
     global _circuit_breaker_failures, _circuit_breaker_open_until
     with _circuit_breaker_lock:
         if time.time() < _circuit_breaker_open_until:
-            _local_ai_state.last_error = "Circuit breaker open: Too many LLM timeouts. Requests temporarily disabled."
+            _set_last_ai_error("Circuit breaker open: Too many LLM timeouts. Requests temporarily disabled.")
             return None
 
     headers = {
@@ -193,7 +199,7 @@ def _send_llm_request(
         
     # OpenAI compatibility endpoint (normalize trailing slash)
     if not api_base_url or not isinstance(api_base_url, str):
-        _local_ai_state.last_error = "API Base URL is not configured or invalid."
+        _set_last_ai_error("API Base URL is not configured or invalid.")
         return None
     endpoint = api_base_url.strip().rstrip('/')
     if not endpoint.endswith('/chat/completions'):
@@ -271,7 +277,7 @@ def _send_llm_request(
                 _circuit_breaker_failures += 1
                 if _circuit_breaker_failures >= max_failures:
                     _circuit_breaker_open_until = time.time() + cooldown_seconds
-            _local_ai_state.last_error = f"Strict timeout exceeded ({timeout}s). LLM process hung."
+            _set_last_ai_error(f"Strict timeout exceeded ({timeout}s). LLM process hung.")
             continue
             
         if error_box:
@@ -303,7 +309,7 @@ def _send_llm_request(
                         reason_str = " ".join(str(e.reason).split())
                         if len(reason_str) > 200:
                             reason_str = reason_str[:200] + "..."
-                        _local_ai_state.last_error = f"HTTP Error {e.code}: {reason_str}"
+                        _set_last_ai_error(f"HTTP Error {e.code}: {reason_str}")
                     else:
                         try:
                             err_json = json.loads(raw_body)
@@ -312,28 +318,28 @@ def _send_llm_request(
                                 msg_str = " ".join(str(msg).split())
                                 if len(msg_str) > 200:
                                     msg_str = msg_str[:200] + "..."
-                                _local_ai_state.last_error = f"HTTP Error {e.code}: {msg_str}"
+                                _set_last_ai_error(f"HTTP Error {e.code}: {msg_str}")
                             else:
                                 body_str = " ".join(raw_body.split())
                                 if len(body_str) > 200:
                                     body_str = body_str[:200] + "..."
-                                _local_ai_state.last_error = f"HTTP Error {e.code}: {body_str}"
+                                _set_last_ai_error(f"HTTP Error {e.code}: {body_str}")
                         except Exception:
                             body_str = " ".join(raw_body.split())
                             if len(body_str) > 200:
                                 body_str = body_str[:200] + "..."
-                            _local_ai_state.last_error = f"HTTP Error {e.code}: {body_str}"
+                            _set_last_ai_error(f"HTTP Error {e.code}: {body_str}")
                 except Exception:
                     reason_str = " ".join(str(e.reason).split())
                     if len(reason_str) > 200:
                         reason_str = reason_str[:200] + "..."
-                    _local_ai_state.last_error = f"HTTP Error {e.code}: {reason_str}"
+                    _set_last_ai_error(f"HTTP Error {e.code}: {reason_str}")
             else:
                 # Gracefully fail and capture normalized exception
                 msg = " ".join(str(e).split())
                 if len(msg) > 200:
                     msg = msg[:200] + "..."
-                _local_ai_state.last_error = msg
+                _set_last_ai_error(msg)
             continue
 
         # Success

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,9 +1,11 @@
 import json
 import socket
+import threading
 import time as _time_module
 import urllib.error
 import urllib.request
 
+from termstory import ai
 from termstory.ai import generate_ai_summary, generate_timeframe_summary
 
 class MockResponse:
@@ -111,6 +113,43 @@ def test_ai_failure_exception(monkeypatch):
         "groq"
     )
     assert res is None
+
+
+def test_last_ai_error_is_shared_across_request_threads(monkeypatch):
+    """A worker failure from a background request thread is visible to callers."""
+    fake_now = [1000.0]
+
+    def mock_urlopen(req, timeout=None):
+        raise urllib.error.URLError("Connection refused")
+
+    def fake_sleep(seconds):
+        fake_now[0] += seconds
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+    monkeypatch.setattr(ai.time, "time", lambda: fake_now[0])
+    monkeypatch.setattr(ai.time, "sleep", fake_sleep)
+
+    ai.clear_last_ai_error()
+    result_box = []
+
+    def run_request():
+        result_box.append(
+            ai._send_llm_request(
+                "prompt",
+                "test-key",
+                "https://api.openai.com/v1",
+                "gpt-4o",
+                "openai",
+            )
+        )
+
+    request_thread = threading.Thread(target=run_request)
+    request_thread.start()
+    request_thread.join()
+
+    assert result_box == [None]
+    assert ai.get_last_ai_error() == "<urlopen error Connection refused>"
+    ai.clear_last_ai_error()
 
 
 def test_ai_url_normalization(monkeypatch):

--- a/tests/test_ai_error_surfacing.py
+++ b/tests/test_ai_error_surfacing.py
@@ -108,33 +108,39 @@ def test_http_error_non_json_body_parsing(monkeypatch):
     assert get_last_ai_error() == "HTTP Error 503: Service Unavailable"
 
 
-def test_concurrent_threads_error_isolation(monkeypatch):
+def test_concurrent_threads_share_latest_error(monkeypatch):
     import threading
-    import time
-    from termstory.ai import _send_llm_request
+    from termstory import ai
+
+    fake_now = [1000.0]
+
+    def fake_sleep(seconds):
+        fake_now[0] += seconds
+
+    monkeypatch.setattr(ai.time, "time", lambda: fake_now[0])
+    monkeypatch.setattr(ai.time, "sleep", fake_sleep)
     
-    barrier = threading.Barrier(2)
+    first_error_recorded = threading.Event()
+    second_error_recorded = threading.Event()
     thread_errors = {}
     
     def run_thread_a():
         clear_last_ai_error()
-        barrier.wait()
-        _send_llm_request("prompt", "key", "", "model", "groq")
-        time.sleep(0.1)
+        ai._send_llm_request("prompt", "key", "", "model", "groq")
+        first_error_recorded.set()
+        second_error_recorded.wait()
         thread_errors["A"] = get_last_ai_error()
         
     def run_thread_b():
-        clear_last_ai_error()
-        
         def mock_urlopen(req, timeout=None):
             raise urllib.error.URLError("Connection refused")
             
         monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
         
-        barrier.wait()
-        _send_llm_request("prompt", "key", "https://api.groq.com/openai/v1", "model", "groq")
-        time.sleep(0.1)
+        first_error_recorded.wait()
+        ai._send_llm_request("prompt", "key", "https://api.groq.com/openai/v1", "model", "groq")
         thread_errors["B"] = get_last_ai_error()
+        second_error_recorded.set()
         
     ta = threading.Thread(target=run_thread_a)
     tb = threading.Thread(target=run_thread_b)
@@ -143,7 +149,7 @@ def test_concurrent_threads_error_isolation(monkeypatch):
     ta.join()
     tb.join()
     
-    assert thread_errors["A"] == "API Base URL is not configured or invalid."
+    assert "Connection refused" in thread_errors["A"]
     assert "Connection refused" in thread_errors["B"]
 
 


### PR DESCRIPTION
## Summary
- Replace thread-local AI error storage with a lock-protected shared last-error value
- Ensure failures from LLM requests made on background request threads are visible to callers
- Update concurrent error-surfacing coverage for the shared latest-error behavior

## Tests
- .venv/bin/python -m pytest tests/test_ai.py -k last_ai_error_is_shared_across_request_threads -q
- XDG_CONFIG_HOME=/private/tmp/termstory-test-config XDG_DATA_HOME=/private/tmp/termstory-test-data .venv/bin/python -m pytest tests/test_ai.py tests/test_ai_error_surfacing.py -q
- XDG_CONFIG_HOME=/private/tmp/termstory-test-config XDG_DATA_HOME=/private/tmp/termstory-test-data .venv/bin/python -m pytest tests/ -q

Closes #122