### PR TITLE
refactor: hoist duplicated max_tokens default to _DEFAULT_MAX_TOKENS

### DIFF
--- a/termstory/ai.py
+++ b/termstory/ai.py
@@ -19,6 +19,7 @@ _circuit_breaker_open_until = 0.0
 # Module-level defaults — used when config is unavailable.
 _DEFAULT_MAX_FAILURES: int = 3
 _DEFAULT_COOLDOWN_SECONDS: float = 60.0
+_DEFAULT_MAX_TOKENS: int = 1500
 
 # In-process cache for the configurable limits.
 # None = re-read from config on the next LLM request.
@@ -166,7 +167,7 @@ def _send_llm_request(
     api_base_url: str,
     model_name: str,
     provider: str,
-    max_tokens: int = 1500,
+    max_tokens: int = _DEFAULT_MAX_TOKENS,
     timeout: float = 30.0
 ) -> Optional[str]:
     """Shared helper to construct and send the OpenAI-compatible chat completion request."""
@@ -526,7 +527,7 @@ def generate_timeframe_summary(
     effective_timeout = timeout if timeout is not None else config.get("request_timeout_seconds", 30.0)
     return _send_llm_request(
         prompt, api_key, api_base_url, model_name, provider,
-        max_tokens=1500, timeout=effective_timeout
+        max_tokens=_DEFAULT_MAX_TOKENS, timeout=effective_timeout
     )
 
 
@@ -854,7 +855,7 @@ def generate_wrapped_summary(
     effective_timeout = timeout if timeout is not None else config.get("request_timeout_seconds", 30.0)
     return _send_llm_request(
         prompt, api_key, api_base_url, model_name, provider,
-        max_tokens=1500, timeout=effective_timeout
+        max_tokens=_DEFAULT_MAX_TOKENS, timeout=effective_timeout
     )
 
 
@@ -901,7 +902,7 @@ def translate_git_anger(
     effective_timeout = timeout if timeout is not None else config.get("request_timeout_seconds", 30.0)
     return _send_llm_request(
         prompt, api_key, api_base_url, model_name, provider,
-        max_tokens=1500, timeout=effective_timeout
+        max_tokens=_DEFAULT_MAX_TOKENS, timeout=effective_timeout
     )
 
 
@@ -952,7 +953,7 @@ def predict_bugs_from_sessions(
     effective_timeout = timeout if timeout is not None else config.get("request_timeout_seconds", 30.0)
     return _send_llm_request(
         prompt, api_key, api_base_url, model_name, provider,
-        max_tokens=1500, timeout=effective_timeout
+        max_tokens=_DEFAULT_MAX_TOKENS, timeout=effective_timeout
     )
 
 
@@ -993,7 +994,7 @@ def generate_rpg_bio(
     effective_timeout = timeout if timeout is not None else config.get("request_timeout_seconds", 30.0)
     return _send_llm_request(
         prompt, api_key, api_base_url, model_name, provider,
-        max_tokens=1500, timeout=effective_timeout
+        max_tokens=_DEFAULT_MAX_TOKENS, timeout=effective_timeout
     )
 
 


### PR DESCRIPTION
## Summary
This PR centralizes the repeated `max_tokens=1500` literal across five call sites in `termstory/ai.py` into a single module-level constant `_DEFAULT_MAX_TOKENS`, following the existing pattern of `_DEFAULT_MAX_FAILURES` and `_DEFAULT_COOLDOWN_SECONDS`. This refactoring improves maintainability by providing a single source of truth for the default token limit, making future updates easier and reducing code duplication.

## Changes
### Core
- **termstory/ai.py**: Added module-level constant `_DEFAULT_MAX_TOKENS: int = 1500` at line 22, alongside existing circuit breaker defaults.
- **termstory/ai.py**: Updated `_send_llm_request()` function default parameter from `max_tokens: int = 1500` to `max_tokens: int = _DEFAULT_MAX_TOKENS` at line 169.
- **termstory/ai.py**: Updated `generate_timeframe_summary()` to use `_DEFAULT_MAX_TOKENS` instead of literal 1500 at line 529.
- **termstory/ai.py**: Updated `generate_wrapped_summary()` to use `_DEFAULT_MAX_TOKENS` instead of literal 1500 at line 857.
- **termstory/ai.py**: Updated `translate_git_anger()` to use `_DEFAULT_MAX_TOKENS` instead of literal 1500 at line 904.
- **termstory/ai.py**: Updated `predict_bugs_from_sessions()` to use `_DEFAULT_MAX_TOKENS` instead of literal 1500 at line 955.
- **termstory/ai.py**: Updated `generate_rpg_bio()` to use `_DEFAULT_MAX_TOKENS` instead of literal 1500 at line 996.

### Intentionally Unchanged
- **termstory/ai.py**: `generate_ai_summary()` retains its function-specific override of `max_tokens=500` at line 433.
- **termstory/ai.py**: `generate_daily_chronicle()` retains its function-specific override of `max_tokens=2000` at line 769.

## Fixes
- Fixes #192 — Centralizes repeated `max_tokens=1500` literal into a module-level constant

## Breaking Changes
None

## Testing
Run the AI test suite to verify no behavior changes:
```bash
pytest tests/test_ai.py tests/test_ai_error_surfacing.py
```
This command passes 44 tests, confirming that the refactoring maintains existing functionality.

## Notes
This change is a pure refactoring with no behavioral impact. The constant follows the established pattern for module-level defaults in `termstory/ai.py`, making the codebase more consistent and easier to maintain. Function-specific token limits (500 for `generate_ai_summary` and 2000 for `generate_daily_chronicle`) were intentionally preserved as they serve different use cases requiring shorter or longer outputs respectively.