### PR TITLE
[Easy] web.py: show Active instead of epoch for active sessions in HTML report (fixes #313)

### DIFF
--- a/termstory/web.py
+++ b/termstory/web.py
@@ -940,6 +940,7 @@ def generate_and_open_report(
         }}
 
         function formatTime(timestamp) {{
+            if (timestamp === null || timestamp === undefined) return "Active";
             const date = new Date(timestamp * 1000);
             return date.toLocaleTimeString(undefined, {{ hour: '2-digit', minute: '2-digit' }});
         }}

--- a/termstory/web.py
+++ b/termstory/web.py
@@ -923,6 +923,7 @@ def generate_and_open_report(
         }}
 
         function formatDuration(seconds) {{
+            if (seconds === null || seconds === undefined) return "Ongoing";
             if (seconds <= 0) return "0s";
             if (seconds < 60) return `${{seconds}}s`;
             const hours = Math.floor(seconds / 3600);


### PR DESCRIPTION
## Summary

Active sessions with `end_time: null` and `duration_seconds: null` displayed incorrect values in the web report timeline. JavaScript null coercion caused `formatTime` to render the Unix epoch (Jan 1, 1970) and `formatDuration` to show "0s". Added null guards to return "Active" and "Ongoing" respectively for ongoing sessions.

## Changes

- **Web Report JavaScript**: Added null/undefined checks to `formatDuration` and `formatTime` functions in `termstory/web.py`  
  - `formatDuration` now returns "Ongoing" for null/undefined seconds instead of coercing to 0
  - `formatTime` now returns "Active" for null/undefined timestamps instead of creating `new Date(0)`

## Fixes

- Fixes #313 — Active sessions now display "Active" / "Ongoing" instead of epoch time and "0s"

## Testing

Generate a web report with an active session (where `end_time` is `null`) and verify the timeline displays "Active" for the end time and "Ongoing" for duration instead of epoch timestamps.