### PR TITLE
fix: validate config values in config set

### DIFF
--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -1377,41 +1377,84 @@ def config_set(key: str, value: str):
     from termstory.config import load_config, save_config, set_config_value, get_config_value
     config = load_config()
     
-    current_val = get_config_value(config, key)
-    if isinstance(current_val, bool):
-        converted_value = value.lower() in ("true", "1", "yes")
-    elif isinstance(current_val, int):
-        try:
-            converted_value = int(value)
-        except ValueError:
-            converted_value = value
-    elif isinstance(current_val, float):
-        try:
-            converted_value = float(value)
-        except ValueError:
+    from termstory.config import translate_legacy_key
+    effective_key = translate_legacy_key(config, key)
+
+    KNOWN_DEFAULTS = {
+        "ai_enabled": False,
+        "active_provider": "disabled",
+        "request_timeout_seconds": 30,
+        "ai_max_failures": 3,
+        "ai_cooldown_seconds": 60.0,
+        "has_seen_onboarding": False,
+        "has_seen_timestamp_prompt": False,
+        "has_seen_onboarding_reminder": False,
+        "max_history_age": 5,
+        "max_query_log": 10000,
+        "db_timeout": 30.0,
+        "reminder_poll_interval": 300,
+        "clustering_threshold": 0.6,
+        "nfs_timeout_cache_ttl": 60,
+    }
+
+    default_val = KNOWN_DEFAULTS.get(effective_key)
+    if default_val is not None:
+        if isinstance(default_val, bool):
+            lowered = value.lower()
+            if lowered not in ("true", "false", "yes", "no", "1", "0"):
+                Console(stderr=True).print(
+                    "[bold red]Invalid boolean value.[/]\n"
+                    "Expected one of:\n"
+                    "true, false, yes, no, 1, 0"
+                )
+                raise typer.Exit(code=1)
+            converted_value = lowered in ("true", "yes", "1")
+        elif isinstance(default_val, (int, float)):
+            try:
+                parsed = float(value)
+            except ValueError:
+                Console(stderr=True).print(
+                    f"[bold red]Invalid value for {key}.[/]\n"
+                    f"Expected a positive number."
+                )
+                raise typer.Exit(code=1)
+            if (
+                parsed <= 0
+                or parsed != parsed
+                or parsed == float('inf')
+                or parsed == float('-inf')
+            ):
+                Console(stderr=True).print(
+                    f"[bold red]Invalid value for {key}.[/]\n"
+                    f"Expected a positive number."
+                )
+                raise typer.Exit(code=1)
+            if isinstance(default_val, int) and parsed == int(parsed):
+                converted_value = int(parsed)
+            else:
+                converted_value = parsed
+        else:
             converted_value = value
     else:
-        if key in ("ai_enabled", "has_seen_onboarding") or key.endswith(".ai_enabled") or key.endswith(".has_seen_onboarding"):
-            converted_value = value.lower() in ("true", "1", "yes")
-        elif "api_key" in key or "token" in key or "password" in key:
-            converted_value = value
-        else:
-            try:
-                if "." in value:
-                    converted_value = float(value)
-                elif value.isdigit() and value.startswith("0") and len(value) > 1:
-                    converted_value = value
-                else:
-                    converted_value = int(value)
-            except ValueError:
-                converted_value = value
-        
+        converted_value = value
+
     set_config_value(config, key, converted_value)
     save_config(config)
     
     set_val = get_config_value(config, key)
     from rich.markup import escape
     console.print(f"[green]Set config key '{escape(key)}' to '{escape(str(set_val))}'[/]")
+
+    # Issue #342 req 5: guidance when enabling AI with no provider configured
+    if effective_key == "ai_enabled" and converted_value is True:
+        current_provider = config.get("active_provider") or config.get("ai_provider", "disabled")
+        if current_provider == "disabled":
+            Console(stderr=True).print(
+                "\n[bold yellow]AI has been enabled, but no provider is configured.[/]\n"
+                "Run:\n"
+                "  [cyan]termstory config set active_provider groq[/cyan]\n"
+                "or configure another provider before using AI features.\n"
+            )
 
 @config_app.command("get")
 def config_get(key: str):

--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -1383,7 +1383,7 @@ def config_set(key: str, value: str):
     KNOWN_DEFAULTS = {
         "ai_enabled": False,
         "active_provider": "disabled",
-        "request_timeout_seconds": 30,
+        "request_timeout_seconds": 30.0,
         "ai_max_failures": 3,
         "ai_cooldown_seconds": 60.0,
         "has_seen_onboarding": False,
@@ -1429,7 +1429,13 @@ def config_set(key: str, value: str):
                     f"Expected a positive number."
                 )
                 raise typer.Exit(code=1)
-            if isinstance(default_val, int) and parsed == int(parsed):
+            if isinstance(default_val, int):
+                if parsed != int(parsed):
+                    Console(stderr=True).print(
+                        f"[bold red]Invalid value for {key}.[/]\n"
+                        f"Expected a positive integer."
+                    )
+                    raise typer.Exit(code=1)
                 converted_value = int(parsed)
             else:
                 converted_value = parsed

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -411,6 +411,179 @@ def test_cli_reset_cleanup_rc_files(tmp_path, monkeypatch):
     assert "alias l='ls'" in new_bashrc
     assert "alias foo=bar" in new_bashrc
 
+def test_config_set_numeric_validation(tmp_path, monkeypatch):
+    """Issue #342: config set rejects invalid numeric values."""
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("termstory.config.get_config_path", lambda: str(config_file))
+
+    runner = CliRunner()
+
+    # Valid timeout values
+    for val in ("30", "45", "60", "0.5", "2.5"):
+        result = runner.invoke(app, ["config", "set", "request_timeout_seconds", val])
+        assert result.exit_code == 0, f"Expected 0 for {val}, got {result.exit_code}: {result.stdout}"
+        import json
+        with open(config_file, "r") as f:
+            data = json.load(f)
+        if "." in val:
+            assert data["request_timeout_seconds"] == float(val)
+        else:
+            assert data["request_timeout_seconds"] == int(val)
+
+    # Invalid timeout values
+    for val in ("abc", "xyz", "ten", "NaN", "inf", "0"):
+        result = runner.invoke(app, ["config", "set", "request_timeout_seconds", val])
+        assert result.exit_code != 0, f"Expected non-zero for {val}, got {result.exit_code}: {result.stdout}"
+        assert "Expected a positive number" in result.stdout or "Expected a positive number" in result.stderr
+
+    # Negative values must also be rejected (use -- to prevent typer option parsing)
+    result = runner.invoke(app, ["config", "set", "request_timeout_seconds", "--", "-5"])
+    assert result.exit_code != 0, f"Expected non-zero for -5, got {result.exit_code}: {result.stdout}"
+    assert "Expected a positive number" in result.stdout or "Expected a positive number" in result.stderr
+
+    # Config file must NOT be modified on failure (request_timeout_seconds should retain last valid value)
+    import json
+    with open(config_file, "r") as f:
+        data = json.load(f)
+    assert data["request_timeout_seconds"] == 2.5  # Last valid value
+
+
+def test_config_set_boolean_validation(tmp_path, monkeypatch):
+    """Issue #342: config set rejects invalid boolean values."""
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("termstory.config.get_config_path", lambda: str(config_file))
+
+    runner = CliRunner()
+
+    # Valid boolean values (case-insensitive)
+    for val in ("true", "false", "yes", "no", "1", "0", "TRUE", "False", "YES", "No"):
+        result = runner.invoke(app, ["config", "set", "ai_enabled", val])
+        assert result.exit_code == 0, f"Expected 0 for {val}, got {result.exit_code}: {result.stdout}"
+        expected = val.lower() in ("true", "yes", "1")
+        import json
+        with open(config_file, "r") as f:
+            data = json.load(f)
+        assert data["ai_enabled"] is expected, f"Expected {expected} for {val}"
+
+    # Invalid boolean values
+    for val in ("maybe", "enable", "disable", "on", "off", "null", "abc", "random"):
+        result = runner.invoke(app, ["config", "set", "ai_enabled", val])
+        assert result.exit_code != 0, f"Expected non-zero for {val}, got {result.exit_code}: {result.stdout}"
+        assert "Invalid boolean value" in result.stdout or "Invalid boolean value" in result.stderr
+
+
+def test_config_set_api_key_preserves_leading_zeros(tmp_path, monkeypatch):
+    """Issue #342: API keys must remain raw strings, no numeric conversion."""
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("termstory.config.get_config_path", lambda: str(config_file))
+
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["config", "set", "groq_api_key", "000012345"])
+    assert result.exit_code == 0
+    import json
+    with open(config_file, "r") as f:
+        data = json.load(f)
+    # Legacy key should be translated to providers.groq.api_key
+    assert data["providers"]["groq"]["api_key"] == "000012345"
+
+
+def test_config_set_ai_enabled_with_disabled_provider_warns(tmp_path, monkeypatch):
+    """Issue #342 req 5: setting ai_enabled=true with disabled provider prints warning."""
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("termstory.config.get_config_path", lambda: str(config_file))
+
+    # Pre-set active_provider to disabled
+    import json
+    with open(config_file, "w") as f:
+        json.dump({"active_provider": "disabled"}, f)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["config", "set", "ai_enabled", "true"])
+    assert result.exit_code == 0
+    assert "AI has been enabled, but no provider is configured" in result.stdout or \
+           "AI has been enabled, but no provider is configured" in result.stderr
+
+    # Verify config was still saved
+    with open(config_file, "r") as f:
+        data = json.load(f)
+    assert data["ai_enabled"] is True
+
+
+def test_config_set_ai_enabled_with_provider_no_warning(tmp_path, monkeypatch):
+    """Issue #342 req 5: setting ai_enabled=true with configured provider does NOT warn."""
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("termstory.config.get_config_path", lambda: str(config_file))
+
+    import json
+    with open(config_file, "w") as f:
+        json.dump({"active_provider": "groq"}, f)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["config", "set", "ai_enabled", "true"])
+    assert result.exit_code == 0
+    assert "AI has been enabled, but no provider is configured" not in result.stdout
+
+
+def test_config_set_unknown_key_preserved(tmp_path, monkeypatch):
+    """Issue #342: unknown/custom keys must be stored as raw strings."""
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("termstory.config.get_config_path", lambda: str(config_file))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["config", "set", "custom_key", "some_value"])
+    assert result.exit_code == 0
+    import json
+    with open(config_file, "r") as f:
+        data = json.load(f)
+    assert data["custom_key"] == "some_value"
+
+
+def test_config_set_legacy_key_validation(tmp_path, monkeypatch):
+    """Issue #342: legacy keys should be validated using translated key's type."""
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("termstory.config.get_config_path", lambda: str(config_file))
+
+    runner = CliRunner()
+
+    # ai_provider is a legacy key that maps to active_provider (string type)
+    result = runner.invoke(app, ["config", "set", "ai_provider", "groq"])
+    assert result.exit_code == 0
+    import json
+    with open(config_file, "r") as f:
+        data = json.load(f)
+    assert data["active_provider"] == "groq"
+
+
+def test_config_set_invalid_value_does_not_modify_config(tmp_path, monkeypatch):
+    """Issue #342: invalid values must never modify config.json."""
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("termstory.config.get_config_path", lambda: str(config_file))
+
+    import json
+    # Start with an empty config
+    with open(config_file, "w") as f:
+        json.dump({}, f)
+
+    # First set a valid timeout
+    runner = CliRunner()
+    result = runner.invoke(app, ["config", "set", "request_timeout_seconds", "30"])
+    assert result.exit_code == 0
+
+    with open(config_file, "r") as f:
+        before = json.load(f)
+    assert before.get("request_timeout_seconds") == 30
+
+    # Now try to set an invalid timeout
+    result = runner.invoke(app, ["config", "set", "request_timeout_seconds", "abc"])
+    assert result.exit_code != 0
+
+    # request_timeout_seconds must still be 30 (unchanged)
+    with open(config_file, "r") as f:
+        after = json.load(f)
+    assert after["request_timeout_seconds"] == 30
+
+
 def test_cli_error_states(tmp_path, monkeypatch):
     db_file = tmp_path / "test_cli_errors.db"
     monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
@@ -741,7 +914,3 @@ def test_cli_predict_enhanced_command(tmp_path, monkeypatch):
     result_days = runner.invoke(app, ["predict", "--days", "7"])
     assert result_days.exit_code == 0
     assert "HugeGraph" in result_days.stdout
-
-
-
-

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -434,12 +434,14 @@ def test_config_set_numeric_validation(tmp_path, monkeypatch):
     for val in ("abc", "xyz", "ten", "NaN", "inf", "0"):
         result = runner.invoke(app, ["config", "set", "request_timeout_seconds", val])
         assert result.exit_code != 0, f"Expected non-zero for {val}, got {result.exit_code}: {result.stdout}"
-        assert "Expected a positive number" in result.stdout or "Expected a positive number" in result.stderr
+        output = result.output or result.stdout
+        assert "Expected a positive number" in output
 
     # Negative values must also be rejected (use -- to prevent typer option parsing)
     result = runner.invoke(app, ["config", "set", "request_timeout_seconds", "--", "-5"])
     assert result.exit_code != 0, f"Expected non-zero for -5, got {result.exit_code}: {result.stdout}"
-    assert "Expected a positive number" in result.stdout or "Expected a positive number" in result.stderr
+    output = result.output or result.stdout
+    assert "Expected a positive number" in output
 
     # Config file must NOT be modified on failure (request_timeout_seconds should retain last valid value)
     import json
@@ -469,7 +471,8 @@ def test_config_set_boolean_validation(tmp_path, monkeypatch):
     for val in ("maybe", "enable", "disable", "on", "off", "null", "abc", "random"):
         result = runner.invoke(app, ["config", "set", "ai_enabled", val])
         assert result.exit_code != 0, f"Expected non-zero for {val}, got {result.exit_code}: {result.stdout}"
-        assert "Invalid boolean value" in result.stdout or "Invalid boolean value" in result.stderr
+        output = result.output or result.stdout
+        assert "Invalid boolean value" in output
 
 
 def test_config_set_api_key_preserves_leading_zeros(tmp_path, monkeypatch):
@@ -502,7 +505,8 @@ def test_config_set_ai_enabled_with_disabled_provider_warns(tmp_path, monkeypatc
     result = runner.invoke(app, ["config", "set", "ai_enabled", "true"])
     assert result.exit_code == 0
     warning_msg = "AI has been enabled, but no provider is configured"
-    assert warning_msg in result.stdout or warning_msg in result.stderr
+    output = result.output or result.stdout
+    assert warning_msg in output
 
     # Verify config was still saved
     with open(config_file, "r") as f:
@@ -523,8 +527,8 @@ def test_config_set_ai_enabled_with_provider_no_warning(tmp_path, monkeypatch):
     result = runner.invoke(app, ["config", "set", "ai_enabled", "true"])
     assert result.exit_code == 0
     warning_msg = "AI has been enabled, but no provider is configured"
-    assert warning_msg not in result.stdout
-    assert warning_msg not in result.stderr
+    output = result.output or result.stdout
+    assert warning_msg not in output
 
 
 def test_config_set_unknown_key_preserved(tmp_path, monkeypatch):
@@ -561,7 +565,8 @@ def test_config_set_integer_keys_reject_fractions(tmp_path, monkeypatch):
     for key, val in [("max_query_log", "10.5"), ("max_query_log", "2.1"), ("ai_max_failures", "1.5")]:
         result = runner.invoke(app, ["config", "set", key, val])
         assert result.exit_code != 0, f"Expected non-zero for {key}={val}"
-        assert "Expected a positive integer" in result.stdout or "Expected a positive integer" in result.stderr
+        output = result.output or result.stdout
+        assert "Expected a positive integer" in output
 
     # Config file unchanged for integer keys (max_query_log should still be 999)
     import json
@@ -625,24 +630,28 @@ def test_cli_error_states(tmp_path, monkeypatch):
     # 1. search with invalid --since date
     result = runner.invoke(app, ["search", "query", "--since", "invalid-date"])
     assert result.exit_code == 1
-    assert "Invalid date" in result.stdout or "Invalid date" in result.stderr
+    output = result.output or result.stdout
+    assert "Invalid date" in output
     
     # 2. project with unknown name
     db = Database(str(db_file))
     db.init_db()
     result = runner.invoke(app, ["project", "non-existent-project-xyz"])
     assert result.exit_code == 1
-    assert "Could not find project matching" in result.stdout or "Could not find project matching" in result.stderr
+    output = result.output or result.stdout
+    assert "Could not find project matching" in output
     
     # 3. config get with missing key
     result = runner.invoke(app, ["config", "get", "some.missing.key"])
     assert result.exit_code == 1
-    assert "Config key 'some.missing.key' not found" in result.stdout or "Config key 'some.missing.key' not found" in result.stderr
+    output = result.output or result.stdout
+    assert "Config key 'some.missing.key' not found" in output
     
     # 4. global --date invalid format
     result = runner.invoke(app, ["--date", "not-a-date"])
     assert result.exit_code == 1
-    assert "Invalid date format" in result.stdout or "Invalid date format" in result.stderr
+    output = result.output or result.stdout
+    assert "Invalid date format" in output
 def test_global_date_accepts_natural_language(tmp_path, monkeypatch):
     db_file = tmp_path / "test_date_override.db"
 
@@ -740,7 +749,8 @@ def test_cli_agy_command(monkeypatch):
     
     result2 = runner.invoke(app, ["agy"])
     assert result2.exit_code == 1
-    assert "Error: 'agy' command not found" in result2.stdout or "Error: 'agy' command not found" in result2.stderr
+    output = result2.output or result2.stdout
+    assert "Error: 'agy' command not found" in output
 
 
 def test_cli_insights_command(tmp_path, monkeypatch):

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -501,8 +501,8 @@ def test_config_set_ai_enabled_with_disabled_provider_warns(tmp_path, monkeypatc
     runner = CliRunner()
     result = runner.invoke(app, ["config", "set", "ai_enabled", "true"])
     assert result.exit_code == 0
-    assert "AI has been enabled, but no provider is configured" in result.stdout or \
-           "AI has been enabled, but no provider is configured" in result.stderr
+    warning_msg = "AI has been enabled, but no provider is configured"
+    assert warning_msg in result.stdout or warning_msg in result.stderr
 
     # Verify config was still saved
     with open(config_file, "r") as f:
@@ -522,7 +522,9 @@ def test_config_set_ai_enabled_with_provider_no_warning(tmp_path, monkeypatch):
     runner = CliRunner()
     result = runner.invoke(app, ["config", "set", "ai_enabled", "true"])
     assert result.exit_code == 0
-    assert "AI has been enabled, but no provider is configured" not in result.stdout
+    warning_msg = "AI has been enabled, but no provider is configured"
+    assert warning_msg not in result.stdout
+    assert warning_msg not in result.stderr
 
 
 def test_config_set_unknown_key_preserved(tmp_path, monkeypatch):
@@ -537,6 +539,35 @@ def test_config_set_unknown_key_preserved(tmp_path, monkeypatch):
     with open(config_file, "r") as f:
         data = json.load(f)
     assert data["custom_key"] == "some_value"
+
+
+def test_config_set_integer_keys_reject_fractions(tmp_path, monkeypatch):
+    """Issue #342: integer config keys must reject fractional values."""
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("termstory.config.get_config_path", lambda: str(config_file))
+
+    runner = CliRunner()
+
+    # Valid integer values
+    for key, val in [("max_query_log", "10"), ("ai_max_failures", "5"), ("max_query_log", "999")]:
+        result = runner.invoke(app, ["config", "set", key, val])
+        assert result.exit_code == 0, f"Expected 0 for {key}={val}, got {result.exit_code}: {result.stdout}"
+        import json
+        with open(config_file, "r") as f:
+            data = json.load(f)
+        assert data[key] == int(val)
+
+    # Invalid fractional values for integer keys
+    for key, val in [("max_query_log", "10.5"), ("max_query_log", "2.1"), ("ai_max_failures", "1.5")]:
+        result = runner.invoke(app, ["config", "set", key, val])
+        assert result.exit_code != 0, f"Expected non-zero for {key}={val}"
+        assert "Expected a positive integer" in result.stdout or "Expected a positive integer" in result.stderr
+
+    # Config file unchanged for integer keys (max_query_log should still be 999)
+    import json
+    with open(config_file, "r") as f:
+        data = json.load(f)
+    assert data["max_query_log"] == 999
 
 
 def test_config_set_legacy_key_validation(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #342

## Summary

This PR adds strict validation to the `termstory config set` command to prevent invalid configuration values from being written while preserving existing behavior for valid inputs.

Previously, invalid numeric values (e.g. `abc` for `request_timeout_seconds`) were stored directly, and unknown boolean values (e.g. `maybe`) were silently coerced to `False`, leading to confusing configuration states.

## Changes

### Validation

- Validate numeric configuration keys (e.g. `request_timeout_seconds`)
  - Accept positive integers and floating-point values
  - Reject non-numeric, zero, negative, `NaN`, and infinite values
  - Display clear error messages without modifying the configuration

- Validate boolean configuration keys
  - Accept only:
    - `true`
    - `false`
    - `yes`
    - `no`
    - `1`
    - `0`
  - Case-insensitive
  - Reject ambiguous values such as `maybe`, `on`, `off`, `enable`, and `disable`

### Configuration behavior

- Preserve API keys, tokens, and passwords as raw strings
- Preserve unknown/custom configuration keys without validation
- Apply validation after legacy key translation so legacy configuration names continue to work correctly

### User guidance

- When enabling `ai_enabled=true` while `active_provider=disabled`, display a helpful warning explaining that a provider still needs to be configured instead of silently leaving the user in a confusing state.

## Tests

Added tests covering:

- Valid numeric values
- Invalid numeric values
- Valid boolean values
- Invalid boolean values
- Legacy key validation
- API key leading-zero preservation
- Unknown key preservation
- AI enablement guidance
- Configuration immutability after validation failures

## Verification

- ✅ `ruff check .`
- ✅ `pytest tests/test_cli_commands.py -v`
- ✅ `pytest tests/test_config.py -v`