### PR TITLE
docs: add AGENTS.md for skills directory

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -3,6 +3,7 @@
 ## Files
 
 - `install.sh` — One-line installer (`curl | bash`) that downloads the project source and installs it.
+- `uninstall.sh` — Uninstaller that removes TermStory-installed files and shell configuration entries.
 - `pocs/` — Proof-of-concept scripts used for experimentation. These are not part of the released package.
 
 ## Conventions

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -9,7 +9,7 @@
 1. Create a new directory under `skills/` using the skill name.
 2. Add a `SKILL.md` file with YAML frontmatter (`name`, `description`, and trigger conditions).
 3. Add any supporting files (references, templates, scripts, etc.) as needed.
-4. Test the skill by loading it in Hermes Agent.
+4. Test the skill using the documented agent/skill loader command for this repository.
 
 ## Conventions
 

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -1,0 +1,18 @@
+# skills/ — Custom Skills
+
+## Structure
+
+- `termstory-tui/` — Skill for interacting with the TermStory TUI.
+
+## Adding a New Skill
+
+1. Create a new directory under `skills/` using the skill name.
+2. Add a `SKILL.md` file with YAML frontmatter (`name`, `description`, and trigger conditions).
+3. Add any supporting files (references, templates, scripts, etc.) as needed.
+4. Test the skill by loading it in Hermes Agent.
+
+## Conventions
+
+- Skill directory names are lowercase and hyphenated.
+- Each skill directory contains a `SKILL.md` file.
+- `SKILL.md` uses YAML frontmatter followed by a Markdown body.


### PR DESCRIPTION
## Description

Add `skills/AGENTS.md` to document the custom skills directory.

The document includes:
- Current skill directory structure
- Instructions for adding new skills
- Skill naming and formatting conventions

Closes #174 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:
- [ ] My code follows the "density over decoration" philosophy.
- [ ] I have not used `rich.panel.Panel` in my code.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
