### PR TITLE
fix: add timeout to git config subprocess calls in formatter.py

### DIFF
--- a/termstory/formatter.py
+++ b/termstory/formatter.py
@@ -982,26 +982,32 @@ def get_operator_handle() -> str:
 
     import subprocess
     try:
-        res = subprocess.run(["git", "config", "github.user"], capture_output=True, text=True, check=False)
+        res = subprocess.run(["git", "config", "github.user"], capture_output=True, text=True, check=False, timeout=5)
         user = res.stdout.strip()
         if user:
             return f"@{user}"
+    except subprocess.TimeoutExpired:
+        logger.debug("Timed out getting github.user from git config", exc_info=True)
     except Exception:
         logger.debug("Could not get github.user from git config", exc_info=True)
     try:
-        res = subprocess.run(["git", "config", "remote.origin.url"], capture_output=True, text=True, check=False)
+        res = subprocess.run(["git", "config", "remote.origin.url"], capture_output=True, text=True, check=False, timeout=5)
         url = res.stdout.strip()
         if url:
             match = re.search(r'github\.com[:/]([^/]+)/', url)
             if match:
                 return f"@{match.group(1)}"
+    except subprocess.TimeoutExpired:
+        logger.debug("Timed out getting remote origin URL from git config", exc_info=True)
     except Exception:
         logger.debug("Could not get remote origin URL from git config", exc_info=True)
     try:
-        res = subprocess.run(["git", "config", "user.name"], capture_output=True, text=True, check=False)
+        res = subprocess.run(["git", "config", "user.name"], capture_output=True, text=True, check=False, timeout=5)
         name = res.stdout.strip()
         if name:
             return f"@{name.replace(' ', '-').lower()}"
+    except subprocess.TimeoutExpired:
+        logger.debug("Timed out getting user.name from git config", exc_info=True)
     except Exception:
         logger.debug("Could not get user.name from git config", exc_info=True)
     try:


### PR DESCRIPTION
## Summary
This PR adds timeout protection to git config subprocess calls in `get_operator_handle()` to prevent indefinite hangs when git processes are unresponsive (e.g., waiting on credential prompts or slow network filesystems). The fix aligns with existing timeout conventions used elsewhere in the codebase and ensures graceful fallback to alternative handle resolution strategies. 

## Changes

### Core
- **termstory/formatter.py** - Modified `get_operator_handle()` function:
  - Added `timeout=5` parameter to the `subprocess.run` call for `git config github.user` 
  - Added `timeout=5` parameter to the `subprocess.run` call for `git config remote.origin.url` 
  - Added `timeout=5` parameter to the `subprocess.run` call for `git config user.name` 
  - Added explicit `except subprocess.TimeoutExpired` handlers for each git config call with debug logging to track timeout events   

## Fixes
- Fixes #249 — Prevents indefinite TUI/CLI freezes when git config subprocess calls hang due to credential prompts or slow network filesystems

## Breaking Changes
None

## Testing
- Run `pytest tests/test_formatter_rich.py -q` — 13 passed
- Run `pytest tests/test_formatter_rich.py tests/test_avatar.py -q` — 15 passed
- The existing test `test_logging_on_exception` in `tests/test_formatter_rich.py` validates exception handling in `get_operator_handle()` 

## Notes
- The 5-second timeout matches the convention used in `termstory/mcp_snapshot.py` for git subprocess calls   
- Other git operations in `termstory/git_integration.py` use a 10-second timeout    
- The timeout-specific exception handling ensures that a timeout on one git config strategy falls through to the next fallback (next git config key, then `getpass`, then `"@developer"`) rather than crashing the application