### PR TITLE
[Ask] Replace hardcoded max_tokens/timeout with shared constant and config

### DIFF
--- a/termstory/ask.py
+++ b/termstory/ask.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Dict, Tuple
 
 from termstory.models import Session
 from termstory.config import get_db_path
-from termstory.ai import _send_llm_request
+from termstory.ai import _send_llm_request, _DEFAULT_MAX_TOKENS
 from termstory.sanitizer import sanitize_session_commands, redact_command
 
 # BM25 tuning constants
@@ -289,6 +289,7 @@ def generate_answer(query: str, sessions: List[Session], ai_client) -> Optional[
             api_key = ai_client.get("api_key") or ""
             api_base_url = ai_client.get("api_base_url") or ""
             model_name = ai_client.get("model_name") or ""
+        request_timeout_seconds = ai_client.get("request_timeout_seconds", 30.0)
     else:
         provider = getattr(ai_client, "provider", None) or getattr(ai_client, "active_provider", "disabled")
         providers = getattr(ai_client, "providers", None)
@@ -300,6 +301,7 @@ def generate_answer(query: str, sessions: List[Session], ai_client) -> Optional[
             api_key = getattr(ai_client, "api_key", "")
             api_base_url = getattr(ai_client, "api_base_url", "")
             model_name = getattr(ai_client, "model_name", "")
+        request_timeout_seconds = getattr(ai_client, "request_timeout_seconds", 30.0)
 
     if not provider or provider == "disabled":
         return "AI capabilities are currently disabled."
@@ -370,7 +372,7 @@ def generate_answer(query: str, sessions: List[Session], ai_client) -> Optional[
         api_base_url=api_base_url,
         model_name=model_name,
         provider=provider,
-        max_tokens=1500,
-        timeout=30.0,
+        max_tokens=_DEFAULT_MAX_TOKENS,
+        timeout=request_timeout_seconds,
     )
     return result

--- a/termstory/ask.py
+++ b/termstory/ask.py
@@ -303,6 +303,18 @@ def generate_answer(query: str, sessions: List[Session], ai_client) -> Optional[
             model_name = getattr(ai_client, "model_name", "")
         request_timeout_seconds = getattr(ai_client, "request_timeout_seconds", 30.0)
 
+    # config.json is loaded via json.load() with no per-key type validation
+    # (see config.py:load_config), so a hand-edited config could set this to
+    # null or a string. dict.get()'s default only covers a missing key, not
+    # a present-but-invalid one, and _send_llm_request does `timeout + 1.0`
+    # on the raw value -- a non-numeric timeout crashes that with an
+    # uncaught TypeError before the request is even sent. Fall back to the
+    # same 30.0 default for any non-numeric value, including bool (which is
+    # technically a numbers.Real subclass in Python but not a meaningful
+    # timeout here).
+    if isinstance(request_timeout_seconds, bool) or not isinstance(request_timeout_seconds, (int, float)):
+        request_timeout_seconds = 30.0
+
     if not provider or provider == "disabled":
         return "AI capabilities are currently disabled."
 

--- a/termstory/ask.py
+++ b/termstory/ask.py
@@ -303,16 +303,34 @@ def generate_answer(query: str, sessions: List[Session], ai_client) -> Optional[
             model_name = getattr(ai_client, "model_name", "")
         request_timeout_seconds = getattr(ai_client, "request_timeout_seconds", 30.0)
 
-    # config.json is loaded via json.load() with no per-key type validation
-    # (see config.py:load_config), so a hand-edited config could set this to
-    # null or a string. dict.get()'s default only covers a missing key, not
-    # a present-but-invalid one, and _send_llm_request does `timeout + 1.0`
-    # on the raw value -- a non-numeric timeout crashes that with an
-    # uncaught TypeError before the request is even sent. Fall back to the
-    # same 30.0 default for any non-numeric value, including bool (which is
-    # technically a numbers.Real subclass in Python but not a meaningful
-    # timeout here).
-    if isinstance(request_timeout_seconds, bool) or not isinstance(request_timeout_seconds, (int, float)):
+    # config.json is loaded via json.load() with no per-key type/range
+    # validation (see config.py:load_config), and `termstory config set
+    # request_timeout_seconds <value>` will happily store 0, a negative
+    # number, or (if the stored value has ever been a float) "inf". Each
+    # of those reaches ai.py's timeout handling differently and badly:
+    #   - non-numeric (None/str): timeout + 1.0 raises an uncaught
+    #     TypeError outside the worker thread's try/except, crashing
+    #     generate_answer entirely.
+    #   - bool: a subclass of int in Python, so isinstance(x, (int, float))
+    #     alone lets it through as timeout=1/0 (True==1/False==0).
+    #   - 0: urlopen puts the socket in non-blocking mode, so every
+    #     request fails instantly with EINPROGRESS regardless of network
+    #     conditions.
+    #   - negative: join_timeout = timeout + 1.0 goes negative, so the
+    #     join loop's elapsed-time check is already true on its first
+    #     iteration -- it never actually waits for the worker.
+    #   - inf/nan: urlopen(timeout=float('inf')) raises OverflowError,
+    #     which isn't in the worker's caught exception tuple, so it dies
+    #     silently in the background thread instead of returning an
+    #     answer or a clean error.
+    # Falls back to the same 30.0 default for any value outside
+    # (0, +inf) rather than trying to enumerate every bad case above.
+    if (
+        isinstance(request_timeout_seconds, bool)
+        or not isinstance(request_timeout_seconds, (int, float))
+        or not math.isfinite(request_timeout_seconds)
+        or request_timeout_seconds <= 0
+    ):
         request_timeout_seconds = 30.0
 
     if not provider or provider == "disabled":

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -535,6 +535,103 @@ def test_generate_answer_bool_timeout_config_falls_back_to_30(monkeypatch):
     assert received["timeout"] == 30.0
 
 
+def test_generate_answer_zero_timeout_config_falls_back_to_30(monkeypatch):
+    """`termstory config set request_timeout_seconds 0` genuinely stores
+    the int 0 (see cli.py:config_set's int-conversion branch). timeout=0
+    puts the socket in non-blocking mode, so every ask request fails
+    instantly with EINPROGRESS regardless of network conditions."""
+    received = {}
+
+    def mock_urlopen(req, timeout=None):
+        received["timeout"] = timeout
+        resp_payload = {"choices": [{"message": {"content": "ok"}}]}
+        return MockResponse(json.dumps(resp_payload).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+    sessions = [
+        Session(id=1, start_time=1700000000, end_time=1700000100, duration_seconds=100, project_id=1, commands=[
+            Command(timestamp=1700000000, command="npm run deploy", session_id=1, project_id=1)
+        ])
+    ]
+    ai_client = {
+        "active_provider": "groq",
+        "request_timeout_seconds": 0,
+        "providers": {
+            "groq": {"api_key": "test-key", "api_base_url": "https://api.groq.com/openai/v1", "model_name": "llama3"}
+        }
+    }
+
+    res = generate_answer("What did I do?", sessions, ai_client)
+    assert res == "ok"
+    assert received["timeout"] == 30.0
+
+
+def test_generate_answer_negative_timeout_config_falls_back_to_30(monkeypatch):
+    """A negative request_timeout_seconds makes ai.py's
+    join_timeout = timeout + 1.0 go negative, so the join loop's
+    elapsed-time check is already true on its very first iteration,
+    it never actually waits for the worker thread."""
+    received = {}
+
+    def mock_urlopen(req, timeout=None):
+        received["timeout"] = timeout
+        resp_payload = {"choices": [{"message": {"content": "ok"}}]}
+        return MockResponse(json.dumps(resp_payload).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+    sessions = [
+        Session(id=1, start_time=1700000000, end_time=1700000100, duration_seconds=100, project_id=1, commands=[
+            Command(timestamp=1700000000, command="npm run deploy", session_id=1, project_id=1)
+        ])
+    ]
+    ai_client = {
+        "active_provider": "groq",
+        "request_timeout_seconds": -5,
+        "providers": {
+            "groq": {"api_key": "test-key", "api_base_url": "https://api.groq.com/openai/v1", "model_name": "llama3"}
+        }
+    }
+
+    res = generate_answer("What did I do?", sessions, ai_client)
+    assert res == "ok"
+    assert received["timeout"] == 30.0
+
+
+def test_generate_answer_infinite_timeout_config_falls_back_to_30(monkeypatch):
+    """float('inf') > 0 is True, so a bare positivity check alone
+    wouldn't catch it. urlopen(timeout=float('inf')) raises OverflowError,
+    which isn't in the worker thread's caught exception tuple, so it
+    would die silently in the background instead of returning an
+    answer or a clean error."""
+    received = {}
+
+    def mock_urlopen(req, timeout=None):
+        received["timeout"] = timeout
+        resp_payload = {"choices": [{"message": {"content": "ok"}}]}
+        return MockResponse(json.dumps(resp_payload).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+    sessions = [
+        Session(id=1, start_time=1700000000, end_time=1700000100, duration_seconds=100, project_id=1, commands=[
+            Command(timestamp=1700000000, command="npm run deploy", session_id=1, project_id=1)
+        ])
+    ]
+    ai_client = {
+        "active_provider": "groq",
+        "request_timeout_seconds": float("inf"),
+        "providers": {
+            "groq": {"api_key": "test-key", "api_base_url": "https://api.groq.com/openai/v1", "model_name": "llama3"}
+        }
+    }
+
+    res = generate_answer("What did I do?", sessions, ai_client)
+    assert res == "ok"
+    assert received["timeout"] == 30.0
+
+
 def test_generate_answer_truncates_large_session(monkeypatch):
     """Sessions with >40 commands should be truncated in the prompt."""
     called_prompts = []

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -409,7 +409,7 @@ def test_generate_answer_uses_shared_max_tokens_and_config_timeout(monkeypatch):
 
 def test_generate_answer_timeout_defaults_to_30_when_unset(monkeypatch):
     """When ai_client has no request_timeout_seconds key at all, the
-    fallback must still be 30.0, behavior unchanged for existing users
+    fallback must still be 30.0 -- behavior unchanged for existing users
     who haven't set this in their config."""
     received = {}
 
@@ -437,6 +437,101 @@ def test_generate_answer_timeout_defaults_to_30_when_unset(monkeypatch):
     }
 
     generate_answer("What did I do?", sessions, ai_client)
+    assert received["timeout"] == 30.0
+
+
+def test_generate_answer_null_timeout_config_falls_back_to_30(monkeypatch):
+    """A hand-edited config.json with `"request_timeout_seconds": null`
+    must not crash generate_answer. Without the guard, `timeout=None`
+    reaches _send_llm_request, which does `timeout + 1.0` and raises an
+    uncaught TypeError before the request is even sent."""
+    received = {}
+
+    def mock_urlopen(req, timeout=None):
+        received["timeout"] = timeout
+        resp_payload = {"choices": [{"message": {"content": "ok"}}]}
+        return MockResponse(json.dumps(resp_payload).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+    sessions = [
+        Session(id=1, start_time=1700000000, end_time=1700000100, duration_seconds=100, project_id=1, commands=[
+            Command(timestamp=1700000000, command="npm run deploy", session_id=1, project_id=1)
+        ])
+    ]
+    ai_client = {
+        "active_provider": "groq",
+        "request_timeout_seconds": None,
+        "providers": {
+            "groq": {"api_key": "test-key", "api_base_url": "https://api.groq.com/openai/v1", "model_name": "llama3"}
+        }
+    }
+
+    res = generate_answer("What did I do?", sessions, ai_client)
+    assert res == "ok"
+    assert received["timeout"] == 30.0
+
+
+def test_generate_answer_string_timeout_config_falls_back_to_30(monkeypatch):
+    """A hand-edited config.json with a string value for
+    request_timeout_seconds (e.g. `"30"` typed as text, or a typo like
+    `"thirty"`) must not crash generate_answer either."""
+    received = {}
+
+    def mock_urlopen(req, timeout=None):
+        received["timeout"] = timeout
+        resp_payload = {"choices": [{"message": {"content": "ok"}}]}
+        return MockResponse(json.dumps(resp_payload).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+    sessions = [
+        Session(id=1, start_time=1700000000, end_time=1700000100, duration_seconds=100, project_id=1, commands=[
+            Command(timestamp=1700000000, command="npm run deploy", session_id=1, project_id=1)
+        ])
+    ]
+    ai_client = {
+        "active_provider": "groq",
+        "request_timeout_seconds": "thirty",
+        "providers": {
+            "groq": {"api_key": "test-key", "api_base_url": "https://api.groq.com/openai/v1", "model_name": "llama3"}
+        }
+    }
+
+    res = generate_answer("What did I do?", sessions, ai_client)
+    assert res == "ok"
+    assert received["timeout"] == 30.0
+
+
+def test_generate_answer_bool_timeout_config_falls_back_to_30(monkeypatch):
+    """bool is a subclass of int in Python, so `isinstance(x, (int, float))`
+    alone would let `request_timeout_seconds: true` slip through as
+    timeout=1 (True == 1) -- a silent, near-instant timeout. Must be
+    explicitly excluded and fall back to 30.0."""
+    received = {}
+
+    def mock_urlopen(req, timeout=None):
+        received["timeout"] = timeout
+        resp_payload = {"choices": [{"message": {"content": "ok"}}]}
+        return MockResponse(json.dumps(resp_payload).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+    sessions = [
+        Session(id=1, start_time=1700000000, end_time=1700000100, duration_seconds=100, project_id=1, commands=[
+            Command(timestamp=1700000000, command="npm run deploy", session_id=1, project_id=1)
+        ])
+    ]
+    ai_client = {
+        "active_provider": "groq",
+        "request_timeout_seconds": True,
+        "providers": {
+            "groq": {"api_key": "test-key", "api_base_url": "https://api.groq.com/openai/v1", "model_name": "llama3"}
+        }
+    }
+
+    res = generate_answer("What did I do?", sessions, ai_client)
+    assert res == "ok"
     assert received["timeout"] == 30.0
 
 

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -366,6 +366,80 @@ def test_generate_answer_success(monkeypatch):
     assert res == "You deployed the website project."
 
 
+def test_generate_answer_uses_shared_max_tokens_and_config_timeout(monkeypatch):
+    """max_tokens must come from ai._DEFAULT_MAX_TOKENS (not a local 1500
+    literal), and timeout must be threaded through from the ai_client's
+    request_timeout_seconds config value rather than a hardcoded 30.0."""
+    from termstory.ai import _DEFAULT_MAX_TOKENS
+
+    received = {}
+
+    def mock_urlopen(req, timeout=None):
+        received["max_tokens"] = json.loads(req.data.decode("utf-8"))["max_tokens"]
+        received["timeout"] = timeout
+        resp_payload = {"choices": [{"message": {"content": "ok"}}]}
+        return MockResponse(json.dumps(resp_payload).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+    sessions = [
+        Session(id=1, start_time=1700000000, end_time=1700000100, duration_seconds=100, project_id=1, commands=[
+            Command(timestamp=1700000000, command="npm run deploy", session_id=1, project_id=1)
+        ])
+    ]
+    # A non-default timeout (45.0, not the old hardcoded 30.0) to prove it's
+    # actually threaded through from config rather than ignored.
+    ai_client = {
+        "active_provider": "groq",
+        "request_timeout_seconds": 45.0,
+        "providers": {
+            "groq": {
+                "api_key": "test-key",
+                "api_base_url": "https://api.groq.com/openai/v1",
+                "model_name": "llama3"
+            }
+        }
+    }
+
+    res = generate_answer("What did I do?", sessions, ai_client)
+    assert res == "ok"
+    assert received["max_tokens"] == _DEFAULT_MAX_TOKENS
+    assert received["timeout"] == 45.0
+
+
+def test_generate_answer_timeout_defaults_to_30_when_unset(monkeypatch):
+    """When ai_client has no request_timeout_seconds key at all, the
+    fallback must still be 30.0, behavior unchanged for existing users
+    who haven't set this in their config."""
+    received = {}
+
+    def mock_urlopen(req, timeout=None):
+        received["timeout"] = timeout
+        resp_payload = {"choices": [{"message": {"content": "ok"}}]}
+        return MockResponse(json.dumps(resp_payload).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+    sessions = [
+        Session(id=1, start_time=1700000000, end_time=1700000100, duration_seconds=100, project_id=1, commands=[
+            Command(timestamp=1700000000, command="npm run deploy", session_id=1, project_id=1)
+        ])
+    ]
+    ai_client = {
+        "active_provider": "groq",
+        "providers": {
+            "groq": {
+                "api_key": "test-key",
+                "api_base_url": "https://api.groq.com/openai/v1",
+                "model_name": "llama3"
+            }
+        }
+    }
+
+    generate_answer("What did I do?", sessions, ai_client)
+    assert received["timeout"] == 30.0
+
+
 def test_generate_answer_truncates_large_session(monkeypatch):
     """Sessions with >40 commands should be truncated in the prompt."""
     called_prompts = []
@@ -616,4 +690,3 @@ def test_generate_answer_redacts_github_pat_in_commit(monkeypatch):
     assert res == "ok"
     sent_prompt = called_prompts[0]
     assert "ghp_ASKSECRET1234567890abcdef" not in sent_prompt
-


### PR DESCRIPTION
## Description
Replaces the hardcoded `max_tokens=1500` and `timeout=30.0` in `ask.py`'s LLM call with `_DEFAULT_MAX_TOKENS` (shared from `ai.py`) and `request_timeout_seconds` read from the existing config. Reuses the config key already used by 5+ call sites in `ai.py` instead of adding a new `ask_timeout` key, so there's one timeout setting for all LLM calls, not two.

Fixes #216

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the "density over decoration" philosophy.
- [x] I have not used `rich.panel.Panel` in my code.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
