### PR TITLE
fix: log errors in stats.py bare except blocks

### DIFF
--- a/termstory/stats.py
+++ b/termstory/stats.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from collections import defaultdict
 from datetime import datetime, timedelta
@@ -5,6 +6,8 @@ from typing import Dict, Any, Optional
 
 from termstory.database import Database
 from termstory.date_utils import get_current_time
+
+logger = logging.getLogger(__name__)
 
 def daily_activity_heatmap(db: Database, days_limit: int = 30, colored: bool = True) -> str:
     """Generate a GitHub-like activity heatmap from the database for the last N days."""
@@ -193,7 +196,7 @@ def detect_project_language_from_files(path: str) -> Optional[str]:
                 _LANG_CACHE[path] = lang
                 return lang
         except Exception:
-            pass
+            logger.debug("Failed to check for config file %s in %s", filename, path, exc_info=True)
             
     try:
         for f in os.listdir(path):
@@ -204,7 +207,7 @@ def detect_project_language_from_files(path: str) -> Optional[str]:
                 _LANG_CACHE[path] = "C/C++"
                 return "C/C++"
     except Exception:
-        pass
+        logger.debug("Failed to list directory contents for language detection: %s", path, exc_info=True)
         
     _LANG_CACHE[path] = None
     return None


### PR DESCRIPTION
## Summary

This PR adds debug-level logging to `detect_project_language_from_files()` in `termstory/stats.py` so filesystem errors that were previously silently swallowed by bare `except Exception: pass` blocks are now surfaced via `logger.debug(...)` with full tracebacks (`exc_info=True`) . A module-level `logger` was added, following the same pattern already used in `formatter.py` .

---

## PR Body (rewritten)

```markdown
## Summary

Replaces two silent `except Exception: pass` blocks in `detect_project_language_from_files()` (`termstory/stats.py`) with `logger.debug(...)` calls that include full traceback info via `exc_info=True`. This surfaces filesystem errors (permissions issues, broken symlinks, restricted environments) that were previously invisible, matching the debug-logging pattern already used elsewhere in the codebase (e.g. `formatter.py`).

## Changes

### Core (`termstory/stats.py`)
- Added `import logging` and a module-level `logger = logging.getLogger(__name__)`.
- In the config-file check loop, replaced the bare `except Exception: pass` with `logger.debug("Failed to check for config file %s in %s", filename, path, exc_info=True)`.
- In the directory-listing fallback (`os.listdir`), replaced the bare `except Exception: pass` with `logger.debug("Failed to list directory contents for language detection: %s", path, exc_info=True)`.

## Fixes

- Fixes #218 — language detection errors were silently swallowed, making debugging difficult when filesystem operations failed.

## Testing

```bash
python -m pytest tests/test_stats.py -v
```
All existing tests pass; only the error path is touched, normal detection behavior is unchanged.

## Notes

Logging is kept at debug level since language detection is best-effort and these failures (e.g. network mounts, restricted directories) are expected in some environments, not exceptional. Approved and merged by @bitflicker64.
```