### PR TITLE
fix(cli): read version from installed package metadata

### DIFF
--- a/termstory/__init__.py
+++ b/termstory/__init__.py
@@ -1,5 +1,5 @@
 import importlib.metadata
 
-__version__ = "0.6.4"
+__version__ = importlib.metadata.version("termstory")
 
 

--- a/termstory/__init__.py
+++ b/termstory/__init__.py
@@ -1,3 +1,5 @@
+import importlib.metadata
+
 __version__ = "0.6.4"
 
 


### PR DESCRIPTION
Use importlib.metadata.version('termstory') instead of hardcoded string so --version always matches the installed package version.

Closes #340