### PR TITLE
fix: handle active sessions with null end time

### DIFF
--- a/termstory/ask.py
+++ b/termstory/ask.py
@@ -156,7 +156,7 @@ def search_ask(query: str, db) -> List[Session]:
                 OR (f.type = 'command' AND CAST(f.ref_id AS INTEGER) = s.id)
                 OR (f.type = 'commit' AND s.project_id = CAST(f.project_id AS INTEGER)
                     AND CAST(f.timestamp AS INTEGER) >= s.start_time - 300
-                    AND CAST(f.timestamp AS INTEGER) <= s.end_time + 600)
+                    AND CAST(f.timestamp AS INTEGER) <= COALESCE(s.end_time, s.start_time) + 600)
             )
             WHERE f.ref_id IS NOT NULL
         """
@@ -196,7 +196,7 @@ def search_ask(query: str, db) -> List[Session]:
                 LEFT JOIN commands c ON s.id = c.session_id
                 LEFT JOIN commits co ON s.project_id = co.project_id
                     AND co.timestamp >= s.start_time - 300
-                    AND co.timestamp <= s.end_time + 600
+                    AND co.timestamp <= COALESCE(s.end_time, s.start_time) + 600
                 WHERE {" OR ".join(where_clauses)}
             """
             cursor.execute(sql, params)

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -882,3 +882,24 @@ def test_generate_answer_redacts_github_pat_in_commit(monkeypatch):
     assert res == "ok"
     sent_prompt = called_prompts[0]
     assert "ghp_ASKSECRET1234567890abcdef" not in sent_prompt
+
+def test_search_ask_active_session_with_null_end_time(tmp_path):
+    db_file = tmp_path / "test_ask_active_session.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    now = 1700000000
+    p = Project(id=1, name="ActiveSessionProject", path="~/active", first_seen=now, last_seen=now, session_count=1, total_time=100)
+    
+    # Session with end_time=None
+    cmd = Command(timestamp=now, command="git push origin main", session_id=1, project_id=1)
+    s = Session(id=1, start_time=now, end_time=None, duration_seconds=0, project_id=1, commands=[cmd])
+    s.ai_summary = "Working on active session"
+    
+    db.save_data([p], [s], [cmd])
+    db.save_session_ai_summary(1, s.ai_summary)
+
+    # We expect this to match despite end_time being None
+    results = search_ask("active session", db)
+    assert len(results) == 1
+    assert results[0].id == 1


### PR DESCRIPTION
## Description

This PR fixes an issue where active sessions (`end_time = NULL`) were incorrectly excluded from `termstory ask` retrieval due to SQL `NULL` handling.

### Changes
- Updated both the FTS and LIKE fallback SQL queries in `termstory/ask.py` to use:
  ```sql
  COALESCE(s.end_time, s.start_time) + 600
  ```
  instead of:
  ```sql
  s.end_time + 600
  ```
- Aligned the session matching logic with the existing implementation in `search.py` and `database.py`.
- Added a regression test covering an active session with `end_time = NULL` to ensure it is correctly returned by the ask retrieval helper.

- Fixes #298

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the "density over decoration" philosophy.
- [x] I have not used `rich.panel.Panel` in my code.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.