### PR TITLE
feat: support natural language dates for --date option

### DIFF
--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -2,7 +2,7 @@ import os
 
 import typer
 from typing import Optional, List
-from datetime import datetime
+from datetime import datetime, timedelta
 from dateutil import parser as date_parser
 
 # Supported tags for session categorization

--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -2,6 +2,7 @@ import os
 
 import typer
 from typing import Optional, List
+from datetime import datetime
 from dateutil import parser as date_parser
 
 # Supported tags for session categorization
@@ -12,7 +13,7 @@ from termstory.parser import parse_all_histories
 from termstory.session import create_sessions
 from termstory.project import detect_projects
 from termstory.database import Database
-from termstory.date_utils import get_current_time, get_today_range
+from termstory.date_utils import get_current_time, get_today_range, parse_date_range_helper
 from termstory.formatter import format_search_results, format_today_output, format_project_output, format_insights_output, format_stats_output, format_profile_output, format_necromancer_score, format_rage_quit_signatures
 import sqlite3
 
@@ -1424,7 +1425,7 @@ def version_callback(value: bool):
 @app.callback(invoke_without_command=True)
 def main(
     ctx: typer.Context,
-    date: Optional[str] = typer.Option(None, "--date", help="Date override (YYYY-MM-DD) for commands"),
+    date: Optional[str] = typer.Option(None, "--date", help="Date override (e.g. today, yesterday, 7days, YYYY-MM-DD) for commands"),
     reset: bool = typer.Option(False, "--reset", help="Reset all TermStory state, configuration, and database"),
     version: Optional[bool] = typer.Option(
         None,
@@ -1441,8 +1442,9 @@ def main(
 
     if date:
         try:
-            date_parser.parse(date)
-            os.environ["TERMSTORY_DATE_OVERRIDE"] = date
+            start_ts, _ = parse_date_range_helper(date)
+            parsed_date = datetime.fromtimestamp(start_ts).strftime("%Y-%m-%d")
+            os.environ["TERMSTORY_DATE_OVERRIDE"] = parsed_date
         except Exception:
             Console(stderr=True).print(f"[bold red]Error: Invalid date format '{date}'[/]")
             raise typer.Exit(code=1)

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -439,7 +439,23 @@ def test_cli_error_states(tmp_path, monkeypatch):
     result = runner.invoke(app, ["--date", "not-a-date"])
     assert result.exit_code == 1
     assert "Invalid date format" in result.stdout or "Invalid date format" in result.stderr
+def test_global_date_accepts_natural_language(tmp_path, monkeypatch):
+    db_file = tmp_path / "test_date_override.db"
 
+    monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.cli.get_history_files", lambda: [])
+    monkeypatch.setattr("termstory.cli.run_ingestion", lambda db: None)
+    monkeypatch.setattr("termstory.cli.show_ui", lambda: None)
+
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["--date", "yesterday"])
+
+    assert result.exit_code == 0
+    # The CLI sets TERMSTORY_DATE_OVERRIDE directly, so clean it up
+    # to avoid leaking state into later tests.
+    os.environ.pop("TERMSTORY_DATE_OVERRIDE", None)
 def test_safe_init_db_corrupted(tmp_path, monkeypatch, capsys):
     import sqlite3
     db_file = tmp_path / "corrupt.db"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,6 +1,6 @@
 import os
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from typer.testing import CliRunner
 from termstory.cli import app
 from termstory.database import Database
@@ -453,6 +453,10 @@ def test_global_date_accepts_natural_language(tmp_path, monkeypatch):
     result = runner.invoke(app, ["--date", "yesterday"])
 
     assert result.exit_code == 0
+    expected = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+    assert os.environ.get("TERMSTORY_DATE_OVERRIDE") == expected, (
+    f"Expected override {expected!r}, got {os.environ.get('TERMSTORY_DATE_OVERRIDE')!r}"
+)
     # The CLI sets TERMSTORY_DATE_OVERRIDE directly, so clean it up
     # to avoid leaking state into later tests.
     os.environ.pop("TERMSTORY_DATE_OVERRIDE", None)


### PR DESCRIPTION
## What this does

Makes the global `--date` option accept natural-language inputs like `today`, `yesterday`, and `7days` — the same strings `--date-range` already supports — and normalizes the result so `TERMSTORY_DATE_OVERRIDE` always gets a clean `YYYY-MM-DD` value.

Before, `--date` only validated the string with `dateutil` and passed it through unchanged. That worked for literal dates, but failed for the shorthand forms. Now it reuses the shared `parse_date_range_helper()` and writes back a normalized date, so downstream code that reads `TERMSTORY_DATE_OVERRIDE` sees a consistent format.

## Changes

- `termstory/cli.py`
  - Added `datetime` import
  - Replaced direct `date_parser.parse()` validation with `parse_date_range_helper()`
  - Normalizes the parsed result to `YYYY-MM-DD` before setting `TERMSTORY_DATE_OVERRIDE`
  - Updated `--date` help text
- `tests/test_cli_commands.py`
  - Added `test_global_date_accepts_natural_language()` for `yesterday`
  - Added manual env cleanup so the override doesn't leak into later tests

## Fix

Closes #255.

## How to test

```bash
pytest tests/test_cli_commands.py::test_global_date_accepts_natural_language
```

Or manually:

```bash
termstory --date yesterday
termstory --date today
termstory --date 7days
termstory --date not-a-date   # should error out
```

## Notes

No breaking changes. The timezone behavior follows the existing `date_utils` helpers (naive local-time timestamps), so the normalized date matches what `--date-range` would produce for the same input.
