### PR TITLE
fix: validate archive --days argument

### DIFF
--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -1187,6 +1187,10 @@ def archive_cmd(
     archive_db: Optional[str] = typer.Option(None, "--archive-db", "-a", help="Path to the archive SQLite database file (defaults to archive.db next to the main database)"),
 ):
     """Archive old sessions and associated data (older than N days) to a separate database."""
+    if days <= 0:
+        Console(stderr=True).print("[bold red]Error: --days must be greater than 0[/]")
+        raise typer.Exit(code=1)
+    
     db_path = get_db_path()
     db = Database(db_path)
     safe_init_db(db)
@@ -1198,7 +1202,7 @@ def archive_cmd(
         archive_db = os.path.join(os.path.dirname(db_path), "archive.db")
     else:
         archive_db = os.path.realpath(os.path.abspath(os.path.expanduser(archive_db)))
-        
+    
     console.print(f"Archiving data older than [bold]{days}[/] days...")
     console.print(f"Main Database: [bold]{db_path}[/]")
     console.print(f"Archive Database: [bold]{archive_db}[/]")

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -218,7 +218,7 @@ def test_cli_archive_rejects_days_zero(tmp_path, monkeypatch):
     result = runner.invoke(app, ["archive", "--days", "0", "--archive-db", str(archive_file)])
     
     assert result.exit_code == 1, result.stdout
-    assert "days must be greater than 0" in (result.stdout or result.stderr or "").lower()
+    assert "days must be greater than 0" in result.output.lower()
     
     # Verify archive logic was not executed (no archive db created)
     assert not archive_file.exists()
@@ -241,7 +241,7 @@ def test_cli_archive_rejects_days_negative(tmp_path, monkeypatch):
     result = runner.invoke(app, ["archive", "--days", "-5", "--archive-db", str(archive_file)])
     
     assert result.exit_code == 1, result.stdout
-    assert "days must be greater than 0" in (result.stdout or result.stderr or "").lower()
+    assert "days must be greater than 0" in result.output.lower()
     
     # Verify archive logic was not executed (no archive db created)
     assert not archive_file.exists()

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -199,3 +199,49 @@ def test_cli_archive_command(tmp_path, monkeypatch):
     c_arch.execute("SELECT COUNT(*) FROM sessions")
     assert c_arch.fetchone()[0] == 1
     conn_arch.close()
+
+
+def test_cli_archive_rejects_days_zero(tmp_path, monkeypatch):
+    monkeypatch.setenv("TERMSTORY_DATE_OVERRIDE", "2026-06-14 12:00:00")
+    
+    db_file = tmp_path / "main_cli.db"
+    archive_file = tmp_path / "archive_cli.db"
+    
+    monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.cli.get_history_files", lambda: [])
+    
+    db = Database(str(db_file))
+    db.init_db()
+    
+    runner = CliRunner()
+    result = runner.invoke(app, ["archive", "--days", "0", "--archive-db", str(archive_file)])
+    
+    assert result.exit_code == 1, result.stdout
+    assert "days must be greater than 0" in (result.stdout or result.stderr or "").lower()
+    
+    # Verify archive logic was not executed (no archive db created)
+    assert not archive_file.exists()
+
+
+def test_cli_archive_rejects_days_negative(tmp_path, monkeypatch):
+    monkeypatch.setenv("TERMSTORY_DATE_OVERRIDE", "2026-06-14 12:00:00")
+    
+    db_file = tmp_path / "main_cli.db"
+    archive_file = tmp_path / "archive_cli.db"
+    
+    monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.cli.get_history_files", lambda: [])
+    
+    db = Database(str(db_file))
+    db.init_db()
+    
+    runner = CliRunner()
+    result = runner.invoke(app, ["archive", "--days", "-5", "--archive-db", str(archive_file)])
+    
+    assert result.exit_code == 1, result.stdout
+    assert "days must be greater than 0" in (result.stdout or result.stderr or "").lower()
+    
+    # Verify archive logic was not executed (no archive db created)
+    assert not archive_file.exists()

--- a/tests/test_archive_validation.py
+++ b/tests/test_archive_validation.py
@@ -1,0 +1,106 @@
+import pytest
+from typer.testing import CliRunner
+from termstory.cli import app
+from termstory.database import Database
+from termstory.models import Project, Session, Command
+from datetime import datetime
+
+
+def test_archive_rejects_days_zero(tmp_path, monkeypatch):
+    """archive --days 0 should fail before touching the archive logic."""
+    monkeypatch.setenv("TERMSTORY_DATE_OVERRIDE", "2026-06-14 12:00:00")
+
+    db_file = tmp_path / "main.db"
+    monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.cli.get_history_files", lambda: [])
+
+    db = Database(str(db_file))
+    db.init_db()
+
+    base_time = int(datetime(2026, 6, 14, 12, 0, 0).timestamp())
+    old_time = base_time - (45 * 24 * 3600)
+    project = Project(id=1, name="Old Project", path="~/old", first_seen=old_time, last_seen=old_time, session_count=1, total_time=60)
+    cmd = Command(id=1, timestamp=old_time, command="git commit -m 'old'", session_id=1, project_id=1)
+    session = Session(id=1, start_time=old_time, end_time=old_time + 60, duration_seconds=60, project_id=1, commands=[cmd])
+    db.save_data([project], [session], [cmd])
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["archive", "--days", "0"])
+
+    assert result.exit_code != 0
+    output = result.stdout + (result.stderr or "")
+    assert "--days must be greater than 0" in output
+
+    conn = db.get_connection()
+    c = conn.cursor()
+    c.execute("SELECT COUNT(*) FROM sessions")
+    assert c.fetchone()[0] == 1
+    conn.close()
+
+
+def test_archive_rejects_days_negative(tmp_path, monkeypatch):
+    """archive --days -5 should fail before touching the archive logic."""
+    monkeypatch.setenv("TERMSTORY_DATE_OVERRIDE", "2026-06-14 12:00:00")
+
+    db_file = tmp_path / "main.db"
+    monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.cli.get_history_files", lambda: [])
+
+    db = Database(str(db_file))
+    db.init_db()
+
+    base_time = int(datetime(2026, 6, 14, 12, 0, 0).timestamp())
+    old_time = base_time - (45 * 24 * 3600)
+    project = Project(id=1, name="Old Project", path="~/old", first_seen=old_time, last_seen=old_time, session_count=1, total_time=60)
+    cmd = Command(id=1, timestamp=old_time, command="git commit -m 'old'", session_id=1, project_id=1)
+    session = Session(id=1, start_time=old_time, end_time=old_time + 60, duration_seconds=60, project_id=1, commands=[cmd])
+    db.save_data([project], [session], [cmd])
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["archive", "--days", "-5"])
+
+    assert result.exit_code != 0
+    output = result.stdout + (result.stderr or "")
+    assert "--days must be greater than 0" in output
+
+    conn = db.get_connection()
+    c = conn.cursor()
+    c.execute("SELECT COUNT(*) FROM sessions")
+    assert c.fetchone()[0] == 1
+    conn.close()
+
+
+def test_archive_accepts_positive_days(tmp_path, monkeypatch):
+    """archive --days 30 should still succeed and archive eligible data."""
+    monkeypatch.setenv("TERMSTORY_DATE_OVERRIDE", "2026-06-14 12:00:00")
+
+    db_file = tmp_path / "main.db"
+    archive_file = tmp_path / "archive.db"
+    monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.cli.get_history_files", lambda: [])
+
+    db = Database(str(db_file))
+    db.init_db()
+
+    base_time = int(datetime(2026, 6, 14, 12, 0, 0).timestamp())
+    old_time = base_time - (45 * 24 * 3600)
+    project = Project(id=1, name="Old Project", path="~/old", first_seen=old_time, last_seen=old_time, session_count=1, total_time=60)
+    cmd = Command(id=1, timestamp=old_time, command="git commit -m 'old'", session_id=1, project_id=1)
+    session = Session(id=1, start_time=old_time, end_time=old_time + 60, duration_seconds=60, project_id=1, commands=[cmd])
+    db.save_data([project], [session], [cmd])
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["archive", "--days", "30", "--archive-db", str(archive_file)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Archiving data older than 30 days" in result.stdout
+    assert "Archiving completed successfully" in result.stdout
+
+    conn = db.get_connection()
+    c = conn.cursor()
+    c.execute("SELECT COUNT(*) FROM sessions")
+    assert c.fetchone()[0] == 0
+    conn.close()

--- a/tests/test_archive_validation.py
+++ b/tests/test_archive_validation.py
@@ -29,7 +29,7 @@ def test_archive_rejects_days_zero(tmp_path, monkeypatch):
     result = runner.invoke(app, ["archive", "--days", "0"])
 
     assert result.exit_code != 0
-    output = result.stdout + (result.stderr or "")
+    output = result.output
     assert "--days must be greater than 0" in output
 
     conn = db.get_connection()
@@ -62,7 +62,7 @@ def test_archive_rejects_days_negative(tmp_path, monkeypatch):
     result = runner.invoke(app, ["archive", "--days", "-5"])
 
     assert result.exit_code != 0
-    output = result.stdout + (result.stderr or "")
+    output = result.output
     assert "--days must be greater than 0" in output
 
     conn = db.get_connection()


### PR DESCRIPTION
## Summary

This PR adds input validation for the `archive` command to prevent invalid `--days` values from reaching the archive logic.

Previously, running:

```bash
termstory archive --days 0
```

allowed the command to proceed into the archive implementation, eventually resulting in a SQLite foreign-key constraint error. Instead of exposing an internal database exception, the CLI now validates the input early and provides a clear, user-friendly error message.

## Changes

- Added validation in `archive_cmd()` to reject `--days` values less than or equal to zero.
- Prevent invalid input from reaching `archive_old_data()`.
- Added regression tests covering:
  - `archive --days 0`
  - `archive --days -5`
- Verified that valid positive values continue to behave as before.

## Why

This change prevents users from triggering an avoidable database error through invalid CLI input, improves the user experience with clear validation feedback, and aligns the archive command with the validation approach already used elsewhere in the project.

## Testing

- ✅ Added regression tests for zero and negative `--days` values.
- ✅ Confirmed existing archive behavior remains unchanged for valid inputs.
- ✅ Relevant archive tests pass locally.

Closes #341