### PR TITLE
fix: compute stats section dividers using visual width

### DIFF
--- a/termstory/formatter.py
+++ b/termstory/formatter.py
@@ -3,6 +3,7 @@ import os
 import re
 import shlex
 import calendar
+import unicodedata
 from collections import Counter, defaultdict
 from datetime import datetime, timedelta
 from typing import List, Dict, Tuple, Optional, Any
@@ -17,6 +18,18 @@ from rich.text import Text
 from rich.markup import escape
 
 logger = logging.getLogger(__name__)
+
+ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+
+def display_len(s: str) -> int:
+    s_clean = ansi_escape.sub('', s)
+    length = 0
+    for char in s_clean:
+        if unicodedata.east_asian_width(char) in ('W', 'F'):
+            length += 2
+        else:
+            length += 1
+    return length
 
 DISPLAY_NAMES = {
     "git": "Git",
@@ -1048,19 +1061,7 @@ def boxify_terminal_wrapped(text: str) -> str:
     is_rpg = any("CHARACTER SHEET" in line.upper() or "TELEMETRY" in line.upper() or "[⚔️" in line or "[🎒" in line for line in cleaned_lines)
     width = 58
     
-    import unicodedata
-    import re
-    ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
-    
-    def display_len(s: str) -> int:
-        s_clean = ansi_escape.sub('', s)
-        length = 0
-        for char in s_clean:
-            if unicodedata.east_asian_width(char) in ('W', 'F'):
-                length += 2
-            else:
-                length += 1
-        return length
+
 
     box_lines = []
     
@@ -1333,7 +1334,7 @@ def format_stats_output(db) -> str:
     sorted_projects = sorted(breakdown.items(), key=lambda x: x[1]["total_duration"], reverse=True)
     
     table = Table(box=None, show_header=True, padding=(0, 2))
-    table.add_column("Project", style="cyan", header_style="bold cyan", overflow="fold")
+    table.add_column("Project", style="cyan", header_style="bold cyan", no_wrap=True)
     table.add_column("Commands", justify="right", style="green")
     table.add_column("Duration", justify="right", style="green")
     table.add_column("Sessions", justify="right", style="green")
@@ -1396,35 +1397,46 @@ def format_stats_output(db) -> str:
     top_hours_str = ", ".join(top_hours_parts) if top_hours_parts else "N/A"
     
     from rich.console import Console
-    from rich.text import Text
-    _measure_console = Console()
+    console = Console()
     
-    def get_markup_width(s: str) -> int:
-        return _measure_console.measure(Text.from_markup(s)).maximum
+    def make_divider(width: int) -> str:
+        return "[dim]" + "─" * width + "[/]"
 
-    heatmap_width = max(30, get_markup_width(heatmap_str))
-    punch_card_width = max(32, get_markup_width(punch_card))
-    lang_width = max(get_markup_width(l) for l in lang_lines) if lang_lines else 21
-    
-    # Build complete report
+    title_heatmap = "[bold cyan]Activity Heatmap (Last 30 Days)[/]"
+    heatmap_content = f"  {heatmap_str}"
+    heatmap_width = Text.from_markup(heatmap_content).cell_len
+
+    title_peak = "[bold cyan]Peak Hours (Command Distribution)[/]"
+    peak_content = f"  {punch_card}"
+    peak_width = Text.from_markup(peak_content).cell_len
+
+    title_lang = "[bold cyan]Language Distribution[/]"
+    if lang_lines:
+        lang_width = max(Text.from_markup(line).cell_len for line in lang_lines)
+    else:
+        lang_width = len("  No languages detected.")
+
+    title_proj = "[bold cyan]Project Breakdown[/]"
+    proj_width = console.measure(table).maximum
+
     output_lines = [
         "📊 [bold]Deep History Statistics & Telemetry[/]",
         "",
-        "[bold cyan]Activity Heatmap (Last 30 Days)[/]",
-        f"[dim]{'─' * heatmap_width}[/]",
-        f"  {heatmap_str}",
+        title_heatmap,
+        make_divider(heatmap_width),
+        heatmap_content,
         "",
-        "[bold cyan]Peak Hours (Command Distribution)[/]",
-        f"[dim]{'─' * punch_card_width}[/]",
-        f"  {punch_card}",
+        title_peak,
+        make_divider(peak_width),
+        peak_content,
         f"  Top Active Hours: {top_hours_str}",
         "",
-        "[bold cyan]Language Distribution[/]",
-        f"[dim]{'─' * lang_width}[/]",
+        title_lang,
+        make_divider(lang_width),
         lang_output,
         "",
-        "[bold cyan]Project Breakdown[/]",
-        "[dim]─────────────────[/]",
+        title_proj,
+        make_divider(proj_width),
     ]
     
     project_table_str = render_to_string(table)


### PR DESCRIPTION
## Summary
This PR improves the visual formatting of the deep history statistics output by replacing hardcoded separator lengths with dynamic visual width calculations. It ensures horizontal rules scale accurately based on actual rendered character widths, particularly important for CJK locales where characters may occupy 2 columns. Additionally, it fixes a project name wrapping bug in the stats table.

## Changes

### Core
- **termstory/formatter.py**
  - Added module-level `display_len` function to calculate visual string width, accounting for ANSI escape codes and CJK character widths (lines 22-31) 
  - Moved `unicodedata` import and `ansi_escape` regex to module level (lines 6, 21-22) 
  - Removed duplicate local `display_len` function from `boxify_terminal_wrapped` (lines 1051-1063 removed) 
  - Updated `format_stats_output` to use dynamic visual widths for section dividers:
    - Added `make_divider` helper function (lines 1400-1402) 
    - Calculated heatmap width using `Text.from_markup().cell_len` (lines 1404-1406) 
    - Calculated peak hours width using `Text.from_markup().cell_len` (lines 1408-1410) 
    - Calculated language distribution width using max line length (lines 1412-1416) 
    - Calculated project breakdown width using `console.measure(table).maximum` (lines 1418-1420) 
  - Added `no_wrap=True` to the Project column in the stats table to prevent wrapping (line 1337) 

## Fixes
- Fixes #259 — Project table wrapping issue and separator width calculation

## Breaking Changes
None

## Testing
To test these changes:
1. Run the stats command: `termstory stats`
2. Verify that horizontal rules align properly with their content
3. Check that project names in the Project Breakdown table do not wrap
4. Test in CJK locale terminals to ensure characters like `█` render with correct width

## Notes
The `display_len` function was previously duplicated inside `boxify_terminal_wrapped` and has now been extracted to module level for reusability. This function properly handles ANSI escape codes and accounts for East Asian wide characters (CJK) that occupy 2 terminal columns. The dynamic width calculation uses Rich's built-in `cell_len` and `Console.measure` to ensure separators match the actual rendered width of content, fixing alignment issues that occurred with hardcoded lengths.