### PR TITLE
docs: add test suite agent guide

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,65 @@
+# tests/ - Test Suite
+
+This directory contains the Termstory pytest suite. Follow these notes when
+adding or changing tests so new coverage matches the existing patterns.
+
+## Running tests
+
+- Full suite used in CI:
+  `pytest --timeout=60 tests/ --ignore=tests/stress`
+- Focused TUI example:
+  `pytest tests/test_tui.py -k "onboarding" --timeout=30 -v`
+- Stress tests live under `tests/stress/` and are excluded from the normal CI
+  command.
+
+## Async and Textual patterns
+
+- Use `@pytest.mark.asyncio` for async Textual tests.
+- Use `async with app.run_test() as pilot:` for Textual app tests.
+- Call `await pilot.pause()` after actions that need Textual's message loop to
+  process callbacks or screen updates.
+- For modal dismiss tests that would hang under Textual 8.x, install the
+  workaround before entering `run_test()`:
+
+  ```python
+  from termstory.testing import install_sync_dismiss_workaround
+
+  install_sync_dismiss_workaround(monkeypatch)
+  ```
+
+## Fixtures and isolation
+
+- Prefer `tempfile.TemporaryDirectory()` or `tmp_path` for filesystem isolation.
+- Use `Database(":memory:")` when a test only needs an in-memory SQLite database.
+- Use files under `tests/fixtures/` for reusable sample input data.
+- Keep `tests/stress/` for slow, adversarial, or timeout-oriented coverage.
+
+## Mocking external behavior
+
+- Mock AI providers rather than making network calls. Existing tests patch
+  request helpers or use patterns such as:
+
+  ```python
+  monkeypatch.setattr("termstory.tui.generate_ai_summary", mock_fn)
+  ```
+
+- Keep provider responses small and deterministic.
+- Do not require real API keys, shell history, external services, or a user's
+  local terminal state.
+
+## Database and CLI conventions
+
+- Create `Database` instances in temporary locations and call `init_db()` before
+  saving data.
+- Assert on persisted rows or returned models, not on private implementation
+  details unless the test is explicitly about a migration or cache behavior.
+- CLI tests should use pytest helpers such as `tmp_path`, `monkeypatch`, and
+  Typer test utilities already present in nearby tests.
+
+## Style
+
+- Keep tests direct and readable. The suite favors explicit setup over shared
+  fixtures when the setup is small.
+- Match existing import style in the neighboring test file.
+- Avoid adding sleeps unless the Textual pilot needs a message-loop tick; prefer
+  `await pilot.pause()` for UI synchronization.


### PR DESCRIPTION
## Summary
This PR adds `tests/AGENTS.md`, a comprehensive testing guide for agents and contributors working on the Termstory codebase. The documentation codifies existing test patterns including pytest commands, Textual async patterns, fixture isolation, AI mocking conventions, and database testing practices to ensure consistency across the test suite.

## Changes
### Documentation
- Added `tests/AGENTS.md` with testing guidance covering:
  - Running tests: documents the full CI suite command `pytest --timeout=60 tests/ --ignore=tests/stress` and focused TUI example `pytest tests/test_tui.py -k "onboarding" --timeout=30 -v`
  - Async and Textual patterns: documents `@pytest.mark.asyncio`, `async with app.run_test() as pilot:`, `await pilot.pause()`, and the modal dismiss workaround for Textual 8.x
  - Fixtures and isolation: recommends `tempfile.TemporaryDirectory()`, `tmp_path`, `Database(":memory:")`, and `tests/fixtures/` for reusable data
  - Mocking external behavior: documents patterns for mocking AI providers using `monkeypatch.setattr("termstory.tui.generate_ai_summary", mock_fn)` and avoiding real API keys or network calls
  - Database and CLI conventions: specifies creating `Database` instances in temporary locations, calling `init_db()` before saving data, and using pytest helpers like `tmp_path` and `monkeypatch`
  - Style guidelines: favors explicit setup over shared fixtures, matching existing import style, and preferring `await pilot.pause()` over sleeps for UI synchronization

## Fixes
- Fixes #171 — adds test-suite guidance documentation for agents and contributors

## Breaking Changes
None

## Testing
This is a docs-only change. To validate the documentation accuracy:
- Run the documented full suite command: `pytest --timeout=60 tests/ --ignore=tests/stress`
- Run the documented focused TUI example: `pytest tests/test_tui.py -k "onboarding" --timeout=30 -v`
- Verify that existing test patterns in `tests/test_tui.py` (e.g., `async with app.run_test() as pilot:` patterns at lines 105, 188, 215) match the documented conventions
- Verify that AI mocking patterns in `tests/test_ai.py` (e.g., `monkeypatch.setattr` at line 483) match the documented conventions

## Notes
- The PR is docs-only and does not modify any test code or implementation
- Validation attempts revealed existing test failures in `tests/test_bash_inspect.py` and `tests/test_null_bytes_zsh.py` (temp-file `PermissionError` on Windows) and `test_tui_landing_page_after_onboarding` (`cursor_node is None`), but these are pre-existing issues unrelated to this documentation change
- The modal dismiss workaround documented in `tests/AGENTS.md` addresses Textual 8.x compatibility issues that cause tests to hang when using `call_after_refresh(self.dismiss)` patterns, as seen in existing test workarounds in `tests/test_tui.py` (lines 318-324, 358-361)