### PR TITLE
refactor: replace hardcoded SQLite chunk size with constant

### DIFF
--- a/termstory/archive.py
+++ b/termstory/archive.py
@@ -6,6 +6,9 @@ from termstory.database import _safe_rollback_and_reraise
 from termstory.database import Database
 from termstory.date_utils import get_current_time
 
+# Keep below SQLite's default SQLITE_MAX_VARIABLE_NUMBER (999).
+_SQLITE_IN_CHUNK_SIZE = 900
+
 def is_timeframe_older_than(timeframe_id: str, tf_type: str, cutoff_date: date) -> bool:
     """Check if a macro_summary timeframe is older than cutoff_date."""
     if tf_type == 'date':
@@ -111,8 +114,8 @@ def archive_old_data(main_db_path: str, archive_db_path: str, days: int) -> Dict
         if proj_ids:
             projects_to_archive = []
             proj_ids_list = list(proj_ids)
-            for i in range(0, len(proj_ids_list), 900):
-                chunk = proj_ids_list[i:i+900]
+            for i in range(0, len(proj_ids_list), _SQLITE_IN_CHUNK_SIZE):
+                chunk = proj_ids_list[i:i + _SQLITE_IN_CHUNK_SIZE]
                 proj_placeholders = ",".join("?" for _ in chunk)
                 cursor.execute(f"SELECT id, name, path, first_seen, last_seen, project_context, created_at FROM main.projects WHERE id IN ({proj_placeholders})", chunk)
                 projects_to_archive.extend(cursor.fetchall())


### PR DESCRIPTION
## Summary

This PR replaces the hardcoded SQLite chunk size value (`900`) used in the project ID batching loop within `archive_old_data()` with a named module-level constant `_SQLITE_IN_CHUNK_SIZE`. This improves code maintainability and documents the technical constraint that the value must stay below SQLite's default `SQLITE_MAX_VARIABLE_NUMBER` limit of 999.

## Changes

### Core
- **termstory/archive.py**: Added module-level constant `_SQLITE_IN_CHUNK_SIZE = 900` with a comment explaining the SQLite variable number constraint
- **termstory/archive.py**: Replaced hardcoded `900` in the project ID batching loop with `_SQLITE_IN_CHUNK_SIZE` constant in the `archive_old_data()` function

## Fixes

- Fixes #252 — Replaces hardcoded SQLite chunk size with named constant for better maintainability

## Breaking Changes

None

## Testing

Run the existing archive test suite to verify the change doesn't break the archiving functionality:

```bash
pytest tests/test_archive.py -v
pytest tests/test_save_data_none_safety.py::test_archive_handles_clean_db -v
```

The existing `test_archive_logic` test in `tests/test_archive.py` exercises the project ID batching logic by creating multiple projects and sessions, ensuring the chunking mechanism continues to work correctly.

## Notes

This is a non-breaking refactoring that improves code readability. The value `900` was chosen to stay safely below SQLite's default `SQLITE_MAX_VARIABLE_NUMBER` limit of 999, which is the maximum number of parameters allowed in a single SQL statement. The batching loop processes project IDs in chunks to avoid hitting this limit when querying projects for archival.