### PR TITLE
test pr

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,1 +1,2 @@
+# Entry-point shim — real CLI lives in `termstory/cli.py` (see pyproject.toml [project.scripts]).
 print(1)


### PR DESCRIPTION
Real CLI entry point lives in `termstory/cli.py` (see pyproject.toml `[project.scripts]`). This file just exists so `python main.py` doesn't error in scratch/test contexts.

No behavior change — comment-only edit.