### PR TITLE
[Easy] search.py: log FTS5 fallback failures instead of silent pass (fixes #295)

### DIFF
--- a/termstory/search.py
+++ b/termstory/search.py
@@ -1,6 +1,9 @@
+import logging
 import sqlite3
 from typing import List, Dict, Optional
 from termstory.database import Database
+
+logger = logging.getLogger(__name__)
 
 def advanced_search(
     db: Database,
@@ -21,8 +24,8 @@ def advanced_search(
         if fts and query:
             try:
                 return _search_new_fts5(conn, query, project_filter, since_ts, until_ts, tag_filters)
-            except sqlite3.OperationalError:
-                pass
+            except sqlite3.OperationalError as e:
+                logger.warning("FTS5 advanced search failed, falling back: %s", e)
 
         # Check if FTS5 is enabled
         fts_enabled = False
@@ -35,8 +38,8 @@ def advanced_search(
         if fts_enabled and query:
             try:
                 return _search_fts5(conn, query, project_filter, since_ts, until_ts, tag_filters)
-            except sqlite3.OperationalError:
-                pass
+            except sqlite3.OperationalError as e:
+                logger.warning("FTS5 search failed, falling back: %s", e)
                 
         return _search_standard(conn, query, project_filter, since_ts, until_ts, tag_filters)
     finally:

--- a/termstory/search.py
+++ b/termstory/search.py
@@ -24,8 +24,8 @@ def advanced_search(
         if fts and query:
             try:
                 return _search_new_fts5(conn, query, project_filter, since_ts, until_ts, tag_filters)
-            except sqlite3.OperationalError as e:
-                logger.warning("FTS5 advanced search failed, falling back: %s", e)
+            except sqlite3.OperationalError:
+                logger.warning("FTS5 advanced search failed, falling back", exc_info=True)
 
         # Check if FTS5 is enabled
         fts_enabled = False
@@ -38,8 +38,8 @@ def advanced_search(
         if fts_enabled and query:
             try:
                 return _search_fts5(conn, query, project_filter, since_ts, until_ts, tag_filters)
-            except sqlite3.OperationalError as e:
-                logger.warning("FTS5 search failed, falling back: %s", e)
+            except sqlite3.OperationalError:
+                logger.warning("FTS5 search failed, falling back", exc_info=True)
                 
         return _search_standard(conn, query, project_filter, since_ts, until_ts, tag_filters)
     finally:


### PR DESCRIPTION
## Summary

Adds logging to FTS5 fallback paths in `advanced_search` to diagnose search failures. Previously, bare `except sqlite3.OperationalError: pass` blocks silently swallowed errors when FTS5 queries failed, making it impossible to distinguish between corrupt indexes, missing tables, or other SQLite issues. This change adds warning logs with full traceback information before falling back to standard search, improving debuggability for search-related issues.

## Changes

- **Logging Infrastructure**: Added `import logging` and module-level `logger = logging.getLogger(__name__)` in `termstory/search.py`
- **FTS5 New Fallback**: Replaced silent `pass` with `logger.warning("FTS5 advanced search failed, falling back", exc_info=True)` in the `_search_new_fts5` exception handler at line 25
- **FTS5 Legacy Fallback**: Replaced silent `pass` with `logger.warning("FTS5 search failed, falling back", exc_info=True)` in the `_search_fts5` exception handler at line 39

## Fixes

- Fixes #295 — adds diagnostic logging to FTS5 fallback paths to identify why full-text search fails (corrupt index, missing tables, etc.)