### PR TITLE
[Web] Log daily activity heatmap query errors

### DIFF
--- a/termstory/web.py
+++ b/termstory/web.py
@@ -1,10 +1,14 @@
 import os
 import json
+import logging
+import sqlite3
 import webbrowser
 from typing import Optional
 from termstory.insights import analyze_all
 from termstory.formatter import _is_noise_command
 from termstory.database import Database
+
+logger = logging.getLogger(__name__)
 
 
 def get_web_data(db: Database, start_ts: Optional[int] = None, end_ts: Optional[int] = None) -> dict:
@@ -230,8 +234,11 @@ def get_web_data(db: Database, start_ts: Optional[int] = None, end_ts: Optional[
         for day, count in cursor.fetchall():
             if day in daily_activity:
                 daily_activity[day]["sessions"] = count
-    except Exception:
-        pass
+    except sqlite3.Error:
+        logger.warning(
+            "Failed to calculate daily activity heatmap; returning zeroed heatmap.",
+            exc_info=True,
+        )
     finally:
         conn.close()
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -67,6 +67,9 @@ def test_get_web_data_logs_daily_activity_query_errors(monkeypatch, caplog):
 
         def get_connection(self):
             self.connection_count += 1
+            # Connection #1: sessions query (section 3)
+            # Connection #2: AI highlights query (section 4, len(ai_sessions) < 15)
+            # Connection #3: heatmap query (section 5) — the one we want to fail
             return FakeConnection(fail=self.connection_count == 3)
 
         def get_sessions_by_ids(self, session_ids):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,5 +1,6 @@
 import os
 import json
+import sqlite3
 import pytest
 from datetime import datetime
 from typer.testing import CliRunner
@@ -28,6 +29,65 @@ def test_get_web_data_empty_db(tmp_path):
     assert len(data["projects"]) == 0
     assert len(data["sessions"]) == 0
     assert len(data["highlights"]) == 0
+
+
+def test_get_web_data_logs_daily_activity_query_errors(monkeypatch, caplog):
+    from termstory import web
+
+    class FakeCursor:
+        def __init__(self, fail=False):
+            self.fail = fail
+
+        def execute(self, query, params=None):
+            if self.fail:
+                raise sqlite3.OperationalError("missing commands table")
+
+        def fetchall(self):
+            return []
+
+    class FakeConnection:
+        def __init__(self, fail=False):
+            self.fail = fail
+
+        def cursor(self):
+            return FakeCursor(fail=self.fail)
+
+        def close(self):
+            pass
+
+    class FakeDatabase:
+        def __init__(self):
+            self.connection_count = 0
+
+        def get_last_ingestion_time(self):
+            return None
+
+        def get_all_projects_with_stats(self):
+            return []
+
+        def get_connection(self):
+            self.connection_count += 1
+            return FakeConnection(fail=self.connection_count == 3)
+
+        def get_sessions_by_ids(self, session_ids):
+            return []
+
+    monkeypatch.setattr(
+        web,
+        "analyze_all",
+        lambda db: {
+            "total_sessions": 0,
+            "total_commands": 0,
+            "total_projects": 0,
+            "streak": 0,
+        },
+    )
+
+    with caplog.at_level("WARNING", logger="termstory.web"):
+        data = web.get_web_data(FakeDatabase())
+
+    assert len(data["daily_activity"]) == 90
+    assert any("daily activity heatmap" in record.message for record in caplog.records)
 
 def test_get_web_data_populated_db(tmp_path):
     db_file = tmp_path / "populated.db"
@@ -257,5 +317,4 @@ def test_swarm_audit_fixes(tmp_path, monkeypatch):
     assert "const reportData =" in html
     # Check if our backslash command exists intact in the JSON
     assert "backslash \\\\" in html
-
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -92,6 +92,7 @@ def test_get_web_data_logs_daily_activity_query_errors(monkeypatch, caplog):
     assert len(data["daily_activity"]) == 90
     assert any("daily activity heatmap" in record.message for record in caplog.records)
 
+
 def test_get_web_data_populated_db(tmp_path):
     db_file = tmp_path / "populated.db"
     db = Database(str(db_file))


### PR DESCRIPTION
## Summary
This PR replaces silent exception handling around the daily-activity heatmap SQLite queries in `get_web_data` with explicit logging. When SQLite query errors occur during heatmap calculation, a warning is now emitted with full traceback details while preserving the zeroed heatmap fallback behavior. This improves observability for database-related issues without changing the user-facing error handling strategy.

## Changes

### Core
- **`termstory/web.py`**: Added `import logging` and `import sqlite3` to support structured error handling and logging.
- **`termstory/web.py`**: Added module-level logger `logger = logging.getLogger(__name__)` for consistent logging within the module.
- **`termstory/web.py`**: In `get_web_data`, replaced the broad `except Exception: pass` with `except sqlite3.Error:` to specifically catch SQLite-related errors during daily activity heatmap calculation.
- **`termstory/web.py`**: Added `logger.warning()` call with `exc_info=True` to log the full traceback when heatmap queries fail, providing diagnostic information while maintaining the zeroed heatmap fallback.

### Tests
- **`tests/test_web.py`**: Added `import sqlite3` to support test error simulation.
- **`tests/test_web.py`**: Added new regression test `test_get_web_data_logs_daily_activity_query_errors` that uses hand-rolled fakes (FakeCursor, FakeConnection, FakeDatabase) to simulate a SQLite query failure on the third connection attempt.
- **`tests/test_web.py`**: The test uses `caplog.at_level("WARNING", logger="termstory.web")` to capture warning logs and asserts both that the zeroed heatmap (90 entries) is returned and that a warning containing "daily activity heatmap" is emitted.

## Fixes
- Fixes #196 — Replace silent daily-activity heatmap exception swallow with warning log for SQLite query errors

## Breaking Changes
None

## Testing
Run the following commands to verify the changes:
```bash
XDG_CONFIG_HOME=/private/tmp/termstory-test-config XDG_DATA_HOME=/private/tmp/termstory-test-data .venv/bin/python -m pytest tests/test_web.py -k logs_daily_activity_query_errors -q
XDG_CONFIG_HOME=/private/tmp/termstory-test-config XDG_DATA_HOME=/private/tmp/termstory-test-data .venv/bin/python -m pytest tests/test_web.py -q
XDG_CONFIG_HOME=/private/tmp/termstory-test-config XDG_DATA_HOME=/private/tmp/termstory-test-data .venv/bin/python -m pytest tests/ -q
```

## Notes
The review thread primarily concerned the bot's star requirement for the repository and did not contain substantive code review feedback or additional fixes. The implementation maintains backward compatibility by preserving the zeroed heatmap fallback behavior while adding visibility into query failures through structured logging.