### PR TITLE
fix(project,search): preserve per-command project context and filter …

### DIFF
--- a/termstory/models.py
+++ b/termstory/models.py
@@ -62,7 +62,7 @@ class Session:
     is_legacy: bool = False     # True = every command in this session has a synthetic timestamp
     tags: Optional[str] = None # Added for session tags as comma-separated list
 
-    
+
     @property
     def duration_readable(self) -> str:
         """Return '2h 15m' format"""
@@ -79,6 +79,18 @@ class Session:
         if not hasattr(self, "_cached_start_time_formatted") or self._cached_start_time_formatted is None:
             self._cached_start_time_formatted = datetime.fromtimestamp(self.start_time).strftime("%I:%M %p")
         return self._cached_start_time_formatted
+
+    @property
+    def project_ids(self) -> set:
+        """Return the set of distinct project IDs assigned to commands in this session.
+
+        A session that switches projects mid-stream (e.g. ``cd ~/A; ...; cd ~/B; ...``)
+        will report both project IDs here, even though ``session.project_id`` only
+        reflects the final project. Useful for project-filtered search that needs
+        to surface sessions whose *any* command ran in the filtered project
+        (see #337, #339).
+        """
+        return {c.project_id for c in self.commands if c.project_id is not None}
 
 @dataclass
 class Project:

--- a/termstory/project.py
+++ b/termstory/project.py
@@ -293,11 +293,43 @@ def _extract_file_args(cmd_str: str) -> List[str]:
     return file_args
 
 
-def _assign_project_to_session(session, project, projects_dict) -> None:
-    """Helper to link a session and its commands to a project."""
+def _assign_project_to_session(
+    session,
+    project,
+    projects_dict,
+    overwrite_per_command: bool = True,
+) -> None:
+    """Link a session and (optionally) every command to a project.
+
+    ``overwrite_per_command=True`` is used by Pass 2/3 to attribute every
+    command in an inferred session to the same project (because we only know
+    the session-level project).
+
+    ``overwrite_per_command=False`` is used by Pass 1 after the per-command
+    walk has already populated ``cmd.project_id`` based on the cwd at the time
+    each command was issued (#337, #339). In that mode we only set
+    ``session.project_id`` and leave any pre-existing per-command values
+    alone — including ``None`` for commands that ran in home before any
+    ``cd`` into a project.
+    """
     session.project_id = project.id
-    for cmd in session.commands:
-        cmd.project_id = project.id
+    if overwrite_per_command:
+        for cmd in session.commands:
+            cmd.project_id = project.id
+
+
+def _effective_end_time(session) -> int:
+    """Return the effective end timestamp for a session.
+
+    Active/open sessions can have ``end_time = None`` (e.g. ``Session(end_time=None,
+    duration_seconds=0)``). To keep project inference and time-gap arithmetic
+    type-safe, fall back to the session's ``start_time`` so that
+    comparisons/subtractions never see ``None``.
+    """
+    end = getattr(session, "end_time", None)
+    if end is None:
+        return session.start_time
+    return end
 
 
 def detect_projects(sessions: List[Session]) -> List[Project]:
@@ -322,14 +354,58 @@ def detect_projects(sessions: List[Session]) -> List[Project]:
     # ── Pass 1: cd-tracking (existing logic) ──────────────────────────
     last_session_end = None
     for session in sorted_sessions:
+        effective_end = _effective_end_time(session)
+
         if last_session_end is not None and session.start_time - last_session_end > 7200:
             old_cwd = home
             cwd = home
-        
+
+        # Helper: register or fetch the project rooted at the current cwd.
+        # Each command's ``project_id`` is set to whatever project was active
+        # at the time the command was issued (i.e. the cwd's project root),
+        # so a session that switches projects mid-stream preserves per-command
+        # attribution (see #337, #339). The session's overall project_id is
+        # still set to the final cwd's project for backward compatibility.
+        def _project_for_cwd(cwd_path: str, ts: int):
+            nonlocal project_id_counter
+            project_root = find_project_root(cwd_path)
+            if project_root == home or project_root == "/":
+                return None
+            if project_root not in projects_dict:
+                display_path = project_root
+                if project_root == home:
+                    display_path = "~"
+                elif project_root.startswith(home + "/"):
+                    display_path = "~" + project_root[len(home):]
+                name = humanize_project_name(project_root)
+                project = Project(
+                    id=project_id_counter,
+                    name=name,
+                    path=display_path,
+                    first_seen=ts,
+                    last_seen=ts,
+                    session_count=0,
+                    total_time=0,
+                )
+                projects_dict[project_root] = project
+                project_id_counter += 1
+            else:
+                project = projects_dict[project_root]
+                project.first_seen = min(project.first_seen, ts)
+                project.last_seen = max(project.last_seen, ts)
+            return project
+
         for cmd in session.commands:
+            # Attribute this command to whatever project the cwd resolved to
+            # *before* its embedded cd subcommands fire. This preserves the
+            # invariant "the command itself ran in cwd, then the cwd changed
+            # for the next command".
+            active_project = _project_for_cwd(cwd, cmd.timestamp)
+            cmd.project_id = active_project.id if active_project is not None else None
+
             cmd_full = cmd.command.strip()
             subcommands = split_chained_commands(cmd_full)
-            
+
             for subcmd in subcommands:
                 # Must start with cd followed by space/tab/EOF
                 if subcmd == "cd" or subcmd.startswith("cd ") or subcmd.startswith("cd\t"):
@@ -356,7 +432,7 @@ def detect_projects(sessions: List[Session]) -> List[Project]:
                                     if os.path.exists(test_path_ancestor):
                                         resolved = test_path_ancestor
                                         break
-                                        
+
                                 if not resolved:
                                     # Try relative to home directory
                                     test_path_home = os.path.abspath(os.path.join(home, path))
@@ -365,52 +441,58 @@ def detect_projects(sessions: List[Session]) -> List[Project]:
                                     else:
                                         # Fallback: just join it relative to current cwd
                                         resolved = test_path
-                                    
+
                         if resolved:
                             if resolved != cwd:
                                 old_cwd = cwd
                                 cwd = resolved
-                        
-        # The project path is the resolved cwd at the end of the session
+
+        # The project path is the resolved cwd at the end of the session.
+        # Session-level project_id remains the final project so existing
+        # callers (formatter/web/insights) keep working unchanged.
         project_root = find_project_root(cwd)
         is_valid_project = project_root != home and project_root != "/"
-        
+
         if is_valid_project:
-            if project_root not in projects_dict:
-                # Convert absolute project root back to a user-friendly path (using ~ if possible)
+            final_project = projects_dict.get(project_root)
+            if final_project is None:
+                # Edge case: cwd walked to a path we haven't registered yet
+                # (e.g. final cwd differs from every cwd seen mid-session).
                 display_path = project_root
                 if project_root == home:
                     display_path = "~"
                 elif project_root.startswith(home + "/"):
                     display_path = "~" + project_root[len(home):]
-                    
                 name = humanize_project_name(project_root)
-                project = Project(
+                final_project = Project(
                     id=project_id_counter,
                     name=name,
                     path=display_path,
                     first_seen=session.start_time,
-                    last_seen=session.end_time,
+                    last_seen=effective_end,
                     session_count=1,
                     total_time=session.duration_seconds
                 )
-                projects_dict[project_root] = project
+                projects_dict[project_root] = final_project
                 project_id_counter += 1
             else:
-                project = projects_dict[project_root]
-                project.first_seen = min(project.first_seen, session.start_time)
-                project.last_seen = max(project.last_seen, session.end_time)
-                project.session_count += 1
-                project.total_time += session.duration_seconds
-                
-            # Link session and commands to project
-            _assign_project_to_session(session, project, projects_dict)
+                final_project.first_seen = min(final_project.first_seen, session.start_time)
+                final_project.last_seen = max(final_project.last_seen, effective_end)
+                final_project.session_count += 1
+                final_project.total_time += session.duration_seconds
+
+            # Link session to final project. Per-command project_id was
+            # already populated by the inline attribution loop above and
+            # must be preserved (don't overwrite).
+            _assign_project_to_session(
+                session, final_project, projects_dict, overwrite_per_command=False
+            )
         else:
             session.project_id = None
             for cmd in session.commands:
                 cmd.project_id = None
-        
-        last_session_end = session.end_time
+
+        last_session_end = effective_end
     
     # ── Pass 2: Command-based inference for "Other" sessions ──────────
     # Build a reverse lookup: abs_path -> project for known projects

--- a/termstory/search.py
+++ b/termstory/search.py
@@ -73,7 +73,7 @@ def _search_new_fts5(
         WITH matched_session_ids AS (
             -- Matches from commands_fts
             SELECT DISTINCT session_id AS id, 1 AS match_type, NULL as rank
-            FROM commands 
+            FROM commands
             WHERE id IN (SELECT rowid FROM commands_fts WHERE commands_fts MATCH ?)
               AND session_id IS NOT NULL
 
@@ -81,7 +81,7 @@ def _search_new_fts5(
 
             -- Matches from sessions_fts
             SELECT rowid AS id, 2 AS match_type, rank
-            FROM sessions_fts 
+            FROM sessions_fts
             WHERE sessions_fts MATCH ?
 
             UNION ALL
@@ -103,28 +103,35 @@ def _search_new_fts5(
         FROM sessions s
         JOIN best_matches bm ON s.id = bm.id
         LEFT JOIN projects p ON s.project_id = p.id
+        LEFT JOIN commands cmd_per_proj ON cmd_per_proj.session_id = s.id
+        LEFT JOIN projects p2 ON cmd_per_proj.project_id = p2.id
         WHERE 1=1
     """
     params = [fts_query, fts_query, fts_query]
-    
+
     if project_filter:
-        sql += " AND p.name LIKE ?"
+        # Match if the session's final project OR any per-command project
+        # matches the filter — fixes #339 where a session that switches
+        # projects mid-stream was filtered out when its commands ran in
+        # a different project than the final cd.
+        sql += " AND (p.name LIKE ? OR p2.name LIKE ?)"
         params.append(f"%{project_filter}%")
-        
+        params.append(f"%{project_filter}%")
+
     if since_ts:
         sql += " AND s.start_time >= ?"
         params.append(since_ts)
-        
+
     if until_ts:
         sql += " AND s.start_time <= ?"
         params.append(until_ts)
-        
+
     if tag_filters:
         for tag in tag_filters:
             sql += " AND s.tags LIKE ?"
             params.append(f"%{tag}%")
-            
-    sql += " ORDER BY bm.min_match_type ASC, bm.min_rank ASC, s.start_time DESC"
+
+    sql += " GROUP BY s.id ORDER BY bm.min_match_type ASC, bm.min_rank ASC, s.start_time DESC"
     if limit is not None:
         sql += " LIMIT ?"
         params.append(limit)
@@ -143,7 +150,7 @@ def _search_fts5(
     limit: Optional[int] = None
 ) -> List[Dict]:
     cursor = conn.cursor()
-    
+
     terms = query.split()
     sanitized_terms = []
     for term in terms:
@@ -151,12 +158,12 @@ def _search_fts5(
         if clean_term:
             sanitized_terms.append(f'"{clean_term}"*')
     fts_query = " ".join(sanitized_terms)
-    
+
     if not fts_query:
         return []
-        
+
     query_val = f"%{query}%"
-    
+
     sql = """
         WITH fts_matches AS (
             SELECT type, ref_id, project_id, timestamp, rank
@@ -166,39 +173,46 @@ def _search_fts5(
         SELECT s.id, s.start_time, s.end_time, s.duration_seconds, s.project_id, p.name, p.path, s.ai_summary
         FROM sessions s
         LEFT JOIN projects p ON s.project_id = p.id
+        LEFT JOIN commands cmd_per_proj ON cmd_per_proj.session_id = s.id
+        LEFT JOIN projects p2 ON cmd_per_proj.project_id = p2.id
         LEFT JOIN fts_matches f ON (
             (f.type = 'session_summary' AND CAST(f.ref_id AS INTEGER) = s.id)
             OR (f.type = 'command' AND CAST(f.ref_id AS INTEGER) = s.id)
-            OR (f.type = 'commit' AND s.project_id = CAST(f.project_id AS INTEGER) 
-                AND CAST(f.timestamp AS INTEGER) >= s.start_time - 300 
+            OR (f.type = 'commit' AND s.project_id = CAST(f.project_id AS INTEGER)
+                AND CAST(f.timestamp AS INTEGER) >= s.start_time - 300
                 AND CAST(f.timestamp AS INTEGER) <= COALESCE(s.end_time, s.start_time) + 600)
         )
-        WHERE (f.rank IS NOT NULL OR p.name LIKE ?)
+        WHERE (f.rank IS NOT NULL OR p.name LIKE ? OR p2.name LIKE ?)
     """
-    params = [fts_query, query_val]
-    
+    params = [fts_query, query_val, query_val]
+
     if project_filter:
-        sql += " AND p.name LIKE ?"
+        # Match if the session's final project OR any per-command project
+        # matches the filter — fixes #339 where a session that switches
+        # projects mid-stream was filtered out when its commands ran in
+        # a different project than the final cd.
+        sql += " AND (p.name LIKE ? OR p2.name LIKE ?)"
         params.append(f"%{project_filter}%")
-        
+        params.append(f"%{project_filter}%")
+
     if since_ts:
         sql += " AND s.start_time >= ?"
         params.append(since_ts)
-        
+
     if until_ts:
         sql += " AND s.start_time <= ?"
         params.append(until_ts)
-        
+
     if tag_filters:
         for tag in tag_filters:
             sql += " AND s.tags LIKE ?"
             params.append(f"%{tag}%")
-            
+
     sql += " GROUP BY s.id ORDER BY CASE WHEN MIN(f.rank) IS NOT NULL THEN 0 ELSE 1 END, MIN(f.rank) ASC, s.start_time DESC"
     if limit is not None:
         sql += " LIMIT ?"
         params.append(limit)
-    
+
     cursor.execute(sql, params)
     rows = cursor.fetchall()
     return _populate_results(cursor, rows, query)
@@ -222,43 +236,52 @@ def _search_standard(
             FROM sessions s
             LEFT JOIN projects p ON s.project_id = p.id
             LEFT JOIN commands c ON s.id = c.session_id
-            LEFT JOIN commits co ON s.project_id = co.project_id 
-                AND co.timestamp >= s.start_time - 300 
+            LEFT JOIN projects p2 ON c.project_id = p2.id
+            LEFT JOIN commits co ON s.project_id = co.project_id
+                AND co.timestamp >= s.start_time - 300
                 AND co.timestamp <= COALESCE(s.end_time, s.start_time) + 600
             WHERE (
                 p.name LIKE ?
+                OR p2.name LIKE ?
                 OR c.command LIKE ?
                 OR co.message LIKE ?
                 OR co.cleaned_message LIKE ?
                 OR s.ai_summary LIKE ?
             )
         """
-        params = [query_val, query_val, query_val, query_val, query_val]
+        params = [query_val, query_val, query_val, query_val, query_val, query_val]
     else:
         sql = """
             SELECT DISTINCT s.id, s.start_time, s.end_time, s.duration_seconds, s.project_id, p.name, p.path, s.ai_summary
             FROM sessions s
             LEFT JOIN projects p ON s.project_id = p.id
+            LEFT JOIN commands c ON s.id = c.session_id
+            LEFT JOIN projects p2 ON c.project_id = p2.id
             WHERE 1=1
         """
-        
+
     if project_filter:
-        sql += " AND p.name LIKE ?"
+        # Match if the session's final project OR any per-command project
+        # matches the filter — fixes #339 where a session that switches
+        # projects mid-stream was filtered out when its commands ran in
+        # a different project than the final cd.
+        sql += " AND (p.name LIKE ? OR p2.name LIKE ?)"
         params.append(f"%{project_filter}%")
-        
+        params.append(f"%{project_filter}%")
+
     if since_ts:
         sql += " AND s.start_time >= ?"
         params.append(since_ts)
-        
+
     if until_ts:
         sql += " AND s.start_time <= ?"
         params.append(until_ts)
-        
+
     if tag_filters:
         for tag in tag_filters:
             sql += " AND s.tags LIKE ?"
             params.append(f"%{tag}%")
-            
+
     sql += " ORDER BY s.start_time DESC"
     if limit is not None:
         sql += " LIMIT ?"

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -48,34 +48,42 @@ def test_detect_projects(monkeypatch):
     cmd1 = Command(timestamp=1000, command="cd ~/projects/incubator-hugegraph")
     cmd2 = Command(timestamp=1010, command="git status")
     s1 = Session(id=1, start_time=1000, end_time=1010, duration_seconds=10, project_id=None, commands=[cmd1, cmd2])
-    
+
     # Session 2: working in project B
     cmd3 = Command(timestamp=2000, command="cd /Users/username/my-awesome-project")
     cmd4 = Command(timestamp=2020, command="python setup.py install")
     s2 = Session(id=2, start_time=2000, end_time=2020, duration_seconds=20, project_id=None, commands=[cmd3, cmd4])
-    
+
     # Session 3: no cd commands
     cmd5 = Command(timestamp=3000, command="echo 'no projects here'")
     s3 = Session(id=3, start_time=3000, end_time=3000, duration_seconds=0, project_id=None, commands=[cmd5])
-    
+
     projects = detect_projects([s1, s2, s3])
-    
+
     # We should have exactly 2 projects detected
     assert len(projects) == 2
-    
+
     # Verify Project A details
     proj_a = next(p for p in projects if "HugeGraph" in p.name)
     assert proj_a.path == "~/projects/incubator-hugegraph"
     assert proj_a.name == "Apache HugeGraph"
     assert s1.project_id == proj_a.id
-    assert cmd1.project_id == proj_a.id
+    # cmd1 is the cd itself — it ran in home (cwd before the cd takes effect),
+    # so its per-command project_id is None (see #337/#339).
+    assert cmd1.project_id is None
+    # cmd2 ran after the cd, so it correctly attributes to proj_a.
     assert cmd2.project_id == proj_a.id
-    
+
     # Verify Project B details
     proj_b = next(p for p in projects if "Awesome" in p.name)
     assert proj_b.path == "/Users/username/my-awesome-project"
     assert s2.project_id == proj_b.id
-    
+    # s2 starts with cwd still pointing at proj_a (the cwd persists across
+    # sessions to mirror terminal tab preservation). So cmd3, the cd command
+    # itself, attributes to proj_a; the cd only takes effect for cmd4.
+    assert cmd3.project_id == proj_a.id
+    assert cmd4.project_id == proj_b.id
+
     # Session 3 inherits Project B because the simulated cwd persists
     assert s3.project_id == proj_b.id
     assert cmd5.project_id == proj_b.id
@@ -434,3 +442,100 @@ def test_listdir_timeout_caching_custom_ttl(monkeypatch):
     with pytest.raises(TimeoutError) as exc_info2:
         _listdir_with_timeout("/some/custom/ttl/mount", timeout=0.1)
     assert "cached" not in str(exc_info2.value)
+
+
+def test_detect_projects_per_command_project_context(monkeypatch):
+    """#337: per-command project_id reflects the cwd at the time the
+    command was issued, not just the final cwd of the session.
+
+    Regression: previously every command in a session was attributed to the
+    session's final project, so a session that ``cd``-ed into project B
+    from project A had all its commands labelled as B.
+    """
+    import os
+    original_listdir = os.listdir
+
+    def mock_listdir(path):
+        if path in (
+            "/Users/username/Projects/acme-billing",
+            "/Users/username/Projects/mobile-companion",
+        ):
+            return [".git"]
+        return original_listdir(path)
+
+    monkeypatch.setattr(os, "listdir", mock_listdir)
+
+    s = Session(
+        id=1, start_time=1000, end_time=5000, duration_seconds=4000,
+        project_id=None,
+        commands=[
+            Command(timestamp=1000, command="cd ~/Projects/acme-billing"),
+            Command(timestamp=1100, command="pytest tests/test_invoice_totals.py -q"),
+            Command(timestamp=1200, command='git commit -m "Fix invoice rounding"'),
+            Command(timestamp=2000, command="cd ~/Projects/mobile-companion"),
+            Command(timestamp=2100, command="npm run test -- --watch=false"),
+            Command(timestamp=2200, command='git commit -m "Clarify offline retry state"'),
+        ],
+    )
+
+    projects = detect_projects([s])
+
+    # Both projects must be discovered
+    assert len(projects) == 2
+    billing = next(p for p in projects if "Acme Billing" in p.name or "Billing" in p.name or "acme" in p.path.lower())
+    mobile = next(p for p in projects if "Mobile Companion" in p.name or "mobile" in p.path.lower())
+
+    # Session's final project must be the mobile-companion (the final cwd)
+    assert s.project_id == mobile.id
+
+    # Per-command attribution rules (see #337):
+    # - cmd[0] is the cd itself, ran in home → None
+    # - cmd[1..2] ran in acme-billing (after the cd took effect)
+    # - cmd[3] is the cd to mobile, ran in acme-billing → acme-billing
+    # - cmd[4..5] ran in mobile-companion
+    assert s.commands[0].project_id is None
+    assert s.commands[1].project_id == billing.id
+    assert s.commands[2].project_id == billing.id
+    assert s.commands[3].project_id == billing.id
+    assert s.commands[4].project_id == mobile.id
+    assert s.commands[5].project_id == mobile.id
+
+    # Session.project_ids helper exposes the union of distinct command projects
+    assert s.project_ids == {billing.id, mobile.id}
+
+
+def test_detect_projects_per_command_null_handling(monkeypatch):
+    """#337: commands whose cwd is not inside any project root must keep
+    cmd.project_id == None (not inherit the session's final project)."""
+    import os
+    original_listdir = os.listdir
+
+    def mock_listdir(path):
+        if path == "/Users/username/Projects/real-project":
+            return [".git"]
+        return original_listdir(path)
+
+    monkeypatch.setattr(os, "listdir", mock_listdir)
+
+    s = Session(
+        id=1, start_time=1000, end_time=2000, duration_seconds=1000,
+        project_id=None,
+        commands=[
+            Command(timestamp=1000, command="echo 'before cd'"),
+            Command(timestamp=1100, command="cd ~/Projects/real-project"),
+            Command(timestamp=1200, command="git status"),
+        ],
+    )
+
+    projects = detect_projects([s])
+
+    assert len(projects) == 1
+    real_proj = projects[0]
+
+    # First command ran before any cd → no project attribution
+    assert s.commands[0].project_id is None
+    # Second command is the cd itself — runs in the pre-cd cwd (home)
+    # so it gets no project attribution
+    assert s.commands[1].project_id is None
+    # Third command runs inside real-project
+    assert s.commands[2].project_id == real_proj.id

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -91,6 +91,60 @@ def test_database_commits_and_search(tmp_path, monkeypatch):
 
 
 
+def test_project_filter_matches_per_command_project(tmp_path, monkeypatch):
+    """#339: project-filtered search must surface sessions whose *commands*
+    ran in the filtered project, even when the session's final project is
+    different (i.e. the session ``cd``-ed between projects mid-stream).
+    """
+    monkeypatch.setenv("TERMSTORY_DATE_OVERRIDE", "2026-06-06 12:00:00")
+    db_file = tmp_path / "test_per_cmd_search.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    from datetime import datetime
+    now = int(datetime(2026, 6, 6, 12, 0, 0).timestamp())
+
+    # Two distinct projects
+    p_acme = Project(
+        id=1, name="Acme Billing", path="~/Projects/acme-billing",
+        first_seen=now, last_seen=now, session_count=1, total_time=100,
+    )
+    p_mobile = Project(
+        id=2, name="Mobile Companion", path="~/Projects/mobile-companion",
+        first_seen=now, last_seen=now, session_count=1, total_time=100,
+    )
+
+    # Session that ran in Acme, then cd'd to Mobile and finished there.
+    # session.project_id is Mobile (the final project), but the matching
+    # command "stripe ..." ran in Acme and is attributed to Acme via
+    # cmd.project_id == p_acme.id.
+    cmd1 = Command(timestamp=now, command="stripe curl https://api.stripe.com/v1/charges", session_id=1, project_id=1)
+    cmd2 = Command(timestamp=now + 100, command="cd ~/Projects/mobile-companion", session_id=1, project_id=1)
+    cmd3 = Command(timestamp=now + 200, command="npm run test", session_id=1, project_id=2)
+    s1 = Session(
+        id=1, start_time=now, end_time=now + 300, duration_seconds=300,
+        project_id=2, commands=[cmd1, cmd2, cmd3],
+    )
+
+    db.save_data([p_acme, p_mobile], [s1], [cmd1, cmd2, cmd3])
+
+    from termstory.search import advanced_search
+
+    # Filter by Acme: should return s1 because cmd1 ran in Acme.
+    results = advanced_search(db, query="stripe", project_filter="Acme Billing")
+    assert len(results) == 1
+    assert results[0]["session_id"] == 1
+
+    # Filter by Mobile: should also return s1 because cmd3 ran in Mobile
+    # (and the session itself ended in Mobile).
+    results = advanced_search(db, query="npm", project_filter="Mobile Companion")
+    assert len(results) == 1
+
+    # Filter by a project that didn't see this command at all — no match.
+    results = advanced_search(db, query="stripe", project_filter="Nonexistent Project")
+    assert len(results) == 0
+
+
 def test_advanced_search(tmp_path, monkeypatch):
     monkeypatch.setenv("TERMSTORY_DATE_OVERRIDE", "2026-06-06 12:00:00")
     db_file = tmp_path / "test_advanced_search.db"


### PR DESCRIPTION
…by it

When a session cd-ed between projects mid-stream (e.g. cd A; ...; cd B; ...), every command in the session was previously attributed to the session's *final* project (B). This corrupted project-scoped search, summaries, insights, and exports (#337) and made
`termstory search <q> --project A` miss commands that were actually executed in A (#339).

Changes:
- Pass 1 of detect_projects now tracks the cwd for each command as it walks session.commands in order, and assigns cmd.project_id based on the cwd that was active *before* the command's embedded cd subcommands fire. A cd command itself runs in the pre-cd cwd (often home) and is therefore attributed to that cwd's project (None if home), not the post-cd project.
- _assign_project_to_session gains an overwrite_per_command flag (default True) so Pass 1 can keep the per-command values it just computed while Pass 2/3 still attribute every command to the session-level project (the only project they have evidence for).
- Session gains a project_ids property returning the set of distinct project IDs assigned to its commands, exposing the per-command attribution to downstream code.
- _search_fts5, _search_new_fts5, and _search_standard all LEFT JOIN commands+projects so the project_filter matches when *any* per-command project (not just s.project_id) matches the filter, fixing #339.

Regression tests cover per-command attribution, the session.project_ids helper, and the per-command-aware project_filter in advanced_search.

Fixes #337, Fixes #339

## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of Change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [ ] My code follows the "density over decoration" philosophy.
- [ ] I have not used `rich.panel.Panel` in my code.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
