### PR TITLE
[Easy] backup.py: catch OSError instead of bare except in backup rotation (fixes #296)

### DIFF
--- a/termstory/backup.py
+++ b/termstory/backup.py
@@ -1,9 +1,12 @@
+import logging
 import os
 import shutil
 import sqlite3
 import glob
 from datetime import datetime
 from termstory.config import get_db_path
+
+logger = logging.getLogger(__name__)
 
 
 def _get_backup_dir() -> str:
@@ -43,8 +46,8 @@ def backup_db() -> str:
             oldest = backups.pop(0)
             if os.path.exists(oldest):
                 os.remove(oldest)
-    except Exception:
-        pass  # Rotation failure should not crash the backup process
+    except OSError as e:
+        logger.warning("Failed to rotate old backups: %s", e)
 
     return backup_path
 


### PR DESCRIPTION
## Summary

This PR fixes overly broad error handling in the backup rotation logic of `termstory/backup.py` by replacing a bare `except Exception: pass` with a specific `except OSError` handler and adding logging to surface failures. The previous implementation silently swallowed all errors, including programming bugs, making debugging difficult. The change ensures that only filesystem-related errors are caught while logging rotation failures for observability.

## Changes

- **Error Handling**: Replaced `except Exception: pass` with `except OSError as e` in the backup rotation block of `backup_db()` to catch only filesystem-related errors from `os.path.exists()` and `os.remove()` 
- **Logging**: Added `import logging` and module-level `logger = logging.getLogger(__name__)` to enable structured logging 
- **Observability**: Added `logger.warning("Failed to rotate old backups: %s", e)` to log rotation failures instead of silently ignoring them 

## Fixes

- Fixes #296 — bare `except Exception` silently swallowed programming bugs in backup rotation

## Testing

Run the existing backup rotation test to verify the fix:
```bash
pytest tests/test_backup.py::test_backup_rotation -v
```

This test creates 12 backups and verifies that only 10 remain, exercising the rotation logic where the error handling change was made .

## Notes

The `OSError` exception family correctly covers expected filesystem errors including `PermissionError` and `FileNotFoundError` in Python 3, so no legitimate error cases are dropped by this change. Rotation failures are now logged but still do not crash the backup process, preserving the original design intent.