### PR TITLE
[MCP Snapshot] Narrow bare except blocks silently swallowing errors

### DIFF
--- a/termstory/mcp_snapshot.py
+++ b/termstory/mcp_snapshot.py
@@ -1,7 +1,11 @@
+import logging
 import os
+import sqlite3
 import subprocess
 import time
 from typing import Dict, Any, List
+
+logger = logging.getLogger(__name__)
 
 def capture_ide_state() -> Dict[str, Any]:
     """Capture active IDE state from environment variables"""
@@ -108,8 +112,11 @@ def capture_git_status(cwd: str) -> Dict[str, Any]:
                     uncommitted.append(line.strip())
             result["uncommitted_files"] = uncommitted
             
-    except Exception:
-        pass
+    except (subprocess.TimeoutExpired, OSError):
+        logger.exception(
+            "capture_git_status: git command failed or timed out for %r; returning partial result.",
+            cwd,
+        )
         
     return result
 
@@ -117,7 +124,10 @@ def capture_mcp_snapshot() -> Dict[str, Any]:
     """Capture a snapshot of the IDE state, git status, and active terminal directories"""
     try:
         cwd = os.getcwd()
-    except Exception:
+    except OSError:
+        logger.exception(
+            "capture_mcp_snapshot: failed to resolve current working directory; cwd will be None."
+        )
         cwd = None
     ide_info = capture_ide_state()
     git_info = capture_git_status(cwd)
@@ -149,6 +159,9 @@ def capture_and_store_mcp_snapshot(db: Any) -> None:
             payload=snapshot,
             captured_at=int(time.time())
         )
-    except Exception:
-        # Fail silently to not disrupt the core ingestion process
-        pass
+    except (sqlite3.DatabaseError, OSError, RuntimeError):
+        # Log but do not re-raise: an MCP snapshot failure must not
+        # disrupt the core ingestion process.
+        logger.exception(
+            "capture_and_store_mcp_snapshot: failed to capture or store MCP snapshot; continuing without it."
+        )

--- a/termstory/mcp_snapshot.py
+++ b/termstory/mcp_snapshot.py
@@ -159,9 +159,13 @@ def capture_and_store_mcp_snapshot(db: Any) -> None:
             payload=snapshot,
             captured_at=int(time.time())
         )
-    except (sqlite3.DatabaseError, OSError, RuntimeError):
+    except (sqlite3.DatabaseError, OSError, RuntimeError, TypeError, ValueError):
         # Log but do not re-raise: an MCP snapshot failure must not
-        # disrupt the core ingestion process.
+        # disrupt the core ingestion process. TypeError/ValueError are
+        # included because Database.save_mcp_snapshot's json.dumps(payload)
+        # call re-raises those unchanged on a non-serializable or circular
+        # payload (via _safe_rollback_and_reraise), on top of the sqlite3/
+        # OSError/RuntimeError failure modes from the db layer itself.
         logger.exception(
             "capture_and_store_mcp_snapshot: failed to capture or store MCP snapshot; continuing without it."
         )

--- a/tests/test_mcp_snapshot.py
+++ b/tests/test_mcp_snapshot.py
@@ -160,11 +160,15 @@ def test_capture_mcp_snapshot_deleted_cwd():
 
 
 def test_capture_git_status_subprocess_timeout():
-    with patch(
-        "termstory.mcp_snapshot.subprocess.run",
-        side_effect=subprocess.TimeoutExpired(cmd="git", timeout=5),
-    ):
+    mock_run = MagicMock(side_effect=subprocess.TimeoutExpired(cmd="git", timeout=5))
+    with patch("termstory.mcp_snapshot.os.path.exists", return_value=True), \
+         patch("termstory.mcp_snapshot.os.path.isdir", return_value=True), \
+         patch("termstory.mcp_snapshot.subprocess.run", mock_run):
         status = capture_git_status("/some/path")
+        # Guard against the fix regressing back to a vacuous test: the
+        # exception handler is only meaningfully exercised if subprocess.run
+        # was actually invoked.
+        assert mock_run.called
         assert not status["is_repo"]
         assert status["branch"] is None
         assert len(status["uncommitted_files"]) == 0
@@ -181,4 +185,20 @@ def test_capture_and_store_mcp_snapshot_db_error_does_not_raise(mock_git, mock_i
 
     # Must swallow the db failure and return normally. A snapshot
     # failure must never disrupt the core ingestion process.
+    capture_and_store_mcp_snapshot(db)
+
+
+@patch("termstory.mcp_snapshot.os.getcwd", return_value="/Users/developer/termstory")
+@patch("termstory.mcp_snapshot.capture_ide_state", return_value={"ide_name": "VS Code", "env_vars": {}})
+@patch("termstory.mcp_snapshot.capture_git_status", return_value={"is_repo": True, "branch": "main", "uncommitted_files": []})
+def test_capture_and_store_mcp_snapshot_non_serializable_payload_does_not_raise(mock_git, mock_ide, mock_cwd):
+    # Regression for a non-serializable payload: Database.save_mcp_snapshot's
+    # internal json.dumps(payload) raises TypeError for objects it can't
+    # encode, and _safe_rollback_and_reraise re-raises it unchanged,
+    # capture_and_store_mcp_snapshot must still swallow it.
+    db = MagicMock()
+    db.get_latest_session_id.return_value = 1
+    db.get_mcp_snapshots.return_value = []
+    db.save_mcp_snapshot.side_effect = TypeError("Object of type set is not JSON serializable")
+
     capture_and_store_mcp_snapshot(db)

--- a/tests/test_mcp_snapshot.py
+++ b/tests/test_mcp_snapshot.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import json
 import sqlite3
+import subprocess
 from unittest.mock import patch, MagicMock
 import pytest
 
@@ -156,3 +157,28 @@ def test_capture_mcp_snapshot_deleted_cwd():
         snapshot = capture_mcp_snapshot()
         assert snapshot["cwd"] is None
         assert not snapshot["git"]["is_repo"]
+
+
+def test_capture_git_status_subprocess_timeout():
+    with patch(
+        "termstory.mcp_snapshot.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="git", timeout=5),
+    ):
+        status = capture_git_status("/some/path")
+        assert not status["is_repo"]
+        assert status["branch"] is None
+        assert len(status["uncommitted_files"]) == 0
+
+
+@patch("termstory.mcp_snapshot.os.getcwd", return_value="/Users/developer/termstory")
+@patch("termstory.mcp_snapshot.capture_ide_state", return_value={"ide_name": "VS Code", "env_vars": {}})
+@patch("termstory.mcp_snapshot.capture_git_status", return_value={"is_repo": True, "branch": "main", "uncommitted_files": []})
+def test_capture_and_store_mcp_snapshot_db_error_does_not_raise(mock_git, mock_ide, mock_cwd):
+    db = MagicMock()
+    db.get_latest_session_id.return_value = 1
+    db.get_mcp_snapshots.return_value = []
+    db.save_mcp_snapshot.side_effect = sqlite3.OperationalError("database is locked")
+
+    # Must swallow the db failure and return normally. A snapshot
+    # failure must never disrupt the core ingestion process.
+    capture_and_store_mcp_snapshot(db)


### PR DESCRIPTION
## Summary
This PR narrows three bare `except Exception` blocks in `termstory/mcp_snapshot.py` to specific exception types and adds `logger.exception(...)` calls so previously silent failures become visible in logs. The changes align with the exception handling convention used elsewhere in the codebase (e.g., `ai.py`) while maintaining the original design intent that MCP snapshot failures must not disrupt the core ingestion pipeline. Two new regression tests are added to cover the subprocess timeout and database error paths.

## Changes

### Core
- **termstory/mcp_snapshot.py**: Added `import logging` and `import sqlite3` at module level, and initialized `logger = logging.getLogger(__name__)` 
- **termstory/mcp_snapshot.py**: In `capture_git_status()`, narrowed `except Exception` to `except (subprocess.TimeoutExpired, OSError)` and added logging for git command failures or timeouts 
- **termstory/mcp_snapshot.py**: In `capture_mcp_snapshot()`, narrowed `except Exception` to `except OSError` and added logging for current working directory resolution failures 
- **termstory/mcp_snapshot.py**: In `capture_and_store_mcp_snapshot()`, narrowed `except Exception` to `except (sqlite3.DatabaseError, OSError, RuntimeError)` and added logging for database/storage failures while maintaining silent failure behavior 

### Tests
- **tests/test_mcp_snapshot.py**: Added `import subprocess` to support timeout testing 
- **tests/test_mcp_snapshot.py**: Added `test_capture_git_status_subprocess_timeout()` to verify that git subprocess timeouts are handled gracefully and return partial results 
- **tests/test_mcp_snapshot.py**: Added `test_capture_and_store_mcp_snapshot_db_error_does_not_raise()` to verify that database errors (e.g., `sqlite3.OperationalError`) are swallowed without disrupting the ingestion process 

## Fixes
- Fixes #215 — Narrows overly broad exception handling in MCP snapshot capture functions and adds logging for better observability

## Breaking Changes
None

## Testing
Run the MCP snapshot test suite to verify the new exception handling behavior:
```bash
pytest tests/test_mcp_snapshot.py -v
```

Specifically, the new tests verify:
- `test_capture_git_status_subprocess_timeout`: Ensures git command timeouts return partial results without raising
- `test_capture_and_store_mcp_snapshot_db_error_does_not_raise`: Ensures database errors are logged but swallowed to prevent ingestion disruption

## Notes
The exception narrowing follows the same pattern used in `termstory/ai.py` for database helper and template loading fallbacks. The functions `capture_git_status`, `capture_mcp_snapshot`, and `capture_and_store_mcp_snapshot` are called from the ingestion pipeline in `termstory/cli.py:170` as part of `run_ingestion()`. The design intent that snapshot failures must not disrupt core ingestion is preserved—exceptions are still swallowed, but now logged for observability.