### PR TITLE
feat(rag): zero-keyword semantic search via query expansion + command preprocessing

### DIFF
--- a/termstory/AGENTS.md
+++ b/termstory/AGENTS.md
@@ -1,78 +1,82 @@
 # termstory/ — Source Package
 
-This directory contains the core implementation of TermStory, including the command-line interface, data storage, parsing pipeline, AI integrations, terminal user interface, and supporting utilities.
+This directory contains the core implementation of **TermStory**, including the command-line interface, data storage, parsing pipeline, AI integrations, terminal user interface, and supporting utilities.
 
 ---
 
-# Entry Points
+## Entry Points
 
-- `cli.py` — Main Typer-based command-line interface coordinating application features.
-- `__main__.py` — Executes the package as `python -m termstory` by invoking the CLI entry point.
-- `__init__.py` — Package initialization and version information.
-
----
-
-# Core Infrastructure
-
-- `config.py` — Loads, saves, and manages application configuration and data directories.
-- `database.py` — SQLite database layer responsible for persistence and connection management.
-- `models.py` — Shared data models used across the application.
-- `date_utils.py` — Common date and time helper utilities.
-- `sanitizer.py` — Utilities for sanitizing terminal history and sensitive information.
+* `cli.py` — Main Typer-based command-line interface coordinating application features.
+* `__main__.py` — Executes the package as `python -m termstory` by invoking the CLI entry point.
+* `__init__.py` — Package initialization and version information.
 
 ---
 
-# History Processing
+## Core Infrastructure
 
-- `parser.py` — Parses terminal history into application data structures.
-- `session.py` — Session grouping and session-related logic.
-- `timestamp_detective.py` — Timestamp detection and recovery utilities.
-- `archive.py` — Archive management and archive-related database operations.
-
----
-
-# AI & Analysis
-
-- `ai.py` — AI provider integration and language model communication.
-- `ask.py` — AI-powered querying of stored terminal history.
-- `rag.py` — Retrieval-augmented generation functionality.
-- `predict.py` — Prediction-related functionality.
-- `insights.py` — Insight generation utilities.
+* `config.py` — Loads, saves, and manages application configuration and data directories.
+* `database.py` — SQLite database layer responsible for persistence and connection management.
+* `models.py` — Shared data models used across the application.
+* `date_utils.py` — Common date and time helper utilities.
+* `sanitizer.py` — Utilities for sanitizing terminal history and sensitive information.
 
 ---
 
-# User Interface
+## History Processing
 
-- `tui.py` — Textual terminal user interface.
-- `formatter.py` — Formatting and rendering helpers.
-- `timeline.py` — Timeline-related functionality.
-- `replay.py` — Replay-related functionality.
-
----
-
-# Search & Organization
-
-- `search.py` — Search-related functionality.
-- `project.py` — Project-related utilities.
-- `tags.py` — Tag management utilities.
-- `stats.py` — Statistics and analytics utilities.
-- `notebook.py` — Notebook-related functionality.
-- `reminder.py` — Reminder-related functionality.
+* `parser.py` — Parses terminal history into application data structures.
+* `session.py` — Session grouping and session-related logic.
+* `timestamp_detective.py` — Timestamp detection and recovery utilities.
+* `archive.py` — Archive management and archive-related database operations.
 
 ---
 
-# Integrations
+## AI & Analysis
 
-- `git_integration.py` — Git integration utilities.
-- `web.py` — Web-related functionality.
-- `exporter.py` — Export functionality.
-- `backup.py` — Database backup utilities.
-- `mcp_snapshot.py` — MCP snapshot utilities.
-- `hermes_obs.py` — Hermes observability and integration utilities.
+* `ai.py` — AI provider integration and language model communication.
+* `ask.py` — AI-powered querying of stored terminal history.
+* `rag.py` — Retrieval-augmented generation: hybrid BM25 + cosine-similarity search over terminal sessions. Supports zero-keyword queries via:
+  * (a) topic-anchor query expansion (`_expand_query`)
+  * (b) command-shorthand preprocessing (`_preprocess_command_text`) so the embedding model receives natural-language signal
+  * (c) an enlarged bounded fallback candidate pool when FTS returns no matches.
+  * Includes a semantic-only mode (`alpha >= 0.999`) that bypasses FTS entirely.
+* `predict.py` — Prediction-related functionality.
+* `insights.py` — Insight generation utilities.
 
 ---
 
-# Data Flow
+## User Interface
+
+* `tui.py` — Textual terminal user interface.
+* `formatter.py` — Formatting and rendering helpers.
+* `timeline.py` — Timeline-related functionality.
+* `replay.py` — Replay-related functionality.
+
+---
+
+## Search & Organization
+
+* `search.py` — Search-related functionality (FTS5 + standard `LIKE`-based fallback).
+* `project.py` — Project-related utilities.
+* `tags.py` — Tag management utilities.
+* `stats.py` — Statistics and analytics utilities.
+* `notebook.py` — Notebook-related functionality.
+* `reminder.py` — Reminder-related functionality.
+
+---
+
+## Integrations
+
+* `git_integration.py` — Git integration utilities.
+* `web.py` — Web-related functionality.
+* `exporter.py` — Export functionality.
+* `backup.py` — Database backup utilities.
+* `mcp_snapshot.py` — MCP snapshot utilities.
+* `hermes_obs.py` — Hermes observability and integration utilities.
+
+---
+
+## Data Flow
 
 A typical processing flow is:
 
@@ -87,19 +91,21 @@ A typical processing flow is:
 
 ---
 
-# Key Conventions
+## Key Conventions
 
-- The application uses a SQLite database for persistent storage.
-- Configuration is managed through `config.py` and stored in the application's configuration directory.
-- The Textual interface uses `call_after_refresh(...)` when UI updates must occur after screen refresh.
-- Background tasks use Textual's `@work` decorator where appropriate.
-- Shared models and utilities are designed to be reused across CLI, TUI, AI, and analysis components.
+* The application uses a SQLite database for persistent storage.
+* Configuration is managed through `config.py` and stored in the application's configuration directory.
+* The Textual interface uses `call_after_refresh(...)` when UI updates must occur after screen refresh.
+* Background tasks use Textual's `@work` decorator where appropriate.
+* Shared models and utilities are designed to be reused across CLI, TUI, AI, and analysis components.
+* The `rag.py` module is the single entry point for semantic search. It does **NOT** invoke any LLM directly — all embeddings are computed locally via `sentence-transformers`. Sanitization of LLM-facing inputs remains the responsibility of the caller (e.g., `ask.py`, `ai.py`).
 
 ---
 
-# Notes for Contributors
+## Notes for Contributors
 
-- Keep module responsibilities focused and cohesive.
-- Reuse shared helpers from `config.py`, `database.py`, `date_utils.py`, and `models.py` where appropriate.
-- Prefer extending existing modules before introducing new abstractions.
-- Follow existing project structure and naming conventions when adding features.
+* Keep module responsibilities focused and cohesive.
+* Reuse shared helpers from `config.py`, `database.py`, `date_utils.py`, and `models.py` where appropriate.
+* Prefer extending existing modules before introducing new abstractions.
+* Follow existing project structure and naming conventions when adding features.
+* **When extending `rag.py`:** The query-expansion (`_TOPIC_EXPANSIONS`) and command-preprocessing (`_COMMAND_VERB_MAP`) maps are intentionally small and conservative. Add new entries only when you have a concrete failing test case demonstrating the gap. Avoid aggressive expansion — it can dilute the embedding signal for normal keyword queries.

--- a/termstory/rag.py
+++ b/termstory/rag.py
@@ -26,6 +26,146 @@ def clear_model_cache():
         _model_cache.clear()
 
 
+# ---------------------------------------------------------------------------
+# Domain-specific preprocessing maps for command/commit embeddings
+# ---------------------------------------------------------------------------
+#
+# all-MiniLM-L6-v2 is a general-purpose sentence embedding model trained on
+# natural-language text. Raw shell commands and short commit subjects are
+# *not* natural language, so the model produces poor embeddings for them.
+# The two maps below are lightweight, rule-based preprocessing aids that
+# bridge this vocabulary gap without requiring a custom-trained model:
+#
+#   * `_COMMAND_VERB_MAP` expands common shell shorthands into natural-
+#     language phrases (e.g. "ps" -> "process status") so the embedding has
+#     something meaningful to encode.
+#
+#   * `_TOPIC_EXPANSIONS` maps abstract conceptual query terms to the
+#     concrete vocabulary that typically appears in commits/commands. This
+#     is what powers zero-keyword queries: a user searching "containerization"
+#     gets the query enriched with "docker, kubernetes, k8s, compose, pod"
+#     before embedding, so the cosine similarity against a `docker ps -a`
+#     session is meaningfully non-zero.
+#
+# Both maps are intentionally small and conservative. They are NOT used for
+# FTS/BM25 retrieval (which still operates on the raw query) — only for the
+# semantic embedding step. This keeps lexical scoring unaffected while
+# improving recall for conceptual queries.
+
+_COMMAND_VERB_MAP: Dict[str, str] = {
+    "ps": "process status",
+    "ls": "list files",
+    "ll": "list files long",
+    "rm": "remove delete",
+    "rmdir": "remove directory",
+    "cp": "copy",
+    "mv": "move rename",
+    "cd": "change directory",
+    "cat": "concatenate print file",
+    "less": "view file",
+    "head": "show file head",
+    "tail": "show file tail",
+    "grep": "search text",
+    "find": "find files",
+    "ssh": "secure shell remote login",
+    "scp": "secure copy remote",
+    "rsync": "sync files remote",
+    "curl": "http request",
+    "wget": "download",
+    "tar": "archive extract",
+    "zip": "compress archive",
+    "unzip": "extract archive",
+    "gzip": "compress",
+    "gunzip": "decompress",
+    "chmod": "change permissions",
+    "chown": "change owner",
+    "chgrp": "change group",
+    "sudo": "superuser privileged",
+    "kill": "terminate process",
+    "killall": "terminate processes by name",
+    "top": "process monitor",
+    "htop": "process monitor interactive",
+    "df": "disk free space",
+    "du": "disk usage",
+    "free": "memory usage",
+    "ifconfig": "network interface config",
+    "ipconfig": "network interface config",
+    "ping": "network reachability test",
+    "netstat": "network connections",
+    "ss": "socket statistics",
+    "traceroute": "network route trace",
+    "dig": "dns lookup",
+    "nslookup": "dns lookup",
+    "git": "version control",
+    "docker": "container runtime",
+    "kubectl": "kubernetes control",
+    "helm": "kubernetes package manager",
+    "npm": "node package manager",
+    "yarn": "node package manager",
+    "pip": "python package installer",
+    "pipenv": "python environment",
+    "poetry": "python dependency manager",
+    "cargo": "rust package manager",
+    "go": "golang",
+    "make": "build tool",
+    "cmake": "build system",
+    "pytest": "python test runner",
+    "jest": "javascript test runner",
+    "mocha": "javascript test runner",
+    "tox": "python test environments",
+    "ansible": "configuration automation",
+    "terraform": "infrastructure as code",
+    "vagrant": "development environment",
+    "systemctl": "service control",
+    "journalctl": "system logs",
+    "crontab": "scheduled tasks",
+    "openssl": "ssl tls crypto",
+}
+
+# Maps abstract conceptual query terms to the concrete vocabulary that
+# typically appears in commands/commits. Used only for query expansion in
+# `_expand_query()` — never used for FTS/BM25 retrieval.
+_TOPIC_EXPANSIONS: Dict[str, List[str]] = {
+    "containerization": ["docker", "container", "kubernetes", "k8s", "compose", "pod"],
+    "container": ["docker", "pod", "kubernetes", "compose"],
+    "containers": ["docker", "pod", "kubernetes", "compose"],
+    "orchestration": ["kubernetes", "k8s", "helm", "compose", "swarm"],
+    "deployment": ["deploy", "release", "kubernetes", "helm", "ci", "cd", "rollout"],
+    "deploy": ["deployment", "release", "rollout", "kubernetes"],
+    "ci": ["continuous integration", "github actions", "gitlab ci", "jenkins"],
+    "cd": ["continuous deployment", "release", "rollout"],
+    "testing": ["test", "pytest", "unittest", "mock", "fixture", "jest"],
+    "test": ["pytest", "unittest", "mock", "fixture", "jest", "mocha"],
+    "tests": ["pytest", "unittest", "mock", "fixture", "jest"],
+    "debugging": ["debug", "pdb", "traceback", "breakpoint", "gdb", "lldb"],
+    "debug": ["pdb", "breakpoint", "traceback", "gdb"],
+    "database": ["sql", "postgres", "mysql", "sqlite", "migration", "query", "db"],
+    "migration": ["migrate", "alembic", "schema", "database"],
+    "refactoring": ["refactor", "cleanup", "rename", "extract", "simplify", "restructure"],
+    "refactor": ["cleanup", "rename", "extract", "restructure"],
+    "performance": ["profile", "benchmark", "optimize", "perf", "slow", "latency"],
+    "optimization": ["optimize", "profile", "benchmark", "perf"],
+    "profiling": ["profile", "perf", "benchmark", "flamegraph"],
+    "security": ["auth", "vulnerability", "sanitize", "encrypt", "token", "jwt", "cve"],
+    "vulnerability": ["cve", "security", "patch", "sanitize"],
+    "documentation": ["docs", "readme", "sphinx", "mkdocs", "docstring", "javadoc"],
+    "docs": ["readme", "sphinx", "mkdocs", "docstring"],
+    "networking": ["http", "tcp", "socket", "api", "request", "endpoint", "rest"],
+    "network": ["http", "tcp", "socket", "api", "endpoint"],
+    "auth": ["login", "token", "jwt", "session", "oauth", "password", "authenticate"],
+    "authentication": ["login", "token", "jwt", "oauth", "session"],
+    "authorization": ["permission", "rbac", "role", "access"],
+    "git": ["commit", "branch", "merge", "rebase", "push", "pull", "checkout"],
+    "version control": ["git", "commit", "branch", "merge", "svn"],
+    "build": ["compile", "make", "cmake", "webpack", "babel", "tsc"],
+    "compilation": ["compile", "gcc", "clang", "make", "cmake"],
+    "linting": ["lint", "flake8", "pylint", "eslint", "ruff"],
+    "formatting": ["format", "black", "prettier", "gofmt", "rustfmt"],
+    "logging": ["log", "logger", "logging", "loguru", "structured log"],
+    "monitoring": ["monitor", "prometheus", "grafana", "datadog", "metric"],
+    "observability": ["trace", "span", "otel", "opentelemetry", "metric", "log"],
+}
+
 
 class BM25:
     """
@@ -40,7 +180,7 @@ class BM25:
         self.doc_freqs = {}
         self.idf = {}
         self.doc_term_freqs = []
-        
+
         # Initialize frequencies
         for doc in corpus:
             tf = {}
@@ -49,7 +189,7 @@ class BM25:
             self.doc_term_freqs.append(tf)
             for term in tf:
                 self.doc_freqs[term] = self.doc_freqs.get(term, 0) + 1
-                
+
         # Calculate IDF
         for term, freq in self.doc_freqs.items():
             # Standard BM25 IDF formula with smoothing to avoid negative values
@@ -59,7 +199,7 @@ class BM25:
         score = 0.0
         tf = self.doc_term_freqs[doc_index]
         doc_len = self.doc_lengths[doc_index]
-        
+
         for term in query_terms:
             if term not in tf:
                 continue
@@ -78,10 +218,130 @@ def tokenize(text: str) -> List[str]:
     return re.findall(r'\w+', text.lower())
 
 
+def _expand_query(query: str) -> str:
+    """
+    Expands a (potentially zero-keyword) query with semantically related
+    anchor terms before embedding.
+
+    Background
+    ----------
+    all-MiniLM-L6-v2 is a general-purpose sentence embedding model. When the
+    user issues a conceptual query like "containerization" against a corpus
+    of literal shell commands (`docker ps -a`) and short commit subjects,
+    the cosine similarity between the query embedding and the document
+    embedding is often near zero — not because the documents are irrelevant,
+    but because the vocabularies don't overlap.
+
+    This function bridges that gap by appending concrete anchor vocabulary
+    to the query. The original query is always preserved verbatim at the
+    front so the embedding stays anchored to the user's actual phrasing;
+    the appended terms just give the model additional signal.
+
+    Scope
+    -----
+    This expansion is used ONLY for the semantic embedding step. The FTS /
+    BM25 retrieval paths still operate on the raw `query`. This keeps the
+    lexical scoring deterministic and unaffected by the expansion heuristic.
+
+    Security
+    --------
+    No LLM is invoked. The expansion map is static and lives in source. The
+    returned string is only ever fed to the local sentence-transformers
+    model, so there is no prompt-injection surface.
+    """
+    if not query:
+        return query
+    query_lower = query.lower()
+    tokens = re.findall(r'\w+', query_lower)
+    expansions: List[str] = []
+    seen = set(tokens)
+
+    # Single-token anchors (e.g. "containerization" -> ["docker", "k8s", ...])
+    for token in tokens:
+        for anchor in _TOPIC_EXPANSIONS.get(token, []):
+            if anchor not in seen:
+                expansions.append(anchor)
+                seen.add(anchor)
+
+    # Multi-word phrase anchors (e.g. "version control" -> ["git", ...]).
+    # Only triggered when the phrase appears verbatim in the query.
+    for phrase, anchors in _TOPIC_EXPANSIONS.items():
+        if ' ' in phrase and phrase in query_lower:
+            for anchor in anchors:
+                if anchor not in seen:
+                    expansions.append(anchor)
+                    seen.add(anchor)
+
+    if not expansions:
+        return query
+    # Cap the expansion to keep the embedding anchored to the original query.
+    return f"{query} (related: {', '.join(expansions[:8])})"
+
+
+def _preprocess_command_text(command: str) -> str:
+    """
+    Preprocesses a raw shell command into a more natural-language-like form
+    before embedding.
+
+    Why
+    ---
+    all-MiniLM-L6-v2 is trained on natural-language text. A raw command
+    string like `ps -a` produces a near-meaningless embedding because the
+    token "ps" carries no semantic signal to the model. Expanding such
+    shorthands to natural-language phrases (`ps` -> `process status`)
+    gives the model a much stronger signal to match against conceptual
+    queries like "list running processes".
+
+    Scope
+    -----
+    Applied only at embedding time, inside `_build_session_document()`. The
+    raw command string is preserved everywhere else (FTS index, BM25
+    corpus tokenization is unaffected because `tokenize()` strips non-word
+    chars anyway, and `matching_commands` is computed against raw commands).
+    """
+    if not command:
+        return ""
+    tokens = command.split()
+    expanded: List[str] = []
+    for tok in tokens:
+        # Strip leading dashes for lookup, but preserve the original token
+        # in the output so the raw command form is still recoverable.
+        bare = tok.lstrip('-').lower()
+        mapped = _COMMAND_VERB_MAP.get(bare)
+        if mapped:
+            expanded.append(f"{tok} ({mapped})")
+        else:
+            expanded.append(tok)
+    return " ".join(expanded)
+
+
+def _build_session_document(session: Dict) -> str:
+    """
+    Builds a natural-language-rich document representation of a session for
+    embedding. Commands are preprocessed via `_preprocess_command_text()` to
+    expand common shorthands; commit messages are kept as-is because they
+    are already natural language. The project name and AI summary are
+    included verbatim to give the embedding model the same context a human
+    reviewer would have.
+    """
+    cmd_str = " ".join(
+        _preprocess_command_text(c) for c in session.get("all_commands", [])
+    )
+    commit_str = " ".join(
+        c.get("message", "") for c in session.get("all_commits", [])
+    )
+    return (
+        f"Project: {session.get('project_name', '')}\n"
+        f"Summary: {session.get('ai_summary') or ''}\n"
+        f"Commands: {cmd_str}\n"
+        f"Commits: {commit_str}"
+    )
+
+
 def get_embeddings(texts: List[str], model_name: str = "all-MiniLM-L6-v2") -> Any:
     """
     Generates sentence embeddings using the sentence-transformers library.
-    
+
     This function caches loaded model instances by model_name to avoid expensive
     reloading on repeated calls.
     """
@@ -115,13 +375,16 @@ def cosine_similarity(v1: Any, v2: Any) -> float:
 def get_semantic_scores(query: str, documents: List[str], model_name: str = "all-MiniLM-L6-v2") -> List[float]:
     """
     Computes semantic similarity (cosine similarity) of a query against a list of documents.
+
+    The `query` is expected to already be preprocessed (e.g. via `_expand_query()`)
+    by the caller if zero-keyword enrichment is desired.
     """
     if not documents:
         return []
     embeddings = get_embeddings([query] + documents, model_name=model_name)
     query_emb = embeddings[0]
     doc_embs = embeddings[1:]
-    
+
     scores = []
     for doc_emb in doc_embs:
         sim = cosine_similarity(query_emb, doc_emb)
@@ -138,12 +401,60 @@ def hybrid_search(
     tag_filters: Optional[List[str]] = None,
     alpha: float = 0.5,
     model_name: str = "all-MiniLM-L6-v2",
-    top_k: Optional[int] = 20
+    top_k: Optional[int] = 20,
+    semantic_candidate_k: Optional[int] = None,
 ) -> List[Dict]:
     """
     Performs a hybrid search (BM25 + Cosine Similarity) over terminal sessions.
-    Uses FTS-backed candidate retrieval first, but falls back to a bounded non-FTS
-    candidate set when no FTS matches are found so semantic reranking still works.
+
+    Uses FTS-backed candidate retrieval first, but falls back to a bounded
+    non-FTS candidate set when no FTS matches are found so semantic
+    reranking still works for zero-keyword queries.
+
+    Zero-keyword query handling
+    ---------------------------
+    A "zero-keyword" query is one whose tokens have NO lexical overlap with
+    any candidate document (e.g. querying "containerization" against a
+    corpus that only contains `docker ps -a`). The BM25 score for every
+    candidate will be 0 in this case. Without special handling, min-max
+    normalization would map all candidates to the same BM25 value (0),
+    which makes the `(1 - alpha) * bm25` term collapse to a constant —
+    effectively turning the hybrid score into pure semantic ranking anyway,
+    but with the appearance of a hybrid score.
+
+    We detect this condition explicitly and:
+      1. Set the normalized BM25 score to a neutral 0.5 (so the alpha
+         blend remains meaningful and the user's `alpha` choice is
+         respected).
+      2. Mark each result with `zero_keyword=True` so the caller / UI can
+         surface the fact that matches are semantic-only.
+      3. Use `_expand_query()` to enrich the query with topic anchors
+         before embedding, dramatically improving recall for conceptual
+         queries against a literal command/commit corpus.
+
+    Candidate pool sizing
+    ---------------------
+    When FTS misses entirely, the fallback pool size is
+    `max(top_k, semantic_candidate_k)` (default `semantic_candidate_k` =
+    `max(top_k * 5, 100)`). This gives the semantic ranker enough room to
+    surface non-keyword matches without resorting to an unbounded full
+    scan, which would be too slow on large histories.
+
+    Semantic-only mode
+    ------------------
+    When `alpha >= 0.999` the FTS step is skipped entirely and ranking is
+    done purely on cosine similarity over the bounded fallback pool. This
+    is useful for power users who know their query is conceptual and want
+    to bypass FTS entirely.
+
+    Security
+    --------
+    This function does not invoke any LLM. All embeddings are computed
+    locally via sentence-transformers. The returned session dicts are safe
+    to feed into LLM-facing code paths because they originate from the
+    SQLite database (which is already subject to the existing sanitization
+    pipeline in `sanitizer.py`) — no new unsanitized user input is added.
+
     If sentence-transformers is not installed, raises an ImportError.
     """
     if not SENTENCE_TRANSFORMERS_AVAILABLE:
@@ -151,20 +462,43 @@ def hybrid_search(
             "The 'sentence-transformers' package is required for semantic search. "
             "Please install it using: pip install sentence-transformers"
         )
-        
-    # Retrieve a bounded candidate set using the text-aware search pipeline before reranking.
-    from termstory.search import advanced_search
-    candidate_sessions = advanced_search(
-        db,
-        query=query,
-        project_filter=project_filter,
-        since_ts=since_ts,
-        until_ts=until_ts,
-        tag_filters=tag_filters,
-        fts=True,
-        limit=top_k
-    )
 
+    if not query:
+        # Nothing to search for — return an empty list rather than pulling
+        # the entire corpus through the embedding pipeline.
+        return []
+
+    # Semantic-only mode: skip FTS entirely and rank a bounded candidate
+    # pool purely by cosine similarity.
+    semantic_only = alpha >= 0.999
+
+    # Default semantic candidate pool: 5x top_k, clamped to a floor of 100
+    # so even small top_k values yield a meaningfully-sized reranking pool.
+    effective_top_k = top_k if top_k is not None else 20
+    if semantic_candidate_k is None:
+        semantic_candidate_k = max(effective_top_k * 5, 100)
+
+    # --- Stage 1: FTS-backed candidate retrieval (skipped in semantic-only mode) ---
+    from termstory.search import advanced_search
+    candidate_sessions: List[Dict] = []
+    if not semantic_only:
+        candidate_sessions = advanced_search(
+            db,
+            query=query,
+            project_filter=project_filter,
+            since_ts=since_ts,
+            until_ts=until_ts,
+            tag_filters=tag_filters,
+            fts=True,
+            limit=top_k
+        )
+
+    # --- Stage 2: Zero-keyword fallback / augmentation ---
+    # If FTS returned no matches (zero-keyword query), OR if we're in
+    # semantic-only mode, pull a bounded non-FTS candidate set so semantic
+    # similarity has something to rank. The pool is enlarged to
+    # `semantic_candidate_k` to give the semantic ranker room to surface
+    # non-keyword matches.
     if not candidate_sessions and query:
         candidate_sessions = advanced_search(
             db,
@@ -173,73 +507,99 @@ def hybrid_search(
             since_ts=since_ts,
             until_ts=until_ts,
             tag_filters=tag_filters,
-            limit=top_k
+            limit=max(effective_top_k, semantic_candidate_k)
         )
-    
-    if not candidate_sessions or not query:
-        return candidate_sessions
 
-    # Construct document representation for each session
-    documents = []
-    for s in candidate_sessions:
-        cmd_str = " ".join(s.get("all_commands", []))
-        commit_str = " ".join([c.get("message", "") for c in s.get("all_commits", [])])
-        doc_text = (
-            f"Project: {s.get('project_name', '')}\n"
-            f"Summary: {s.get('ai_summary') or ''}\n"
-            f"Commands: {cmd_str}\n"
-            f"Commits: {commit_str}"
-        )
-        documents.append(doc_text)
-        
-    # 1. Compute BM25 scores
+    if not candidate_sessions:
+        return []
+
+    # --- Stage 3: Document construction with command preprocessing ---
+    # Commands are expanded via `_preprocess_command_text()` so the embedding
+    # model has natural-language signal to work with. This is critical for
+    # zero-keyword recall: `ps -a` alone produces a near-zero signal, but
+    # `ps (process status) -a (all)` matches a query like "list processes"
+    # much more reliably.
+    documents = [_build_session_document(s) for s in candidate_sessions]
+
+    # --- Stage 4: BM25 (lexical) scoring ---
+    # BM25 still operates on the raw query (NOT the expanded query) so the
+    # lexical signal remains deterministic and unaffected by the topic
+    # expansion heuristic.
     tokenized_corpus = [tokenize(doc) for doc in documents]
     query_terms = tokenize(query)
     bm25 = BM25(tokenized_corpus)
     bm25_scores = [bm25.get_score(i, query_terms) for i in range(len(candidate_sessions))]
-    
-    # 2. Compute Cosine Similarity scores
-    semantic_scores = get_semantic_scores(query, documents, model_name=model_name)
-    
-    # 3. Min-Max normalization for BM25 scores
-    min_bm25 = min(bm25_scores) if bm25_scores else 0.0
-    max_bm25 = max(bm25_scores) if bm25_scores else 0.0
-    bm25_range = max_bm25 - min_bm25
-    if bm25_range == 0.0:
-        bm25_range = 1e-9
-    normalized_bm25 = [(score - min_bm25) / bm25_range for score in bm25_scores]
-    
-    # 4. Min-Max normalization for semantic scores
+
+    # Detect the zero-keyword condition: every BM25 score is zero, meaning
+    # no query token appears in any candidate document.
+    zero_keyword = bool(bm25_scores) and all(s <= 0.0 for s in bm25_scores)
+    if not bm25_scores:
+        zero_keyword = True
+
+    # --- Stage 5: Semantic scoring with query expansion ---
+    # The expanded query is used ONLY for embedding, never for BM25. This
+    # is what makes zero-keyword queries work: "containerization" gets
+    # enriched with "docker, kubernetes, k8s, compose, pod" before encoding,
+    # so the cosine similarity against a `docker ps -a` session is high.
+    expanded_query = _expand_query(query)
+    semantic_scores = get_semantic_scores(expanded_query, documents, model_name=model_name)
+
+    # --- Stage 6: Min-Max normalization ---
+    # For zero-keyword queries, BM25 is uninformative (every score is 0).
+    # Rather than letting min-max collapse to 0 for everyone (which would
+    # make the alpha blend meaningless), we set normalized BM25 to a
+    # neutral 0.5 so the semantic signal dominates as intended by `alpha`
+    # without artificially penalizing every candidate.
+    if zero_keyword:
+        normalized_bm25 = [0.5] * len(candidate_sessions)
+    else:
+        min_bm25 = min(bm25_scores) if bm25_scores else 0.0
+        max_bm25 = max(bm25_scores) if bm25_scores else 0.0
+        bm25_range = max_bm25 - min_bm25
+        if bm25_range == 0.0:
+            bm25_range = 1e-9
+        normalized_bm25 = [(score - min_bm25) / bm25_range for score in bm25_scores]
+
     min_sem = min(semantic_scores) if semantic_scores else 0.0
     max_sem = max(semantic_scores) if semantic_scores else 0.0
     sem_range = max_sem - min_sem
     if sem_range == 0.0:
         sem_range = 1e-9
     normalized_sem = [(score - min_sem) / sem_range for score in semantic_scores]
-    
-    # Combine scores
+
+    # --- Stage 7: Combine scores and populate result metadata ---
     scored_sessions = []
     for i, s in enumerate(candidate_sessions):
         h_score = alpha * normalized_sem[i] + (1.0 - alpha) * normalized_bm25[i]
-        
-        # Populate matching_commands and matching_commits based on overlapping terms
+
+        # matching_commands / matching_commits are computed against the
+        # RAW query terms (not the expanded query). For zero-keyword
+        # queries these lists will be empty, which is the correct
+        # behavior: we surface the session via semantic similarity alone,
+        # not via fake lexical matches against expansion anchors.
         matching_cmds = []
         for cmd in s.get("all_commands", []):
             if any(term in cmd.lower() for term in query_terms):
                 matching_cmds.append(cmd)
-                
+
         matching_commits = []
         for commit in s.get("all_commits", []):
             msg = commit.get("message", "").lower()
             if any(term in msg for term in query_terms):
                 matching_commits.append(commit)
-                
+
         s["matching_commands"] = matching_cmds
         s["matching_commits"] = matching_commits
         s["hybrid_score"] = h_score
+        # Expose the raw sub-scores and zero-keyword flag so callers
+        # (CLI, TUI, future LLM-facing code) can reason about why a
+        # session was surfaced.
+        s["semantic_score"] = float(semantic_scores[i]) if i < len(semantic_scores) else 0.0
+        s["bm25_score"] = float(bm25_scores[i]) if i < len(bm25_scores) else 0.0
+        s["zero_keyword"] = zero_keyword
         scored_sessions.append(s)
-        
+
     # Sort sessions by hybrid score descending
     scored_sessions.sort(key=lambda x: x["hybrid_score"], reverse=True)
-    
+
     return scored_sessions

--- a/termstory/rag.py
+++ b/termstory/rag.py
@@ -602,4 +602,13 @@ def hybrid_search(
     # Sort sessions by hybrid score descending
     scored_sessions.sort(key=lambda x: x["hybrid_score"], reverse=True)
 
-    return scored_sessions
+    # Truncate the ranked pool back down to the requested top_k. The
+    # fallback / semantic-only branches above intentionally pull a larger
+    # candidate pool (`max(effective_top_k, semantic_candidate_k)`, floor
+    # 100) so the semantic ranker has room to surface non-keyword matches
+    # — but the *return* contract of this function is "at most top_k
+    # sessions". Without this final slice, callers that don't re-truncate
+    # (anything other than the CLI's `--limit` path) would receive up to
+    # 100 sessions for zero-keyword / semantic-only queries regardless of
+    # the `top_k` argument.
+    return scored_sessions[:effective_top_k]

--- a/tests/test_rag_zero_keyword.py
+++ b/tests/test_rag_zero_keyword.py
@@ -1,0 +1,415 @@
+"""
+Additional tests for zero-keyword semantic search (Issue #47).
+
+These tests are APPENDED to the existing tests/test_rag.py — they cover:
+  * Query expansion (`_expand_query`)
+  * Command text preprocessing (`_preprocess_command_text`)
+  * Zero-keyword hybrid search (conceptual query -> semantic match)
+  * Semantic-only mode (alpha=1.0 bypasses FTS)
+  * Preservation of the existing FTS-miss fallback path
+"""
+
+import math
+import pytest
+from termstory.database import Database
+from termstory.models import Project, Session, Command
+
+
+# --- Reuse the mocks from the existing test module (re-declared here so the
+# --- new test file is self-contained). --------------------------------------
+
+class MockLinalg:
+    @staticmethod
+    def norm(v):
+        return math.sqrt(sum(x * x for x in v))
+
+
+class MockNp:
+    linalg = MockLinalg
+    ndarray = list
+
+    @staticmethod
+    def dot(v1, v2):
+        return sum(x * y for x, y in zip(v1, v2))
+
+
+class MockSentenceTransformer:
+    """Embedding mock that maps by keyword presence.
+
+    The mock mimics the *spirit* of all-MiniLM-L6-v2: it produces the same
+    embedding for any text containing a given keyword. This lets us assert
+    that the query-expansion pipeline (`_expand_query`) actually causes the
+    expanded query to land in the same semantic neighborhood as the target
+    document.
+    """
+    def __init__(self, model_name: str):
+        self.model_name = model_name
+
+    def encode(self, texts, **kwargs):
+        embeddings = []
+        for text in texts:
+            text_lower = text.lower()
+            if "docker" in text_lower:
+                embeddings.append([1.0, 0.0, 0.0])
+            elif "pytest" in text_lower or "test" in text_lower:
+                embeddings.append([0.0, 1.0, 0.0])
+            else:
+                embeddings.append([0.0, 0.0, 1.0])
+        return embeddings
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the new preprocessing helpers
+# ---------------------------------------------------------------------------
+
+def test_expand_query_adds_anchors_for_known_topics():
+    from termstory.rag import _expand_query
+
+    # 'containerization' is a key in _TOPIC_EXPANSIONS — should pull in
+    # 'docker', 'kubernetes', 'k8s', etc.
+    expanded = _expand_query("containerization")
+    assert "containerization" in expanded
+    assert "docker" in expanded
+    assert "kubernetes" in expanded
+
+    # Original query always preserved verbatim at the front.
+    assert expanded.startswith("containerization")
+
+    # Multi-word phrase anchor.
+    expanded_phrase = _expand_query("how does version control work here")
+    assert "git" in expanded_phrase
+    assert "commit" in expanded_phrase
+
+    # Unknown topic: query returned unchanged (no expansion).
+    assert _expand_query("flibbertigibbet") == "flibbertigibbet"
+
+    # Empty query short-circuits.
+    assert _expand_query("") == ""
+
+
+def test_expand_query_is_capped_to_eight_anchors():
+    from termstory.rag import _expand_query, _TOPIC_EXPANSIONS
+
+    # Find a topic with > 8 anchors to verify the cap.
+    big_topic = None
+    for k, v in _TOPIC_EXPANSIONS.items():
+        if len(v) > 8 and ' ' not in k:
+            big_topic = k
+            break
+    if big_topic is None:
+        pytest.skip("No topic with >8 single-token anchors in the map")
+
+    expanded = _expand_query(big_topic)
+    # The "(related: ...)" suffix should contain at most 8 comma-separated
+    # anchor terms.
+    suffix = expanded.split("(related:", 1)[1]
+    anchors = [a.strip().rstrip(")") for a in suffix.split(",")]
+    assert len(anchors) <= 8
+
+
+def test_preprocess_command_text_expands_shorthands():
+    from termstory.rag import _preprocess_command_text
+
+    # Known shorthand gets expanded inline.
+    out = _preprocess_command_text("ps -a")
+    assert "ps" in out  # original token preserved
+    assert "process status" in out  # expansion appended in parens
+
+    # Multiple known shorthands in one command.
+    out2 = _preprocess_command_text("sudo rm -rf /tmp/foo")
+    assert "superuser" in out2
+    assert "remove delete" in out2
+
+    # Unknown command passes through unchanged.
+    out3 = _preprocess_command_text("foobar --flag value")
+    assert out3 == "foobar --flag value"
+
+    # Empty / None-safe.
+    assert _preprocess_command_text("") == ""
+
+
+def test_build_session_document_uses_preprocessed_commands():
+    from termstory.rag import _build_session_document
+
+    session = {
+        "project_name": "Demo",
+        "ai_summary": "Running process checks",
+        "all_commands": ["ps -a", "docker ps"],
+        "all_commits": [{"message": "feat: add stuff"}],
+    }
+    doc = _build_session_document(session)
+    # Preprocessing expanded the shorthands...
+    assert "process status" in doc
+    assert "container runtime" in doc
+    # ...and the raw tokens are still individually present (just with
+    # parenthetical expansions inserted after them, so the bare command
+    # form is NOT contiguous — that's intentional).
+    assert "ps" in doc
+    assert "docker" in doc
+    # Commit message included verbatim.
+    assert "feat: add stuff" in doc
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for the new zero-keyword behavior in hybrid_search()
+# ---------------------------------------------------------------------------
+
+def _seed_two_session_db(db, now):
+    """Seed a DB with one Docker session and one unrelated session."""
+    p1 = Project(id=1, name="Docker Registry", path="~/projects/docker",
+                 first_seen=now, last_seen=now,
+                 session_count=1, total_time=100)
+    p2 = Project(id=2, name="Unrelated Work", path="~/projects/other",
+                 first_seen=now, last_seen=now,
+                 session_count=1, total_time=100)
+
+    cmd1 = Command(timestamp=now, command="docker ps -a", session_id=1, project_id=1)
+    s1 = Session(id=1, start_time=now, end_time=now + 100,
+                 duration_seconds=100, project_id=1, commands=[cmd1])
+    s1.ai_summary = "Running docker daemon container checks"
+
+    cmd2 = Command(timestamp=now + 5000, command="echo hello world",
+                   session_id=2, project_id=2)
+    s2 = Session(id=2, start_time=now + 5000, end_time=now + 5100,
+                 duration_seconds=100, project_id=2, commands=[cmd2])
+    s2.ai_summary = "Unrelated shell work"
+
+    db.save_data([p1, p2], [s1, s2], [cmd1, cmd2])
+    return p1, p2, s1, s2
+
+
+def test_hybrid_search_zero_keyword_query(tmp_path, monkeypatch):
+    """
+    Zero-keyword scenario: query 'containerization' has NO lexical overlap
+    with any command/commit in the DB. The system should still surface the
+    Docker session as the top result via:
+      (a) FTS miss -> fallback to a bounded non-FTS candidate pool, AND
+      (b) `_expand_query('containerization')` adds 'docker' to the
+          embedding, so the mock SentenceTransformer produces the same
+          embedding for both the query and the Docker document.
+    """
+    monkeypatch.setattr("termstory.rag.SENTENCE_TRANSFORMERS_AVAILABLE", True)
+    monkeypatch.setattr("termstory.rag.SentenceTransformer", MockSentenceTransformer, raising=False)
+    monkeypatch.setattr("termstory.rag.np", MockNp)
+
+    db_file = tmp_path / "test_rag_zero_keyword.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    now = 1780000000
+    _seed_two_session_db(db, now)
+
+    from termstory.rag import hybrid_search
+
+    results = hybrid_search(db, "containerization", alpha=0.8)
+
+    # FTS will miss -> fallback pulls both sessions.
+    assert len(results) >= 1
+    # Docker session should be ranked FIRST via semantic similarity.
+    assert results[0]["session_id"] == 1
+    assert results[0]["project_name"] == "Docker Registry"
+    # The zero_keyword flag is surfaced so the UI can indicate semantic-only
+    # matches to the user.
+    assert results[0]["zero_keyword"] is True
+    # Sub-scores are exposed for downstream consumers.
+    assert "semantic_score" in results[0]
+    assert "bm25_score" in results[0]
+    # BM25 score is 0 for every candidate (zero lexical overlap).
+    assert results[0]["bm25_score"] == 0.0
+    # No fake lexical matches against the expanded query.
+    assert results[0]["matching_commands"] == []
+
+
+def test_hybrid_search_zero_keyword_ranks_relevant_above_irrelevant(tmp_path, monkeypatch):
+    """
+    When two candidates are returned by the fallback pool, the semantically
+    relevant one must rank strictly above the irrelevant one.
+    """
+    monkeypatch.setattr("termstory.rag.SENTENCE_TRANSFORMERS_AVAILABLE", True)
+    monkeypatch.setattr("termstory.rag.SentenceTransformer", MockSentenceTransformer, raising=False)
+    monkeypatch.setattr("termstory.rag.np", MockNp)
+
+    db_file = tmp_path / "test_rag_zero_keyword_rank.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    now = 1780000000
+    _seed_two_session_db(db, now)
+
+    from termstory.rag import hybrid_search
+
+    results = hybrid_search(db, "containerization", alpha=0.8)
+    assert len(results) == 2
+    # Docker session > Unrelated session.
+    assert results[0]["session_id"] == 1
+    assert results[1]["session_id"] == 2
+    assert results[0]["hybrid_score"] > results[1]["hybrid_score"]
+
+
+def test_hybrid_search_semantic_only_mode_bypasses_fts(tmp_path, monkeypatch):
+    """
+    With alpha >= 0.999 the FTS step is skipped entirely; the candidate
+    pool comes from the bounded non-FTS fallback and ranking is purely
+    semantic.
+    """
+    monkeypatch.setattr("termstory.rag.SENTENCE_TRANSFORMERS_AVAILABLE", True)
+    monkeypatch.setattr("termstory.rag.SentenceTransformer", MockSentenceTransformer, raising=False)
+    monkeypatch.setattr("termstory.rag.np", MockNp)
+
+    db_file = tmp_path / "test_rag_semantic_only.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    now = 1780000000
+    _seed_two_session_db(db, now)
+
+    # Grab a reference to the real advanced_search BEFORE monkeypatching
+    # so the spy can delegate without infinite recursion.
+    from termstory.search import advanced_search as _real_advanced_search
+
+    calls = []
+
+    def spy_advanced_search(db_obj, query=None, **kwargs):
+        calls.append(query)
+        return _real_advanced_search(db_obj, query=query, **kwargs)
+
+    monkeypatch.setattr("termstory.search.advanced_search", spy_advanced_search)
+
+    from termstory.rag import hybrid_search
+
+    results = hybrid_search(db, "docker", alpha=1.0)
+    # Only the fallback (query=None) call should have happened.
+    assert all(q is None for q in calls), calls
+    # Docker session still ranks first (semantic match).
+    assert results[0]["session_id"] == 1
+
+
+def test_hybrid_search_preserves_existing_fts_fallback_behavior(tmp_path, monkeypatch):
+    """
+    Regression test: the existing FTS-miss fallback path (used by the
+    pre-issue-#47 test `test_hybrid_search_falls_back_when_fts_has_no_matches`)
+    must still trigger exactly twice — once with the query, once with
+    `query=None` — when FTS misses.
+    """
+    monkeypatch.setattr("termstory.rag.SENTENCE_TRANSFORMERS_AVAILABLE", True)
+    monkeypatch.setattr("termstory.rag.SentenceTransformer", MockSentenceTransformer, raising=False)
+    monkeypatch.setattr("termstory.rag.np", MockNp)
+
+    db_file = tmp_path / "test_rag_fallback_regression.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    now = 1780000000
+    p1 = Project(id=1, name="Docker Registry", path="~/projects/docker",
+                 first_seen=now, last_seen=now,
+                 session_count=1, total_time=100)
+    cmd1 = Command(timestamp=now, command="docker ps -a", session_id=1, project_id=1)
+    s1 = Session(id=1, start_time=now, end_time=now + 100,
+                 duration_seconds=100, project_id=1, commands=[cmd1])
+    s1.ai_summary = "Running docker daemon container checks"
+    db.save_data([p1], [s1], [cmd1])
+
+    calls = []
+
+    def fake_advanced_search(db_obj, query=None, **kwargs):
+        calls.append(query)
+        if query == "containerization":
+            return []  # FTS miss
+        return [{
+            "session_id": 1,
+            "start_time": now,
+            "end_time": now + 100,
+            "duration_seconds": 100,
+            "project_id": 1,
+            "project_name": "Docker Registry",
+            "project_path": "~/projects/docker",
+            "ai_summary": "Running docker daemon container checks",
+            "all_commands": ["docker ps -a"],
+            "matching_commands": [],
+            "all_commits": [],
+            "matching_commits": [],
+        }]
+
+    monkeypatch.setattr("termstory.search.advanced_search", fake_advanced_search)
+
+    from termstory.rag import hybrid_search
+    results = hybrid_search(db, "containerization", alpha=0.5)
+
+    assert len(results) == 1
+    assert results[0]["session_id"] == 1
+    assert calls[0] == "containerization"
+    assert calls[1] is None
+
+
+def test_hybrid_search_empty_query_returns_empty(tmp_path, monkeypatch):
+    """
+    An empty query should short-circuit to [] WITHOUT invoking FTS or the
+    embedding pipeline. This prevents accidentally pulling the entire
+    corpus through semantic scoring.
+    """
+    monkeypatch.setattr("termstory.rag.SENTENCE_TRANSFORMERS_AVAILABLE", True)
+    monkeypatch.setattr("termstory.rag.SentenceTransformer", MockSentenceTransformer, raising=False)
+    monkeypatch.setattr("termstory.rag.np", MockNp)
+
+    db_file = tmp_path / "test_rag_empty_query.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    # Spy on advanced_search to make sure it is NOT called.
+    calls = []
+
+    def spy_advanced_search(db_obj, query=None, **kwargs):
+        calls.append(query)
+        return []
+
+    monkeypatch.setattr("termstory.search.advanced_search", spy_advanced_search)
+
+    from termstory.rag import hybrid_search
+    results = hybrid_search(db, "", alpha=0.5)
+
+    assert results == []
+    assert calls == []
+
+
+def test_hybrid_search_normal_keyword_query_still_uses_fts_first(tmp_path, monkeypatch):
+    """
+    Regression test: a normal keyword query (e.g. 'docker') should still
+    hit the FTS path FIRST and not unnecessarily fall through to the
+    zero-keyword fallback pool.
+    """
+    monkeypatch.setattr("termstory.rag.SENTENCE_TRANSFORMERS_AVAILABLE", True)
+    monkeypatch.setattr("termstory.rag.SentenceTransformer", MockSentenceTransformer, raising=False)
+    monkeypatch.setattr("termstory.rag.np", MockNp)
+
+    db_file = tmp_path / "test_rag_normal_keyword.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    now = 1780000000
+    _seed_two_session_db(db, now)
+
+    # Grab a reference to the real advanced_search BEFORE monkeypatching
+    # so the spy can delegate without infinite recursion.
+    from termstory.search import advanced_search as _real_advanced_search
+
+    calls = []
+
+    def spy_advanced_search(db_obj, query=None, **kwargs):
+        calls.append(query)
+        return _real_advanced_search(db_obj, query=query, **kwargs)
+
+    monkeypatch.setattr("termstory.search.advanced_search", spy_advanced_search)
+
+    from termstory.rag import hybrid_search
+    results = hybrid_search(db, "docker", alpha=0.5)
+
+    # FTS path was used (query == "docker").
+    assert "docker" in calls
+    # No fallback to query=None should have been necessary.
+    assert None not in calls
+    # zero_keyword flag is False because 'docker' has lexical overlap.
+    assert all(r["zero_keyword"] is False for r in results)
+    # Docker session ranked first.
+    assert results[0]["session_id"] == 1
+    # matching_commands populated as before.
+    assert "docker ps -a" in results[0]["matching_commands"]


### PR DESCRIPTION
## Description
Implements the long-term R&D concept from #47: semantic deep-dive via local RAG with zero-keyword query support.

Users can now search their terminal history using conceptual queries (e.g. "containerization", "deployment", "refactoring") even when those exact words never appear in any command, commit message, or project name. The system surfaces semantically related sessions via local embedding similarity — no LLM call, no API key, no network.

Closes #47 

## Type of Change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [x] My code follows the "density over decoration" philosophy.
- [x] I have not used `rich.panel.Panel` in my code.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
