### PR TITLE
Fix issue #222 bare exception blocks in reminder.py

### DIFF
--- a/termstory/reminder.py
+++ b/termstory/reminder.py
@@ -2,8 +2,9 @@ import json
 import logging
 import math
 import os
-import time
 import re
+import sqlite3
+import time
 from typing import List, Dict, Optional, Tuple
 from termstory.config import get_app_dir, load_config
 
@@ -21,7 +22,8 @@ def load_reminders() -> List[Dict]:
     try:
         with open(path, "r", encoding="utf-8") as f:
             return json.load(f)
-    except Exception:
+    except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        logger.exception("Failed to load reminders from %s", path)
         return []
 
 def save_reminders(reminders: List[Dict]) -> None:
@@ -162,7 +164,8 @@ def _resolve_clustering_threshold() -> float:
     try:
         cfg = load_config()
         return float(cfg.get("clustering_threshold", _DEFAULT_CLUSTERING_THRESHOLD))
-    except Exception:
+    except (OSError, TypeError, ValueError) as exc:
+        logger.exception("Failed to resolve clustering threshold; using default")
         return _DEFAULT_CLUSTERING_THRESHOLD
 
 
@@ -217,6 +220,7 @@ def cluster_commands(commands: List[str], threshold: Optional[float] = None) -> 
             emb_list = embeddings
     except Exception:
         # Fallback if encoding failed
+        logger.exception("Failed to generate embeddings for command clustering")
         verb_clusters = {}
         for cmd in unique_cmds:
             verb = cmd.split()[0] if cmd.split() else "other"
@@ -313,8 +317,8 @@ def consolidate_sleep_contexts(db, force: bool = False) -> int:
         row = cursor.fetchone()
         if row and row[0] is not None:
             last_end = row[0]
-    except Exception:
-        pass
+    except (sqlite3.DatabaseError, ValueError, TypeError, OSError) as exc:
+        logger.exception("Failed to read the last sleep consolidation marker")
     finally:
         conn.close()
 
@@ -332,8 +336,8 @@ def consolidate_sleep_contexts(db, force: bool = False) -> int:
         rows = cursor.fetchall()
         for r in rows:
             commands.append({"command": r[0], "timestamp": r[1]})
-    except Exception:
-        pass
+    except (sqlite3.DatabaseError, ValueError, TypeError, OSError) as exc:
+        logger.exception("Failed to fetch commands for sleep consolidation")
     finally:
         conn.close()
 
@@ -428,8 +432,8 @@ def start_sleep_daemon(db_path: str):
             start_new_session=True,
             env=env
         )
-    except Exception:
-        pass
+    except OSError as exc:
+        logger.exception("Failed to start sleep daemon")
 
 
 def run_sleep_daemon(db_path: str):
@@ -454,8 +458,8 @@ def run_sleep_daemon(db_path: str):
         try:
             if os.path.exists(pid_file):
                 os.remove(pid_file)
-        except Exception:
-            pass
+        except OSError as exc:
+            logger.exception("Failed to remove sleep daemon PID file %s", pid_file)
         sys.exit(0)
         
     signal.signal(signal.SIGTERM, cleanup_pid)
@@ -465,19 +469,19 @@ def run_sleep_daemon(db_path: str):
         try:
             with open(pid_file, "w") as f:
                 f.write(str(os.getpid()))
-        except Exception:
-            pass
+        except OSError as exc:
+            logger.exception("Failed to write sleep daemon PID file %s", pid_file)
             
         db = Database(db_path)
         while True:
             try:
                 consolidate_sleep_contexts(db, force=False)
             except Exception:
-                pass
+                logger.exception("Failed to run consolidate_sleep_contexts in sleep daemon")
             time.sleep(poll_interval)
     finally:
         try:
             if os.path.exists(pid_file):
                 os.remove(pid_file)
-        except Exception:
-            pass
+        except OSError as exc:
+            logger.exception("Failed to remove sleep daemon PID file %s", pid_file)

--- a/termstory/reminder.py
+++ b/termstory/reminder.py
@@ -22,7 +22,7 @@ def load_reminders() -> List[Dict]:
     try:
         with open(path, "r", encoding="utf-8") as f:
             return json.load(f)
-    except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
         logger.exception("Failed to load reminders from %s", path)
         return []
 


### PR DESCRIPTION
## Summary
This PR replaces silent bare `except Exception: pass` blocks in `termstory/reminder.py` with structured logging and narrowed exception types, making failures visible in production logs while preserving the existing fallback behavior and application resilience.

## Changes

### Core - termstory/reminder.py
- Added `import sqlite3` to support specific database exception types
- **`load_reminders()`**: Changed from broad `except Exception:` to specific `(OSError, TypeError, ValueError, json.JSONDecodeError)` and added `logger.exception()` call with file path context
- **`_resolve_clustering_threshold()`**: Changed from broad `except Exception:` to specific `(OSError, TypeError, ValueError)` and added `logger.exception()` call
- **`cluster_commands()`**: Added `logger.exception()` call in the embeddings fallback path to log encoding failures
- **`consolidate_sleep_contexts()`**: 
  - First database query: Changed from `except Exception: pass` to specific `(sqlite3.DatabaseError, ValueError, TypeError, OSError)` with `logger.exception()` for reading consolidation marker
  - Second database query: Changed from `except Exception: pass` to specific `(sqlite3.DatabaseError, ValueError, TypeError, OSError)` with `logger.exception()` for fetching commands
- **`start_sleep_daemon()`**: Changed from broad `except Exception: pass` to specific `OSError` with `logger.exception()` for subprocess spawning failures
- **`run_sleep_daemon()`**:
  - `cleanup_pid` signal handler: Changed from `except Exception: pass` to specific `OSError` with `logger.exception()` for PID file removal
  - PID file writing: Changed from `except Exception: pass` to specific `OSError` with `logger.exception()` for PID file creation
  - Main daemon loop: Added `logger.exception()` call for `consolidate_sleep_contexts()` failures while keeping broad Exception catch to ensure daemon continues running
  - Finally block cleanup: Changed from `except Exception: pass` to specific `OSError` with `logger.exception()` for final PID file removal

## Fixes
- Fixes #222 — Replaces silent exception handling with structured logging to make failures visible in production

## Breaking Changes
None

## Testing
Run the existing reminder test suite to verify that error handling still works correctly:
```bash
pytest tests/test_reminder.py -v
```

Test the sleep daemon functionality manually:
```bash
termstory sleep --consolidate
termstory sleep --show
```

Verify that logs now contain exception details when errors occur by checking the application logs during reminder operations and sleep daemon execution.

## Notes
The PR maintains all existing fallback behavior—functions still return default values or continue execution on errors—but now logs the full exception traceback for debugging. The exception types were narrowed to only those realistically expected at each call site (e.g., `OSError` for file operations, `sqlite3.DatabaseError` for database queries). The sleep daemon's main loop intentionally keeps a broad `except Exception` to ensure the daemon remains resilient and continues running even if consolidation fails.