### PR TITLE
fix(cli): require confirmation before `restore` overwrites the live database

### DIFF
--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -1177,16 +1177,91 @@ def backup_cmd():
     console.print(f"[bold green]✅ Backup created at {escape(backup_path)}[/]")
 
 @app.command("restore")
-def restore_cmd(backup_path: str = typer.Argument(..., help="Path to the backup .db file to restore")):
-    """Restore the TermStory database from a backup file."""
+def restore_cmd(
+    backup_path: str = typer.Argument(..., help="Path to the backup .db file to restore"),
+    yes: bool = typer.Option(
+        False,
+        "--yes", "-y",
+        help="Skip the interactive confirmation prompt (required in non-interactive shells)."
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Print the source backup path and destination database path without performing the restore."
+    ),
+):
+    """Restore the TermStory database from a backup file.
+
+    This command OVERWRITES the live TermStory database at the current
+    `get_db_path()` location with the contents of the supplied backup file.
+    Because a restore is a destructive operation (any sessions, commands,
+    and commits recorded after the backup was taken will be lost), the
+    command follows the same safety pattern as `termstory reset`:
+
+      * In an interactive shell, the user is prompted to confirm and the
+        default is "no" (any response other than `y` / `yes` aborts).
+      * In a non-interactive shell (no TTY on stdin), the command refuses
+        to proceed unless `--yes` is supplied. This prevents scripts and
+        CI pipelines from silently destroying the live database.
+      * `--dry-run` prints the source and destination paths and exits
+        without touching either file.
+
+    Use `--yes` (or `-y`) to skip the prompt in automation.
+    """
     from termstory.backup import restore_db
     from rich.markup import escape
+    import os as _os
+
+    # Validate the backup file exists BEFORE prompting. A mistyped path
+    # should produce a clear "file not found" error, not a confirmation
+    # prompt that the user might blindly accept.
+    if not _os.path.isfile(backup_path):
+        console.print(f"[bold red]Error: backup file not found at {escape(backup_path)}[/]")
+        raise typer.Exit(code=1)
+
+    live_db_path = get_db_path()
+
+    # Always show the user exactly what is about to happen, in both
+    # interactive and non-interactive modes. This makes accidental
+    # restores from the wrong backup file much less likely.
+    console.print("[bold red]WARNING: this will overwrite your live TermStory database.[/bold red]")
+    console.print(f"  [cyan]source (backup):[/cyan] {escape(backup_path)}")
+    console.print(f"  [cyan]target (live):[/cyan]  {escape(live_db_path)}")
+
+    if dry_run:
+        console.print("\n[yellow]Dry run complete. No files were modified.[/yellow]")
+        return
+
+    if not yes:
+        # A non-interactive shell can't answer the prompt; refuse instead
+        # of silently aborting with a success exit code. This mirrors the
+        # safety pattern in `perform_reset`.
+        if not sys.stdin.isatty():
+            console.print(
+                "[bold red]Refusing to restore in a non-interactive shell without --yes.[/bold red]"
+            )
+            raise typer.Exit(code=1)
+        try:
+            response = input(
+                "\nOverwrite the live database with this backup? [y/N]: "
+            ).strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            console.print("\n[red]Restore cancelled by user interruption.[/red]")
+            raise typer.Exit(code=1)
+        if response not in ("y", "yes"):
+            console.print("[yellow]Restore aborted.[/yellow]")
+            return
+
     try:
         restore_db(backup_path)
-        console.print(f"[bold green]✅ Database restored from {escape(backup_path)}[/]")
     except FileNotFoundError as e:
+        # restore_db re-checks file existence; preserve the existing
+        # error-handling contract in case the file disappeared between
+        # our preflight check and the actual restore call.
         console.print(f"[bold red]Error: {escape(str(e))}[/]")
         raise typer.Exit(code=1)
+
+    console.print(f"[bold green]✅ Database restored from {escape(backup_path)}[/]")
 
 
 

--- a/tests/test_cli_restore_confirmation.py
+++ b/tests/test_cli_restore_confirmation.py
@@ -1,0 +1,336 @@
+"""
+Tests for the `termstory restore` command confirmation pattern (Issue #293).
+
+These tests verify the safety pattern added to `restore_cmd`:
+  * Non-interactive shell without `--yes` exits non-zero (refuses).
+  * Non-interactive shell with `--yes` performs the restore.
+  * `--dry-run` prints paths and does not touch the live DB.
+  * Interactive shell with a "no" response aborts.
+  * Interactive shell with a "yes" response performs the restore.
+  * Missing backup file exits non-zero BEFORE any prompt.
+  * Existing `--yes` automation path still works end-to-end.
+"""
+
+import os
+import pytest
+from typer.testing import CliRunner
+from termstory.cli import app
+from termstory.database import Database
+from termstory.models import Project, Session, Command
+
+
+def _seed_db(db_path: str, project_name: str = "Live Project") -> None:
+    """Initialize a DB and seed it with one project/session/command."""
+    db = Database(db_path)
+    db.init_db()
+    now = 1730000000
+    project = Project(
+        id=1, name=project_name, path="~/demo",
+        first_seen=now, last_seen=now,
+        session_count=1, total_time=100,
+    )
+    command = Command(timestamp=now, command="echo live", session_id=1, project_id=1)
+    session = Session(
+        id=1, start_time=now, end_time=now + 100,
+        duration_seconds=100, project_id=1, commands=[command],
+    )
+    db.save_data([project], [session], [command])
+
+
+def _make_backup(db_path: str, backup_path: str) -> None:
+    """Copy db_path -> backup_path to simulate a pre-existing backup file."""
+    import shutil
+    shutil.copy2(db_path, backup_path)
+
+
+def _patch_paths(monkeypatch, tmp_path, live_db_name: str = "live.db"):
+    """Patch all DB-path lookups to point under tmp_path."""
+    live_db = tmp_path / live_db_name
+    monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(live_db))
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: str(live_db))
+    monkeypatch.setattr("termstory.backup.get_db_path", lambda: str(live_db))
+    return live_db
+
+
+def _force_non_interactive(monkeypatch):
+    """
+    Force `sys.stdin.isatty()` to return False inside `restore_cmd`.
+
+    `typer.testing.CliRunner` replaces `sys.stdin` with a BytesIO-backed
+    wrapper DURING `invoke()`, so monkeypatching `sys.stdin.isatty` on the
+    real stdin object doesn't survive into the invoked command. We replace
+    the `sys` module reference inside `termstory.cli` with a lightweight
+    fake whose `stdin.isatty()` returns False. This survives the
+    CliRunner's stdin replacement because the lookup goes through our fake
+    `sys` object, not the real one.
+    """
+    import types
+    fake_stdin = types.SimpleNamespace(isatty=lambda: False)
+    fake_sys = types.SimpleNamespace(stdin=fake_stdin)
+    monkeypatch.setattr("termstory.cli.sys", fake_sys)
+
+
+def _force_interactive(monkeypatch):
+    """
+    Force `sys.stdin.isatty()` to return True inside `restore_cmd`, so the
+    interactive prompt branch is taken. See `_force_non_interactive` for
+    why we replace the whole `sys` module reference.
+    """
+    import types
+    fake_stdin = types.SimpleNamespace(isatty=lambda: True)
+    fake_sys = types.SimpleNamespace(stdin=fake_stdin)
+    monkeypatch.setattr("termstory.cli.sys", fake_sys)
+
+
+# ---------------------------------------------------------------------------
+# Non-interactive shell behavior (the regression this issue is about)
+# ---------------------------------------------------------------------------
+
+def test_restore_non_interactive_without_yes_refuses(tmp_path, monkeypatch):
+    """
+    In a non-interactive shell (no TTY on stdin), `termstory restore <path>`
+    must refuse to proceed and exit non-zero. This prevents scripts / CI
+    from silently destroying the live database.
+    """
+    live_db = _patch_paths(monkeypatch, tmp_path)
+    _seed_db(str(live_db), project_name="Live Project")
+
+    backup_file = tmp_path / "backup.db"
+    _make_backup(str(live_db), str(backup_file))
+
+    # Force non-interactive: stdin has no TTY.
+    _force_non_interactive(monkeypatch)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["restore", str(backup_file)])
+    assert result.exit_code == 1, (
+        f"Expected exit code 1 in non-interactive shell without --yes, "
+        f"got {result.exit_code}. Output:\n{result.output}"
+    )
+    combined = result.output.lower()
+    assert "non-interactive" in combined or "refusing" in combined
+    # The live DB must NOT have been touched — the source backup path
+    # was never even passed to restore_db.
+    assert "refusing to restore" in combined
+
+
+def test_restore_non_interactive_with_yes_succeeds(tmp_path, monkeypatch):
+    """
+    `termstory restore --yes <path>` must succeed in a non-interactive
+    shell. This is the automation-friendly path.
+    """
+    live_db = _patch_paths(monkeypatch, tmp_path)
+    _seed_db(str(live_db), project_name="Live Project")
+
+    # Create a backup containing DIFFERENT data so we can verify the
+    # restore actually replaced the live DB.
+    backup_db = tmp_path / "backup.db"
+    _seed_db(str(backup_db), project_name="Backup Project")
+    # The seed function initializes a fresh DB at backup_db. Now copy
+    # it to the expected backup path — but actually we can just pass
+    # backup_db directly to the restore command.
+
+    _force_non_interactive(monkeypatch)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["restore", "--yes", str(backup_db)])
+    assert result.exit_code == 0, (
+        f"Expected exit code 0 with --yes, got {result.exit_code}. "
+        f"Output:\n{result.output}"
+    )
+    assert "database restored" in result.output.lower()
+
+    # Verify the live DB now reflects the BACKUP's data, not the original.
+    restored = Database(str(live_db))
+    projects = restored.search_projects("")
+    assert len(projects) == 1
+    assert projects[0].name == "Backup Project"
+
+
+def test_restore_short_flag_y_also_works(tmp_path, monkeypatch):
+    """The `-y` short flag must behave identically to `--yes`."""
+    live_db = _patch_paths(monkeypatch, tmp_path)
+    _seed_db(str(live_db), project_name="Live Project")
+
+    backup_db = tmp_path / "backup.db"
+    _seed_db(str(backup_db), project_name="Backup Project")
+
+    _force_non_interactive(monkeypatch)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["restore", "-y", str(backup_db)])
+    assert result.exit_code == 0, result.output
+    assert "database restored" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# --dry-run
+# ---------------------------------------------------------------------------
+
+def test_restore_dry_run_does_not_modify_live_db(tmp_path, monkeypatch):
+    """
+    `--dry-run` prints source + target paths and exits 0 without calling
+    restore_db. The live DB must be byte-for-byte unchanged.
+    """
+    live_db = _patch_paths(monkeypatch, tmp_path)
+    _seed_db(str(live_db), project_name="Live Project")
+
+    backup_db = tmp_path / "backup.db"
+    _seed_db(str(backup_db), project_name="Backup Project")
+
+    live_size_before = live_db.stat().st_size
+    live_mtime_before = live_db.stat().st_mtime
+
+    _force_non_interactive(monkeypatch)
+
+    runner = CliRunner()
+    # --dry-run should NOT require --yes (it is non-destructive).
+    result = runner.invoke(app, ["restore", "--dry-run", str(backup_db)])
+    assert result.exit_code == 0, result.output
+
+    combined = result.output.lower()
+    assert "dry run" in combined
+    assert "no files were modified" in combined
+    # Both paths should be echoed back to the user.
+    assert str(backup_db) in result.output
+    assert str(live_db) in result.output
+
+    # The live DB must be unchanged.
+    assert live_db.stat().st_size == live_size_before
+    assert live_db.stat().st_mtime == live_mtime_before
+
+
+# ---------------------------------------------------------------------------
+# Interactive shell behavior
+# ---------------------------------------------------------------------------
+
+def test_restore_interactive_default_no_aborts(tmp_path, monkeypatch):
+    """
+    In an interactive shell, the user is prompted and the default is "no".
+    Any response other than y/yes must abort the restore without modifying
+    the live DB.
+    """
+    live_db = _patch_paths(monkeypatch, tmp_path)
+    _seed_db(str(live_db), project_name="Live Project")
+
+    backup_db = tmp_path / "backup.db"
+    _seed_db(str(backup_db), project_name="Backup Project")
+
+    _force_interactive(monkeypatch)
+
+    # Simulate the user just pressing Enter (default = no).
+    monkeypatch.setattr("builtins.input", lambda prompt="": "")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["restore", str(backup_db)])
+    assert result.exit_code == 0, result.output  # abort is a clean exit
+    assert "restore aborted" in result.output.lower()
+
+    # The live DB must still contain the original "Live Project" data.
+    restored = Database(str(live_db))
+    projects = restored.search_projects("")
+    assert any(p.name == "Live Project" for p in projects)
+
+
+def test_restore_interactive_yes_proceeds(tmp_path, monkeypatch):
+    """
+    In an interactive shell, answering "y" to the prompt proceeds with
+    the restore.
+    """
+    live_db = _patch_paths(monkeypatch, tmp_path)
+    _seed_db(str(live_db), project_name="Live Project")
+
+    backup_db = tmp_path / "backup.db"
+    _seed_db(str(backup_db), project_name="Backup Project")
+
+    _force_interactive(monkeypatch)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["restore", str(backup_db)])
+    assert result.exit_code == 0, result.output
+    assert "database restored" in result.output.lower()
+
+    restored = Database(str(live_db))
+    projects = restored.search_projects("")
+    assert len(projects) == 1
+    assert projects[0].name == "Backup Project"
+
+
+def test_restore_interactive_keyboard_interrupt_aborts(tmp_path, monkeypatch):
+    """A Ctrl-C / EOF at the prompt must abort cleanly with exit code 1."""
+    live_db = _patch_paths(monkeypatch, tmp_path)
+    _seed_db(str(live_db), project_name="Live Project")
+
+    backup_db = tmp_path / "backup.db"
+    _seed_db(str(backup_db), project_name="Backup Project")
+
+    _force_interactive(monkeypatch)
+
+    def raise_eof(prompt=""):
+        raise EOFError()
+
+    monkeypatch.setattr("builtins.input", raise_eof)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["restore", str(backup_db)])
+    assert result.exit_code == 1, result.output
+    assert "cancelled" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Preflight validation
+# ---------------------------------------------------------------------------
+
+def test_restore_missing_backup_file_exits_nonzero_before_prompt(tmp_path, monkeypatch):
+    """
+    A mistyped backup path must produce a clear "file not found" error and
+    exit non-zero WITHOUT ever prompting the user.
+    """
+    live_db = _patch_paths(monkeypatch, tmp_path)
+    _seed_db(str(live_db), project_name="Live Project")
+
+    missing_path = str(tmp_path / "does_not_exist.db")
+
+    prompt_called = []
+
+    def fail_if_called(prompt=""):
+        prompt_called.append(True)
+        return "y"
+
+    _force_interactive(monkeypatch)
+    monkeypatch.setattr("builtins.input", fail_if_called)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["restore", missing_path])
+    assert result.exit_code == 1, result.output
+    assert "not found" in result.output.lower()
+    # The prompt must never have been shown.
+    assert prompt_called == []
+
+
+def test_restore_preserves_existing_error_contract_on_missing_file(tmp_path, monkeypatch):
+    """
+    Regression: the existing `restore_db` raises FileNotFoundError if the
+    file disappears between our preflight check and the actual restore
+    call. The CLI must still translate that into exit code 1 (the
+    pre-issue-#293 behavior).
+    """
+    live_db = _patch_paths(monkeypatch, tmp_path)
+    _seed_db(str(live_db), project_name="Live Project")
+
+    backup_db = tmp_path / "backup.db"
+    _seed_db(str(backup_db), project_name="Backup Project")
+
+    # Make restore_db raise FileNotFoundError to simulate a race where
+    # the backup file is deleted after our preflight check.
+    def fake_restore_db(path):
+        raise FileNotFoundError(f"Backup file not found at {path}")
+
+    monkeypatch.setattr("termstory.backup.restore_db", fake_restore_db)
+    _force_non_interactive(monkeypatch)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["restore", "--yes", str(backup_db)])
+    assert result.exit_code == 1, result.output
+    assert "error" in result.output.lower()


### PR DESCRIPTION
## Description

Previously, `termstory restore <backup.db>` overwrote the live database immediately with no interactive prompt, no `--yes` flag, and no dry-run option. A single mistyped path or accidental restore could silently destroy current history.

This PR updates `restore_cmd` in `termstory/cli.py` to align with the existing `perform_reset` destructive-operation safety pattern:

* **Preflight File Check:** Validates that the backup file exists and exits with `1` before displaying prompts.
* **Path Transparency:** Explicitly displays the source (backup) and target (live DB) paths prior to restoration.
* **Interactive Confirmation:** Prompts users in interactive shells (defaulting to `[y/N]`) and gracefully handles `KeyboardInterrupt` / `EOFError`.
* **Non-Interactive Safeguard:** Refuses execution in non-TTY shells unless `--yes` is explicitly provided, preventing script errors from silently wiping databases.
* **Automation Flag:** Adds `--yes` (`-y`) to skip confirmation prompts for CI/automated flows.
* **Dry Run:** Adds `--dry-run` to preview source and target paths without modifying any files.

Fixes #293 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the "density over decoration" philosophy.
- [x] I have not used `rich.panel.Panel` in my code.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.