### PR TITLE
fix(core): resolve stats layout overflow and AI background thread errors

### DIFF
--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -856,6 +856,11 @@ def perform_reset(auto_confirm: bool = False, dry_run: bool = False):
         return
 
     if not auto_confirm:
+        # A non-interactive shell can't answer the prompt; refuse instead of
+        # silently aborting with a success exit code.
+        if not sys.stdin.isatty():
+            console.print("[bold red]Refusing to reset in a non-interactive shell without --yes.[/bold red]")
+            raise typer.Exit(code=1)
         response = Prompt.ask("\nAre you sure you want to delete all TermStory data?", choices=["y", "yes", "n", "no"], default="n")
         if response.lower() not in ["y", "yes"]:
             console.print("[yellow]Reset aborted.[/yellow]")


### PR DESCRIPTION
## Summary
This PR fixes stats rendering layout issues, improves reset command safety with confirmation prompts and dry-run support, and adds debug logging for previously swallowed exceptions across the codebase. The changes address visual misalignment in Unicode/CJK character rendering, prevent accidental data loss in non-interactive environments, and improve observability of background operations.

## Changes

### Core / Formatting
- **termstory/formatter.py**: Added `overflow="fold"` to the Project column in the stats table to gracefully handle long project names with spaces, preventing corrupted table rows 
- **termstory/formatter.py**: Implemented dynamic visual width calculation using `rich.console.Console().measure()` for separator lines in stats output, fixing Unicode/CJK character (`█`) width misalignments where `len()` incorrectly computed visual width alongside ANSI markup tags 

### CLI / Reset Behavior
- **termstory/cli.py**: Modified `perform_reset()` to accept `auto_confirm` and `dry_run` parameters for safer reset operations 
- **termstory/cli.py**: Added non-interactive shell detection in `perform_reset()` - now refuses to reset without `--yes` flag when `sys.stdin.isatty()` returns False, exiting with code 1 instead of silently aborting with success 
- **termstory/cli.py**: Added `--yes`/`-y` and `--dry-run` options to `reset_cmd()` for explicit confirmation control and preview of deletions 
- **termstory/cli.py**: Added `--yes` option to the global `--reset` flag in `main()` for consistency 
- **termstory/cli.py**: Improved date parsing error messages from "Could not parse date" to "Invalid date. Expected YYYY-MM-DD." for better user guidance 

### Debug Logging
- **termstory/archive.py**: Added debug logging for database operation failures (DETACH, VACUUM) that were previously silently swallowed 
- **termstory/timestamp_detective.py**: Added debug logging for probe failures in timestamp detection operations (file timestamps, brew prefix, npm root, git log, shlex split, pip packages, docker, macOS logs) 
- **termstory/tui.py**: Added debug logging for UI exceptions that were previously suppressed in button handlers, text updates, canvas refreshes, clipboard operations, and background workers 

### Tests
- **tests/test_cli_commands.py**: Updated `mock_perform_reset` signature to accept `*args, **kwargs` to match new function signature 
- **tests/test_cli_commands.py**: Changed reset cleanup test to use `["reset", "--yes"]` instead of `["reset"]` to accommodate new confirmation requirement 
- **tests/test_cli_commands.py**: Updated error message assertion from "Could not parse date" to "Invalid date" to match improved error messaging 

## Fixes
- Fixes #259 — Stats rendering layout issues with Unicode/CJK characters
- Fixes #257 — Reset command safety and confirmation behavior
- Fixes #238 — Table text wrapping for long project names

## Breaking Changes
None. The reset command changes are backward compatible - the `--yes` flag is optional for interactive use, and non-interactive shells now fail explicitly instead of silently succeeding.

## Testing
To test the changes:

1. **Stats rendering**: Run `termstory stats` and verify that separator lines align correctly with Unicode/CJK characters and long project names wrap properly in the table
2. **Reset command**: 
   - Test interactive reset: `termstory reset` (should prompt for confirmation)
   - Test non-interactive refusal: `echo "" | termstory reset` (should exit with code 1 and error message)
   - Test explicit confirmation: `termstory reset --yes` (should proceed without prompt)
   - Test dry-run: `termstory reset --dry-run` (should show paths without deleting)
3. **Date parsing**: Run `termstory search query --since invalid-date` and verify the improved error message
4. **Debug logging**: Run with debug logging enabled to verify that previously swallowed exceptions are now logged

## Notes
The original PR description mentioned fixing a "background thread AI error" bug by replacing `threading.local()` with a shared global variable. However, this change was **not** implemented in the final diff. As clarified in the review thread, the AI error slot remains thread-local because each `@work(thread=True)` worker reads its own `last_error` on its own thread, so there is no shared slot to race on. The test suite was not updated to verify cross-thread visibility as originally claimed. The actual changes focus on stats rendering, reset safety, and debug logging improvements.