### PR TITLE
fix(tui): use configured api_base_url default in AI settings modal

### DIFF
--- a/termstory/tui.py
+++ b/termstory/tui.py
@@ -585,7 +585,7 @@ class OnboardingScreen(_DeferredDismissMixin, ModalScreen[dict]):
             base_url = self.query_one("#input-base-url").value.strip()
             model_name = self.query_one("#input-model-name").value.strip()
             github_username = self.query_one("#input-github-username").value.strip().lstrip('@')
-            
+
             error_label = self.query_one("#error-api-key")
             if self.selected_provider in ("groq", "openai", "custom") and not api_key:
                 error_label.update("API Key cannot be empty.")
@@ -593,15 +593,19 @@ class OnboardingScreen(_DeferredDismissMixin, ModalScreen[dict]):
                 return
             else:
                 error_label.styles.display = "none"
-            
+
             if not base_url:
-                if self.selected_provider == "groq":
-                    base_url = "https://api.groq.com/openai/v1"
-                elif self.selected_provider == "openai":
-                    base_url = "https://api.openai.com/v1"
-                elif self.selected_provider == "ollama":
-                    base_url = "http://localhost:11434/v1"
-                    
+                # Fall back to the configured default for this provider instead
+                # of a hardcoded URL. ``load_config()`` already merges the
+                # default endpoints into the nested ``providers.*.api_base_url``
+                # keys, so this picks up customisations set via
+                # ``termstory config set providers.groq.api_base_url <url>``.
+                # Fixes #152.
+                from termstory.config import get_config_value
+                base_url = get_config_value(
+                    self.config, f"providers.{self.selected_provider}.api_base_url"
+                ) or ""
+
             if "providers" not in self.config:
                 self.config["providers"] = {}
             if self.selected_provider not in self.config["providers"]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,54 @@ from unittest.mock import patch, mock_open
 
 from termstory.config import load_config, save_config, get_config_path
 
+def test_api_base_url_is_configurable_per_provider(tmp_path, monkeypatch):
+    """#152: the api_base_url for every provider must come from config and
+    be overridable via ``termstory config set providers.<p>.api_base_url``.
+    Hardcoded fallbacks (the old behaviour in cli.py / tui.py) silently
+    ignored user customisations.
+    """
+    config_file = tmp_path / "config.json"
+    config_data = {
+        "active_provider": "groq",
+        "providers": {
+            "groq": {
+                "api_key": "fake-key",
+                # User overrides Groq to point at a self-hosted proxy
+                "api_base_url": "https://my-proxy.example.com/openai/v1",
+                "model_name": "llama-3.1-8b-instant",
+            },
+        },
+    }
+    config_file.write_text(json.dumps(config_data))
+
+    with patch("termstory.config.get_config_path", return_value=str(config_file)):
+        config = load_config()
+
+        # get_config_value must use dot-path traversal (dict.get() does NOT)
+        from termstory.config import get_config_value
+
+        url = get_config_value(config, "providers.groq.api_base_url")
+        assert url == "https://my-proxy.example.com/openai/v1", (
+            "Configured api_base_url was not returned by get_config_value() "
+            "(regression of #152 dot-notation lookup bug)"
+        )
+
+        # Other providers must still return their defaults after merge
+        openai_url = get_config_value(config, "providers.openai.api_base_url")
+        assert openai_url == "https://api.openai.com/v1"
+
+        ollama_url = get_config_value(config, "providers.ollama.api_base_url")
+        assert ollama_url == "http://localhost:11434/v1"
+
+        # The helper that ai-aware callers use (cli.get_ai_provider_settings)
+        # must surface the custom URL, not a hardcoded fallback.
+        from termstory.cli import get_ai_provider_settings
+
+        provider, _api_key, base_url, _model = get_ai_provider_settings(config)
+        assert provider == "groq"
+        assert base_url == "https://my-proxy.example.com/openai/v1"
+
+
 def test_load_config_corrupted_file(tmp_path):
     # Mock get_config_path to point to our tmp_path
     config_file = tmp_path / "config.json"


### PR DESCRIPTION
The TUI's "Save" action in the AI provider settings modal used a hardcoded fallback block (mirroring the one previously removed from cli.py:699) for groq/openai/ollama base URLs when the user left the "Base URL" field blank. That ignored any custom value set via `termstory config set providers.<provider>.api_base_url <url>` and silently overwrote the user's setting on save.

Replace the hardcoded fallback with
`get_config_value(config, f"providers.{provider}.api_base_url")`, which already returns the configured default (merged into the nested config by load_config()) — so a user-supplied URL is preserved and a blank field correctly resolves to the provider's configured default.

Adds a regression test in tests/test_config.py that pins a custom api_base_url in config.json and asserts it survives both `get_config_value` and `cli.get_ai_provider_settings`, preventing future regressions of the dot-notation lookup bug.

Fixes #152

## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of Change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [ ] My code follows the "density over decoration" philosophy.
- [ ] I have not used `rich.panel.Panel` in my code.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
