### PR TITLE
feat: improve formatter summaries for advanced git commands

### DIFF
--- a/termstory/formatter.py
+++ b/termstory/formatter.py
@@ -691,6 +691,41 @@ def clean_command_to_memory(cmd_str: str) -> str:
             return "Push changes to remote"
         if "pull" in cmd_str:
             return "Pull latest changes"
+
+        # Interactive rebase
+        rebase_i = re.search(r'rebase\s+-i\s+HEAD~(\d+)', cmd_str)
+        if rebase_i:
+            n = int(rebase_i.group(1))
+            if n == 1:
+                return "Interactive rebase of last commit"
+            return f"Interactive rebase of last {n} commits"
+
+        # Normal rebase onto a branch/ref
+        rebase_onto = re.search(r'(?<!-)rebase\s+(?:onto\s+)?(\S+)', cmd_str)
+        if rebase_onto:
+            target = rebase_onto.group(1)
+            if target == "onto":
+                target = rebase_onto.group(2) if rebase_onto.lastindex >= 2 else target
+            return f"Rebase onto {target}"
+
+        # Cherry-pick
+        if re.search(r'cherry-pick', cmd_str):
+            return "Cherry-pick commit"
+
+        # Reset variants
+        reset_match = re.search(r'reset\s+(--hard|--soft|--mixed)?\s*HEAD~(\d+)', cmd_str)
+        if reset_match:
+            modifier = reset_match.group(1) or ""
+            n = int(reset_match.group(2))
+            count_str = "previous commit" if n == 1 else f"{n} commits back"
+            if modifier == "--hard":
+                return f"Hard reset to {count_str}" if n == 1 else f"Hard reset {count_str}"
+            elif modifier == "--soft":
+                return f"Soft reset {count_str}"
+            elif modifier == "--mixed":
+                return f"Mixed reset to {count_str}" if n == 1 else f"Mixed reset {count_str}"
+            else:
+                return f"Reset to {count_str}" if n == 1 else f"Reset {count_str}"
             
     # 3. Clean newlines and split chains using quote-aware tokenizer
     clean = cmd_str.replace("\n", " ").strip()

--- a/termstory/formatter.py
+++ b/termstory/formatter.py
@@ -693,19 +693,21 @@ def clean_command_to_memory(cmd_str: str) -> str:
             return "Pull latest changes"
 
         # Interactive rebase
-        rebase_i = re.search(r'rebase\s+-i\s+HEAD~(\d+)', cmd_str)
+        rebase_i = re.search(r'rebase\s+(?:-i|--interactive)\s+HEAD~(\d+)', cmd_str)
         if rebase_i:
             n = int(rebase_i.group(1))
             if n == 1:
                 return "Interactive rebase of last commit"
             return f"Interactive rebase of last {n} commits"
 
-        # Normal rebase onto a branch/ref
-        rebase_onto = re.search(r'(?<!-)rebase\s+(?:onto\s+)?(\S+)', cmd_str)
+        # Generic interactive rebase (onto a branch/ref, not HEAD~N)
+        if re.search(r'rebase\s+(?:-i|--interactive)\s+', cmd_str) and not re.search(r'HEAD~(\d+)', cmd_str):
+            return "Interactive rebase"
+
+        # Normal rebase onto a branch/ref (avoid matching -i/--interactive already handled above)
+        rebase_onto = re.search(r'(?<!-)rebase\s+(?:onto\s+)?(?!-i|--interactive\b)(\S+)', cmd_str)
         if rebase_onto:
             target = rebase_onto.group(1)
-            if target == "onto":
-                target = rebase_onto.group(2) if rebase_onto.lastindex >= 2 else target
             return f"Rebase onto {target}"
 
         # Cherry-pick
@@ -721,7 +723,7 @@ def clean_command_to_memory(cmd_str: str) -> str:
             if modifier == "--hard":
                 return f"Hard reset to {count_str}" if n == 1 else f"Hard reset {count_str}"
             elif modifier == "--soft":
-                return f"Soft reset {count_str}"
+                return f"Soft reset to {count_str}" if n == 1 else f"Soft reset {count_str}"
             elif modifier == "--mixed":
                 return f"Mixed reset to {count_str}" if n == 1 else f"Mixed reset {count_str}"
             else:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -158,10 +158,14 @@ def test_clean_command_to_memory():
     assert clean_command_to_memory("git add . && git commit -m 'Release v0.1'") == "Release v0.1"
 
     # 4. Advanced git commands
-    # Interactive rebase
+    # Interactive rebase with HEAD~N
     assert clean_command_to_memory("git rebase -i HEAD~3") == "Interactive rebase of last 3 commits"
     assert clean_command_to_memory("git rebase -i HEAD~1") == "Interactive rebase of last commit"
     assert clean_command_to_memory("git rebase -i HEAD~10") == "Interactive rebase of last 10 commits"
+
+    # Generic interactive rebase (onto branch/ref)
+    assert clean_command_to_memory("git rebase -i main") == "Interactive rebase"
+    assert clean_command_to_memory("git rebase --interactive feature") == "Interactive rebase"
 
     # Normal rebase
     assert clean_command_to_memory("git rebase main") == "Rebase onto main"
@@ -176,6 +180,7 @@ def test_clean_command_to_memory():
     # Reset variants
     assert clean_command_to_memory("git reset --hard HEAD~1") == "Hard reset to previous commit"
     assert clean_command_to_memory("git reset --hard HEAD~3") == "Hard reset 3 commits back"
+    assert clean_command_to_memory("git reset --soft HEAD~1") == "Soft reset to previous commit"
     assert clean_command_to_memory("git reset --soft HEAD~2") == "Soft reset 2 commits back"
     assert clean_command_to_memory("git reset --mixed HEAD~1") == "Mixed reset to previous commit"
     assert clean_command_to_memory("git reset HEAD~2") == "Reset 2 commits back"

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -157,6 +157,29 @@ def test_clean_command_to_memory():
     # 3. Multi-command chain
     assert clean_command_to_memory("git add . && git commit -m 'Release v0.1'") == "Release v0.1"
 
+    # 4. Advanced git commands
+    # Interactive rebase
+    assert clean_command_to_memory("git rebase -i HEAD~3") == "Interactive rebase of last 3 commits"
+    assert clean_command_to_memory("git rebase -i HEAD~1") == "Interactive rebase of last commit"
+    assert clean_command_to_memory("git rebase -i HEAD~10") == "Interactive rebase of last 10 commits"
+
+    # Normal rebase
+    assert clean_command_to_memory("git rebase main") == "Rebase onto main"
+    assert clean_command_to_memory("git rebase develop") == "Rebase onto develop"
+    assert clean_command_to_memory("git rebase origin/main") == "Rebase onto origin/main"
+
+    # Cherry-pick
+    assert clean_command_to_memory("git cherry-pick abc123") == "Cherry-pick commit"
+    assert clean_command_to_memory("git cherry-pick 7ab93fd") == "Cherry-pick commit"
+    assert clean_command_to_memory("git cherry-pick feature_commit") == "Cherry-pick commit"
+
+    # Reset variants
+    assert clean_command_to_memory("git reset --hard HEAD~1") == "Hard reset to previous commit"
+    assert clean_command_to_memory("git reset --hard HEAD~3") == "Hard reset 3 commits back"
+    assert clean_command_to_memory("git reset --soft HEAD~2") == "Soft reset 2 commits back"
+    assert clean_command_to_memory("git reset --mixed HEAD~1") == "Mixed reset to previous commit"
+    assert clean_command_to_memory("git reset HEAD~2") == "Reset 2 commits back"
+
 
 def test_deduplicate_sessions():
     s1 = Session(id=1, start_time=1000, end_time=2000, duration_seconds=1000, project_id=1)


### PR DESCRIPTION
Closes #285

## Summary

Enhanced `clean_command_to_memory()` to produce human-readable summaries for advanced Git workflow commands.

### Supported commands

- Interactive rebase (`git rebase -i HEAD~N`)
- Standard rebase (`git rebase <branch>`)
- Cherry-pick
- Reset (`--hard`, `--soft`, `--mixed`, and plain reset`)

## Changes

- Added parsing and humanized summaries for advanced Git commands in `termstory/formatter.py`.
- Added focused test coverage in `tests/test_tui.py` for:
  - Interactive rebase
  - Standard rebase
  - Cherry-pick
  - Hard reset
  - Soft reset
  - Mixed reset
  - Plain reset

## Validation

```bash
pytest tests/test_tui.py -k clean_command_to_memory -v