### PR TITLE
Fix AI onboarding when AI is already configured

### DIFF
--- a/termstory/tui.py
+++ b/termstory/tui.py
@@ -2215,9 +2215,27 @@ class TermStoryWorkspace(App):
         tree = self.query_one("#history-navigator")
         tree.populate(self.projects, self.sessions)
         
-        # Handle onboarding or start summarization
-        if not self.config.get("has_seen_onboarding", False):
-            self.push_screen(OnboardingScreen(self.config), self.handle_onboarding_result)
+        # Show onboarding only if the user hasn't completed onboarding and AI is not already configured.
+        has_seen_onboarding = self.config.get("has_seen_onboarding", False)
+        ai_enabled = self.config.get("ai_enabled", False)
+        active_provider = self.config.get("active_provider", "disabled")
+
+        providers = self.config.get("providers", {})
+        provider_cfg = providers.get(active_provider, {}) if isinstance(providers, dict) else {}
+
+        api_key = provider_cfg.get("api_key")
+
+        ai_already_configured = (
+            ai_enabled
+            and active_provider not in ("", "disabled", None)
+            and bool(api_key)
+        )
+
+        if not has_seen_onboarding and not ai_already_configured:
+            self.push_screen(
+                OnboardingScreen(self.config),
+                self.handle_onboarding_result,
+            )
         
         # Automatically focus today's date node or the most recent date node
         if self.auto_select_today_on_mount:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -339,6 +339,77 @@ async def test_tui_action_show_onboarding():
 
 
 @pytest.mark.asyncio
+async def test_tui_skips_onboarding_when_ai_already_configured():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        db_path = os.path.join(tmp_dir, "test.db")
+        db = Database(db_path)
+        db.init_db()
+
+        app = TermStoryWorkspace(
+            db,
+            days_limit=30,
+            config_override={
+                "has_seen_onboarding": False,
+                "ai_enabled": True,
+                "active_provider": "groq",
+                "providers": {
+                    "groq": {
+                        "api_key": "dummy-key"
+                    }
+                },
+            },
+        )
+
+        async with app.run_test():
+            assert not isinstance(app.screen, OnboardingScreen)
+
+
+@pytest.mark.asyncio
+async def test_tui_shows_onboarding_when_api_key_missing():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        db_path = os.path.join(tmp_dir, "test.db")
+        db = Database(db_path)
+        db.init_db()
+
+        app = TermStoryWorkspace(
+            db,
+            days_limit=30,
+            config_override={
+                "has_seen_onboarding": False,
+                "ai_enabled": True,
+                "active_provider": "groq",
+                "providers": {
+                    "groq": {}
+                },
+            },
+        )
+
+        async with app.run_test():
+            assert isinstance(app.screen, OnboardingScreen)
+
+
+@pytest.mark.asyncio
+async def test_tui_shows_onboarding_when_provider_disabled():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        db_path = os.path.join(tmp_dir, "test.db")
+        db = Database(db_path)
+        db.init_db()
+
+        app = TermStoryWorkspace(
+            db,
+            days_limit=30,
+            config_override={
+                "has_seen_onboarding": False,
+                "ai_enabled": True,
+                "active_provider": "disabled",
+            },
+        )
+
+        async with app.run_test():
+            assert isinstance(app.screen, OnboardingScreen)
+
+
+@pytest.mark.asyncio
 async def test_tui_onboarding_click_disabled():
     """Verify 'Keep Local Only' (ctrl+d -> action_choose_disabled) sets
     has_seen_onboarding=True, ai_enabled=False on OnboardingScreen.config.


### PR DESCRIPTION
## Summary
This PR fixes the TUI displaying the AI onboarding screen for users who already have a configured and active AI provider. The fix adds a compound check in `on_mount` to skip onboarding when AI is enabled, a non-disabled provider is active, and an API key is configured, while preserving the onboarding flow for new users.

## Changes
- **Core**: Modified `TermStoryWorkspace.on_mount` in `termstory/tui.py` to add `ai_already_configured` check that evaluates `ai_enabled`, `active_provider` (excluding `"disabled"`, `""`, `None`), and `api_key` presence before pushing `OnboardingScreen` 
- **Core**: Added defensive `isinstance(providers, dict)` check when accessing provider configuration 
- **Tests**: Added `test_tui_skips_onboarding_when_ai_already_configured` to verify onboarding is skipped when AI is fully configured 
- **Tests**: Added `test_tui_shows_onboarding_when_api_key_missing` to verify onboarding appears when API key is absent 
- **Tests**: Added `test_tui_shows_onboarding_when_provider_disabled` to verify onboarding appears when provider is set to "disabled" 

## Architecture / Flow
```mermaid
flowchart TD
    A[on_mount] --> B{has_seen_onboarding?}
    B -->|False| C{ai_already_configured?}
    B -->|True| D[Skip onboarding]
    C -->|True| D
    C -->|False| E[Push OnboardingScreen]
    
    C --> F{ai_enabled?}
    F -->|False| C
    F -->|True| G{active_provider not disabled?}
    G -->|False| C
    G -->|True| H{api_key present?}
    H -->|False| C
    H -->|True| C
```

## Fixes
- Fixes #344 — AI onboarding screen shown to users with already configured providers

## Testing
Run the new test cases to verify the fix:
```bash
pytest tests/test_tui.py::test_tui_skips_onboarding_when_ai_already_configured
pytest tests/test_tui.py::test_tui_shows_onboarding_when_api_key_missing
pytest tests/test_tui.py::test_tui_shows_onboarding_when_provider_disabled
```