### PR TITLE
fix: redact credentials in web report command output

### DIFF
--- a/termstory/web.py
+++ b/termstory/web.py
@@ -6,6 +6,7 @@ import webbrowser
 from typing import Optional
 from termstory.insights import analyze_all
 from termstory.formatter import _is_noise_command
+from termstory.sanitizer import redact_command
 from termstory.database import Database
 
 logger = logging.getLogger(__name__)

--- a/termstory/web.py
+++ b/termstory/web.py
@@ -89,11 +89,11 @@ def get_web_data(db: Database, start_ts: Optional[int] = None, end_ts: Optional[
                 "cleaned_message": c.get("cleaned_message", "")
             })
 
-        # Mapped commands
+        # Mapped commands (redacted to avoid embedding secrets in the report)
         commands = []
         for cmd in s.commands:
             commands.append({
-                "command": cmd.command,
+                "command": redact_command(cmd.command),
                 "timestamp": cmd.timestamp,
                 "exit_code": cmd.exit_code,
                 "is_legacy": cmd.is_legacy,


### PR DESCRIPTION
Apply redact_command() to command text when building the web report JSON payload so credential-like patterns are not embedded in the shareable HTML report.

Closes #346