### PR TITLE
[Easy] exporter.py: honor TERMSTORY_DATE_OVERRIDE for numeric --since (fixes #316)

### DIFF
--- a/termstory/exporter.py
+++ b/termstory/exporter.py
@@ -7,6 +7,7 @@ from typing import List, Dict, Any, Optional
 from dateutil import parser as date_parser
 
 from termstory.database import Database
+from termstory.date_utils import get_current_time
 from termstory.models import Session, Command, Project
 
 def parse_since(since_str: Optional[str]) -> Optional[int]:
@@ -17,7 +18,7 @@ def parse_since(since_str: Optional[str]) -> Optional[int]:
     since_str = since_str.strip()
     if since_str.isdigit():
         days = int(since_str)
-        now = datetime.now()
+        now = get_current_time()
         dt = now - timedelta(days=days)
         # Start of that day
         start_of_day = datetime.combine(dt.date(), datetime.min.time())

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -55,6 +55,18 @@ def test_parse_since():
     with pytest.raises(ValueError):
         parse_since("not-a-date")
 
+def test_parse_since_with_date_override(monkeypatch):
+    monkeypatch.setenv("TERMSTORY_DATE_OVERRIDE", "2026-06-03 12:00:00")
+    parsed = parse_since("3")
+    assert parsed is not None
+    expected = int(datetime(2026, 5, 31, 0, 0, 0).timestamp())
+    assert parsed == expected
+
+def test_parse_since_date_string_unaffected(monkeypatch):
+    monkeypatch.setenv("TERMSTORY_DATE_OVERRIDE", "2026-06-03 12:00:00")
+    parsed = parse_since("2026-06-01")
+    assert parsed == int(datetime(2026, 6, 1, 0, 0).timestamp())
+
 def test_fetch_export_data(temp_db):
     # Test fetch all
     sessions = fetch_export_data(temp_db)


### PR DESCRIPTION
## Summary

Replaced `datetime.now()` with `date_utils.get_current_time()` in `parse_since` so that numeric `--since` values (e.g. `termstory export --since 3`) respect `TERMSTORY_DATE_OVERRIDE`, consistent with the rest of the CLI.

## Changes

- `termstory/exporter.py`: imported `get_current_time` from `date_utils` and used it instead of `datetime.now()` at line 20.

Fixes #316