### PR TITLE
[Parser] Narrow bare except blocks silently swallowing errors

### DIFF
--- a/termstory/parser.py
+++ b/termstory/parser.py
@@ -1,6 +1,7 @@
 import os
 import re
 import logging
+import sqlite3
 from datetime import datetime, timedelta
 from typing import List, Optional, Dict, Any, Union, Callable
 from termstory.models import Command
@@ -186,7 +187,11 @@ def parse_zsh_history(
     # Get file mtime as a common reference point — used in both branches below.
     try:
         file_mtime = int(os.path.getmtime(filepath))
-    except Exception:
+    except OSError:
+        logger.exception(
+            "parse_zsh_history: failed to stat %r for mtime; using current time as anchor.",
+            filepath,
+        )
         file_mtime = int(datetime.now().timestamp())
 
     n_legacy = len(legacy_items)
@@ -249,7 +254,17 @@ def parse_zsh_history(
             try:
                 resolved_paths = project_paths() if callable(project_paths) else project_paths
             except Exception:
-                pass
+                # project_paths is an arbitrary caller-supplied callback (see the
+                # Callable[[], List[str]] type hint), its failure modes aren't
+                # knowable from this file, so this one is intentionally kept
+                # broad rather than narrowed to a specific tuple. It's a nice-to-
+                # have enrichment for the Timestamp Detective, not core parsing,
+                # so we degrade to an empty project list instead of failing the
+                # whole history parse.
+                logger.exception(
+                    "parse_zsh_history: project_paths callback raised; "
+                    "continuing without project-path enrichment."
+                )
         detective = TimestampDetective(
             search_root=os.path.expanduser("~"),
             project_paths=resolved_paths or []
@@ -401,9 +416,13 @@ def parse_bash_history(
         
     try:
         mtime = int(os.path.getmtime(filepath))
-    except Exception:
+    except OSError:
+        logger.exception(
+            "parse_bash_history: failed to stat %r for mtime; using current time as anchor.",
+            filepath,
+        )
         mtime = int(datetime.now().timestamp())
-        
+
     raw_lines = []
     with open(filepath, 'r', encoding='utf-8', errors='replace') as f:
         for line in f:
@@ -691,7 +710,11 @@ def parse_fish_history(
         
     try:
         mtime = int(os.path.getmtime(filepath))
-    except Exception:
+    except OSError:
+        logger.exception(
+            "parse_fish_history: failed to stat %r for mtime; using current time as anchor.",
+            filepath,
+        )
         mtime = int(datetime.now().timestamp())
         
     temp_commands = []
@@ -737,7 +760,11 @@ def parse_powershell_history(
         
     try:
         mtime = int(os.path.getmtime(filepath))
-    except Exception:
+    except OSError:
+        logger.exception(
+            "parse_powershell_history: failed to stat %r for mtime; using current time as anchor.",
+            filepath,
+        )
         mtime = int(datetime.now().timestamp())
         
     raw_lines = []
@@ -780,8 +807,11 @@ def parse_all_histories(
     if db is not None:
         try:
             existing_lookup = db.get_all_commands_lookup()
-        except Exception:
-            pass
+        except (sqlite3.DatabaseError, OSError, RuntimeError):
+            logger.exception(
+                "parse_all_histories: failed to load existing command timestamp lookup; "
+                "continuing without timestamp locking."
+            )
 
     all_commands = []
     for path in filepaths:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -357,3 +357,49 @@ def test_assign_missing_timestamps_fallback_clamping():
     assert commands[0].timestamp == 1748851190
 
 
+def test_parse_zsh_history_getmtime_oserror_falls_back(tmp_path):
+    from unittest.mock import patch
+
+    temp_file = tmp_path / "zsh_getmtime_fail_test"
+    temp_file.write_text(": 1748851200:0;git status\n")
+
+    # os.path.getmtime raising must not abort the parse, it should fall
+    # back to the current time as the anchor instead of propagating.
+    with patch("termstory.parser.os.path.getmtime", side_effect=OSError("stat failed")):
+        commands = parse_zsh_history(str(temp_file))
+        assert len(commands) == 1
+        assert commands[0].command == "git status"
+
+
+def test_parse_zsh_history_project_paths_callback_raises(tmp_path):
+    from unittest.mock import patch
+
+    temp_file = tmp_path / "zsh_project_paths_raise_test"
+    temp_file.write_text("legacy cmd\n")
+
+    def bad_callback():
+        raise RuntimeError("resolver blew up")
+
+    # A raising project_paths callback must not abort the parse, legacy
+    # commands should still come through with project-path enrichment
+    # simply skipped for this run.
+    commands = parse_zsh_history(str(temp_file), project_paths=bad_callback)
+    assert len(commands) == 1
+    assert commands[0].command == "legacy cmd"
+
+
+def test_parse_all_histories_db_lookup_error_does_not_raise(tmp_path):
+    from unittest.mock import MagicMock
+    import sqlite3
+
+    temp_file = tmp_path / "zsh_history_db_error_test"
+    temp_file.write_text(": 1748851200:0;git status\n")
+
+    db = MagicMock()
+    db.get_all_commands_lookup.side_effect = sqlite3.OperationalError("database is locked")
+
+    # A failing lookup must not abort ingestion, it should just proceed
+    # without timestamp-locking against prior runs.
+    commands = parse_all_histories([str(temp_file)], db=db)
+    assert len(commands) == 1
+    assert commands[0].command == "git status"


### PR DESCRIPTION
## Description
Narrows all 6 bare `except Exception` blocks in `termstory/parser.py` (across `parse_zsh_history`, `parse_bash_history`, `parse_fish_history`, `parse_powershell_history`, and `parse_all_histories`) to specific exception types where the failure mode is predictable, and logs each via `logger.exception(...)` so previously silent parser failures are now visible. Follows the same convention already established in `ai.py`/#190 and `mcp_snapshot.py`/#215.

Added 3 regression tests that were previously missing coverage: `getmtime` raising `OSError`, the `project_paths` callback raising, and a db lookup failure.

Fixes #213 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the "density over decoration" philosophy.
- [x] I have not used `rich.panel.Panel` in my code.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
