### PR TITLE
fix: make today comparison opt-in by default

### DIFF
--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -280,7 +280,7 @@ def search_history(
 
 @app.command("today")
 def show_today(
-    compare: bool = typer.Option(True, "--compare/--no-compare", help="Compare with yesterday's metrics")
+    compare: bool = typer.Option(False, "--compare/--no-compare", help="Compare each project's time with yesterday")
 ):
     """Show today's work summary"""
     db_path = get_db_path()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -620,6 +620,99 @@ def test_cli_project_context_command(tmp_path, monkeypatch):
     assert "This project is for graph databases" in result_show.stdout.strip()
 
 
+def test_cli_today_compare_flag_defaults_to_false(tmp_path, monkeypatch):
+    db_file = tmp_path / "test_cli_today.db"
+    monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.cli.get_history_files", lambda: [])
+    monkeypatch.setattr("termstory.cli.run_ingestion", lambda db: None)
+
+    db = Database(str(db_file))
+    db.init_db()
+
+    from termstory.date_utils import get_current_time
+    now = int(get_current_time().timestamp())
+    p = Project(id=1, name="HugeGraph", path="~/projects/incubator-hugegraph", first_seen=now, last_seen=now, session_count=1, total_time=100)
+    cmd = Command(timestamp=now, command="docker run nginx", session_id=1, project_id=1)
+    s = Session(id=1, start_time=now, end_time=now + 100, duration_seconds=100, project_id=1, commands=[cmd])
+    db.save_data([p], [s], [cmd])
+
+    captured = []
+    def mock_format_today_output(sessions, projects, compare_sessions=None):
+        captured.append({"compare_sessions": compare_sessions})
+        return "Today summary"
+
+    monkeypatch.setattr("termstory.cli.format_today_output", mock_format_today_output)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["today"])
+    assert result.exit_code == 0
+    assert len(captured) == 1
+    assert captured[0]["compare_sessions"] is None
+
+
+def test_cli_today_compare_flag_enabled(tmp_path, monkeypatch):
+    db_file = tmp_path / "test_cli_today_compare.db"
+    monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.cli.get_history_files", lambda: [])
+    monkeypatch.setattr("termstory.cli.run_ingestion", lambda db: None)
+
+    db = Database(str(db_file))
+    db.init_db()
+
+    from termstory.date_utils import get_current_time
+    now = int(get_current_time().timestamp())
+    p = Project(id=1, name="HugeGraph", path="~/projects/incubator-hugegraph", first_seen=now, last_seen=now, session_count=1, total_time=100)
+    cmd = Command(timestamp=now, command="docker run nginx", session_id=1, project_id=1)
+    s = Session(id=1, start_time=now, end_time=now + 100, duration_seconds=100, project_id=1, commands=[cmd])
+    db.save_data([p], [s], [cmd])
+
+    captured = []
+    def mock_format_today_output(sessions, projects, compare_sessions=None):
+        captured.append({"compare_sessions": compare_sessions})
+        return "Today summary"
+
+    monkeypatch.setattr("termstory.cli.format_today_output", mock_format_today_output)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["today", "--compare"])
+    assert result.exit_code == 0
+    assert len(captured) == 1
+    assert captured[0]["compare_sessions"] is not None
+
+
+def test_cli_today_no_compare_flag_explicit(tmp_path, monkeypatch):
+    db_file = tmp_path / "test_cli_today_nocompare.db"
+    monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.cli.get_history_files", lambda: [])
+    monkeypatch.setattr("termstory.cli.run_ingestion", lambda db: None)
+
+    db = Database(str(db_file))
+    db.init_db()
+
+    from termstory.date_utils import get_current_time
+    now = int(get_current_time().timestamp())
+    p = Project(id=1, name="HugeGraph", path="~/projects/incubator-hugegraph", first_seen=now, last_seen=now, session_count=1, total_time=100)
+    cmd = Command(timestamp=now, command="docker run nginx", session_id=1, project_id=1)
+    s = Session(id=1, start_time=now, end_time=now + 100, duration_seconds=100, project_id=1, commands=[cmd])
+    db.save_data([p], [s], [cmd])
+
+    captured = []
+    def mock_format_today_output(sessions, projects, compare_sessions=None):
+        captured.append({"compare_sessions": compare_sessions})
+        return "Today summary"
+
+    monkeypatch.setattr("termstory.cli.format_today_output", mock_format_today_output)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["today", "--no-compare"])
+    assert result.exit_code == 0
+    assert len(captured) == 1
+    assert captured[0]["compare_sessions"] is None
+
+
 def test_cli_predict_enhanced_command(tmp_path, monkeypatch):
     db_file = tmp_path / "test_cli_predict_enhanced.db"
     monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))


### PR DESCRIPTION
Closes #347
## Summary

This PR changes the default behavior of the `today` command so that comparison with yesterday is shown only when explicitly requested using `--compare`.

## Changes

- Changed the default value of the `compare` CLI option from `True` to `False`.
- Updated the help text to clarify that comparison is optional.
- Added regression tests covering:
  - Default `today` command behavior
  - `--compare`
  - `--no-compare`

## Behavior

### Before

```bash
termstory today
```

Displayed today's summary along with comparison against yesterday.

### After

```bash
termstory today
```

Displays only today's summary.

```bash
termstory today --compare
```

Displays today's summary together with comparison against yesterday.

```bash
termstory today --no-compare
```

Explicitly disables comparison (same as the default behavior).


## Testing

- Added regression tests for all compare flag behaviors.
- Verified CLI help shows `--compare / --no-compare` with the default set to `no-compare`.
- ✅ `pytest tests/test_cli_commands.py -k today`
- ✅ `pytest tests/test_cli_commands.py`
- Verified only the intended files were modified.