### PR TITLE
docs: add AGENTS.md for scripts directory

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -3,6 +3,7 @@
 ## Files
 
 - `install.sh` — One-line installer (`curl | bash`) that downloads the project source and installs it.
+- `uninstall.sh` — Companion uninstall script for removing Termstory installation artifacts.
 - `pocs/` — Proof-of-concept scripts used for experimentation. These are not part of the released package.
 
 ## Conventions

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -3,7 +3,7 @@
 ## Files
 
 - `install.sh` — One-line installer (`curl | bash`) that downloads the project source and installs it.
-- `uninstall.sh` — Companion uninstall script for removing Termstory installation artifacts.
+- `uninstall.sh` — Companion uninstall script for removing Termstory installation artifacts and the `~/.termstory` data directory; `--yes` skips the confirmation prompt.
 - `pocs/` — Proof-of-concept scripts used for experimentation. These are not part of the released package; `poc_fts5.py` targets `~/.termstory/termstory.db` and mutates live local data, so do not run it unless you intend to alter that database.
 
 ## Conventions

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,12 @@
+# scripts/ — Shell Scripts
+
+## Files
+
+- `install.sh` — One-line installer (`curl | bash`) that downloads the project source and installs it.
+- `pocs/` — Proof-of-concept scripts used for experimentation. These are not part of the released package.
+
+## Conventions
+
+- The install script checks for a Python 3 interpreter and uses `pip` to install the project.
+- The installer attempts a virtual environment installation first and falls back to a user installation if needed.
+- Scripts in `pocs/` are experimental,  throwaway scripts and are not intended as stable tooling.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -4,7 +4,7 @@
 
 - `install.sh` — One-line installer (`curl | bash`) that downloads the project source and installs it.
 - `uninstall.sh` — Companion uninstall script for removing Termstory installation artifacts.
-- `pocs/` — Proof-of-concept scripts used for experimentation. These are not part of the released package.
+- `pocs/` — Proof-of-concept scripts used for experimentation. These are not part of the released package; `poc_fts5.py` targets `~/.termstory/termstory.db` and mutates live local data, so do not run it unless you intend to alter that database.
 
 ## Conventions
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -9,4 +9,4 @@
 
 - The install script checks for a Python 3 interpreter and uses `pip` to install the project.
 - The installer attempts a virtual environment installation first and falls back to a user installation if needed.
-- Scripts in `pocs/` are experimental,  throwaway scripts and are not intended as stable tooling.
+- Scripts in `pocs/` are experimental and are not intended as stable tooling; inspect them before running because some target local Termstory data rather than isolated fixtures.


### PR DESCRIPTION
## Description

Add `scripts/AGENTS.md` to document the scripts in the `scripts/` directory.

The documentation was verified against the current implementation:

- ✅ `install.sh` checks for a Python 3 interpreter before installation.
- ✅ Uses `pip` to install the project.
- ✅ Attempts a virtual environment installation first and falls back to a user installation if needed.
- ✅ `pocs/` contains proof-of-concept/experimental scripts.

Fixes #173 

## Type of Change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:
- [ ] My code follows the "density over decoration" philosophy.
- [ ] I have not used `rich.panel.Panel` in my code.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.