### PR TITLE
ci: add pytest-rerunfailures for flaky-test retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]" 2>/dev/null || pip install -e .
-          pip install pytest pytest-cov pytest-asyncio pytest-timeout
+          pip install pytest pytest-cov pytest-asyncio pytest-timeout pytest-rerunfailures
 
       - name: Run test suite
         run: |
@@ -39,8 +39,9 @@ jobs:
             -q \
             --ignore=tests/stress \
             --ignore=tests/poc_debounced.py \
-            -x \
-            --timeout=60
+            --timeout=60 \
+            --reruns 2 \
+            --reruns-delay 1
 
       - name: Upload coverage report
         if: matrix.python-version == '3.11'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ test = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "pytest-timeout>=2.1.0",
+    "pytest-rerunfailures>=12.0",
 ]
 rag = [
     "sentence-transformers>=2.2.0",


### PR DESCRIPTION
Tests that exercise concurrency, timing, or async behaviour can intermittently fail for environmental reasons that have nothing to do with the code under test. Combined with the existing `-x` flag, a single transient failure short-circuits the whole matrix job.

Wire `pytest-rerunfailures>=12.0` into both CI and the local `[test]` extras so a transient flake is auto-retried before the job is marked failed:

- `pyproject.toml`: add pytest-rerunfailures to the test optional dependencies so dev installs match CI.
- `.github/workflows/ci.yml`: install pytest-rerunfailures in the test matrix, drop `-x` (it works against collecting complete results across retries), and pass `--reruns 2 --reruns-delay 1` to every pytest invocation.

Verified locally with a 1-shot flaky test that the rerun fires once and passes (`1 passed, 1 rerun in 1.03s`).

Fixes #237

## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of Change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [ ] My code follows the "density over decoration" philosophy.
- [ ] I have not used `rich.panel.Panel` in my code.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
