### PR TITLE
fix: validate predict CLI arguments

### DIFF
--- a/termstory/predict.py
+++ b/termstory/predict.py
@@ -304,6 +304,11 @@ class Predictor:
                 "message": "No history available"  # only if empty
             }
         """
+        if top_n <= 0:
+            raise ValueError("top must be greater than 0")
+        if days is not None and days <= 0:
+            raise ValueError("days must be greater than 0")
+
         if now is None:
             now = datetime.now()
         tz = now.tzinfo

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -616,3 +616,20 @@ class TestPredictorOngoingSessionsAndTimezone:
             assert "morning" in res_est["time_context"]
         finally:
             os.unlink(db_path)
+
+class TestPredictorValidation:
+    def test_invalid_top(self):
+        p = Predictor("dummy.db")
+        with pytest.raises(ValueError, match="top must be greater than 0"):
+            p.predict(top_n=0)
+            
+        with pytest.raises(ValueError, match="top must be greater than 0"):
+            p.predict(top_n=-1)
+
+    def test_invalid_days(self):
+        p = Predictor("dummy.db")
+        with pytest.raises(ValueError, match="days must be greater than 0"):
+            p.predict(days=0)
+            
+        with pytest.raises(ValueError, match="days must be greater than 0"):
+            p.predict(days=-5)


### PR DESCRIPTION
## Description

This PR fixes validation for the `predict` command by ensuring the `--top` and `--days` arguments accept only positive integer values.

Previously, negative or zero values were accepted, resulting in misleading behavior or incorrect prediction results instead of failing fast with a clear error message.

### Changes
- Added validation to reject `top_n <= 0`.
- Added validation to reject `days <= 0` when `days` is provided.
- Raised clear `ValueError` messages before any prediction or database operations are performed.
- Added regression tests covering negative and zero values for both `--top` and `--days`.

- Fixes #348

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the "density over decoration" philosophy.
- [x] I have not used `rich.panel.Panel` in my code.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.