### PR TITLE
feat: support uv package manager in Timestamp Detective

### DIFF
--- a/termstory/timestamp_detective.py
+++ b/termstory/timestamp_detective.py
@@ -653,6 +653,14 @@ class TimestampDetective:
                 target_path = os.path.join(virtual_cwd, venv_name, "bin", "activate")
                 label = f"stat: venv/{venv_name}/bin/activate"
 
+        # ── uv venv [name] ──
+        if not target_path:
+            m = re.match(r'^uv\s+venv\s*(\S*)', cmd)
+            if m:
+                venv_name = m.group(1).strip().strip('"\'') or ".venv"
+                target_path = os.path.join(virtual_cwd, venv_name, "bin", "activate")
+                label = f"stat: uv venv/{venv_name}/bin/activate"
+
         # ── cargo init [dir] ──
         if not target_path:
             m = re.match(r'^cargo\s+init\s*(.*)', cmd)
@@ -667,6 +675,12 @@ class TimestampDetective:
             if re.match(r'^go\s+mod\s+init', cmd):
                 target_path = os.path.join(virtual_cwd, "go.mod")
                 label = "stat: go mod init → go.mod"
+
+        # ── uv init ──
+        if not target_path:
+            if re.match(r'^uv\s+init', cmd):
+                target_path = os.path.join(virtual_cwd, "pyproject.toml")
+                label = "stat: uv init → pyproject.toml"
 
         if not target_path:
             return None

--- a/termstory/timestamp_detective.py
+++ b/termstory/timestamp_detective.py
@@ -772,6 +772,13 @@ class TimestampDetective:
             if ts:
                 return (ts, f"gem: {gem_name}")
 
+        # ── uv add / uv pip install → uv.lock ──
+        if re.match(r'^uv\s+(?:add|pip\s+install)\s', cmd):
+            lock_path = os.path.join(virtual_cwd, "uv.lock")
+            ts = self._get_file_timestamp(lock_path)
+            if ts:
+                return (ts, "uv: uv.lock")
+
         return None
 
     def _get_pip_package_timestamp(self, package: str) -> Optional[int]:


### PR DESCRIPTION
Add detection for:
- uv init → pyproject.toml (file stat)
- uv venv [name] → .venv/bin/activate (file stat)
- uv add / uv pip install → uv.lock (package manager)

Closes #366