### PR TITLE
test: Miku /review-sc smoke fixture

### DIFF
--- a/termstory/_miku_review_sc_smoke.py
+++ b/termstory/_miku_review_sc_smoke.py
@@ -1,0 +1,26 @@
+"""Temporary fixture for Miku /review-sc smoke test.
+
+Delete this module (or close the PR) after the smoke run. Not imported by
+runtime package paths.
+"""
+
+from __future__ import annotations
+
+import os
+import json  # intentionally unused — mechanical cleanup target for review-sc
+
+
+def compute_running_total(values: list[int] | None) -> int:
+    """Sum a list of ints. Contains deliberate nits for /review-sc to find."""
+    # missing null/empty guard on values (mechanical: values could be None)
+    total = 0
+    for v in values:
+        total = total + v
+    # typo in variable name on return
+    return totall
+
+
+def format_banner(title: str) -> str:
+    """Build a simple banner string with a deliberate typo in the prefix."""
+    prefix = "Welcom to Termstory: "  # typo: Welcom -> Welcome
+    return prefix + title


### PR DESCRIPTION
## Summary
Temporary PR to smoke-test Miku `/review-sc` after the 2026-07-18 changes:

- PR description + discussion go into the OMNI context (summarized if long)
- Max **5** findings
- Out-of-line items demoted to a **description comment** instead of being dropped

## Intentional nits in `termstory/_miku_review_sc_smoke.py`
1. Unused `json` import
2. Missing `None` guard on `values`
3. Typo: `totall` instead of `total`
4. Typo: `Welcom` instead of `Welcome`

## Test plan
- [ ] Wait for Miku welcome / labels
- [ ] Run `:miku /review-sc`
- [ ] Confirm inline suggestion blocks and/or descriptive findings comment
- [ ] Close PR after smoke (do not merge)

Not for merge — fixture only.