### PR TITLE
fix: replace warning print statements with logger

### DIFF
--- a/termstory/config.py
+++ b/termstory/config.py
@@ -1,7 +1,9 @@
 import os
 import json
 import sys
+import logging
 from typing import List, Any
+logger = logging.getLogger(__name__)
 
 def get_app_dir(dir_type: str = "data") -> str:
     """Get the appropriate application directory.
@@ -191,16 +193,18 @@ def load_config() -> dict:
             ValueError,
             RecursionError,
         ) as e:
-            print(
-                f"Warning: config file '{config_path}' contains invalid data and will be ignored ({e}).",
-                file=sys.stderr,
+            logger.warning(
+                "Config file '%s' contains invalid data and will be ignored (%s).",
+                config_path,
+                e,
             )
             config = {}
 
         except OSError as e:
-            print(
-                f"Warning: could not read config file '{config_path}': {e}",
-                file=sys.stderr,
+            logger.warning(
+                "Could not read config file '%s': %s",
+                config_path,
+            e,
             )
             config = {}
 


### PR DESCRIPTION
## Description

This PR replaces warning `print(..., file=sys.stderr)` calls in `config.py` with the project's standard logging system.

Using `logger.warning()` ensures warning messages follow the existing logging configuration, respect log levels, and remain consistent with the rest of the codebase.

Fixes #250

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the "density over decoration" philosophy.
- [x] I have not used `rich.panel.Panel` in my code.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.