### PR TITLE
enhancement: live-reload support for ~/.termstoryignore

### DIFF
--- a/termstory/sanitizer.py
+++ b/termstory/sanitizer.py
@@ -7,9 +7,6 @@ from typing import List, Tuple, Optional
 logger = logging.getLogger(__name__)
 
 # Load custom redaction patterns from .termstoryignore
-# IMPORTANT: This loads once at module import time (called at the bottom of this file).
-# Edits to ~/.termstoryignore take effect only after restarting TermStory — there is no
-# live-reload. This is a known limitation documented in SECURITY.md.
 def load_custom_ignore_rules() -> tuple:
     local_patterns = []
     paths = [
@@ -30,7 +27,6 @@ def load_custom_ignore_rules() -> tuple:
             except Exception:
                 pass
     return tuple(local_patterns)
-CUSTOM_REDACTION_PATTERNS = load_custom_ignore_rules()
 # Blacklist patterns - if a command matches any of these, the entire session is dropped from AI
 BLACKLIST_PATTERNS = [
     re.compile(r'\bvault\b', re.IGNORECASE),

--- a/termstory/sanitizer.py
+++ b/termstory/sanitizer.py
@@ -269,8 +269,8 @@ def redact_command(cmd: str) -> str:
     # 9. Entropy-based heuristic for high-entropy strings
     cmd = redact_high_entropy(cmd)
     
-    # 10. Custom User Rules
-    for pattern in CUSTOM_REDACTION_PATTERNS:
+    # 10. Custom User Rules (live-reloaded from ~/.termstoryignore)
+    for pattern in load_custom_ignore_rules():
         cmd = pattern.sub('[REDACTED_CUSTOM]', cmd)
         
     return cmd

--- a/termstory/sanitizer.py
+++ b/termstory/sanitizer.py
@@ -6,13 +6,29 @@ from typing import List, Tuple, Optional
 
 logger = logging.getLogger(__name__)
 
-# Load custom redaction patterns from .termstoryignore
+# Live-reloaded custom redaction patterns from ~/.termstoryignore
+# Patterns are cached with mtime-based invalidation; changes to the file
+# are picked up automatically on the next call to load_custom_ignore_rules().
+_cached_ignore_rules: tuple = ()
+_cached_ignore_mtime: float = 0
+
 def load_custom_ignore_rules() -> tuple:
-    local_patterns = []
+    global _cached_ignore_rules, _cached_ignore_mtime
     paths = [
         os.path.expanduser('~/.termstoryignore'),
         os.path.expanduser('~/.termstory/.termstoryignore')
     ]
+    latest_mtime = 0.0
+    found = False
+    for path in paths:
+        if os.path.exists(path):
+            found = True
+            mtime = os.path.getmtime(path)
+            if mtime > latest_mtime:
+                latest_mtime = mtime
+    if found and latest_mtime <= _cached_ignore_mtime:
+        return _cached_ignore_rules
+    local_patterns = []
     for path in paths:
         if os.path.exists(path):
             try:
@@ -26,7 +42,9 @@ def load_custom_ignore_rules() -> tuple:
                                 pass
             except Exception:
                 pass
-    return tuple(local_patterns)
+    _cached_ignore_rules = tuple(local_patterns)
+    _cached_ignore_mtime = latest_mtime
+    return _cached_ignore_rules
 # Blacklist patterns - if a command matches any of these, the entire session is dropped from AI
 BLACKLIST_PATTERNS = [
     re.compile(r'\bvault\b', re.IGNORECASE),

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -85,21 +85,18 @@ def test_custom_termstoryignore(tmp_path):
         # Mock expanduser to return our temp ignore file for the first path only
         mock_expanduser.side_effect = lambda x: str(ignore_file) if x == '~/.termstoryignore' else str(tmp_path / "nonexistent")
         
-        # Clear existing patterns and reload
-        original_patterns = sanitizer.CUSTOM_REDACTION_PATTERNS
-        sanitizer.CUSTOM_REDACTION_PATTERNS = tuple()
+        # Reset cache and reload
+        sanitizer._cached_ignore_rules = ()
+        sanitizer._cached_ignore_mtime = 0
         
-        sanitizer.CUSTOM_REDACTION_PATTERNS = sanitizer.load_custom_ignore_rules()
+        rules = sanitizer.load_custom_ignore_rules()
         
-        assert len(sanitizer.CUSTOM_REDACTION_PATTERNS) == 2
+        assert len(rules) == 2
         
         # Test if it redacts
         cmd = "echo my_custom_secret_pattern is here"
         redacted = sanitizer.redact_command(cmd)
         assert redacted == "echo [REDACTED_CUSTOM] is here"
-        
-        # Restore original patterns
-        sanitizer.CUSTOM_REDACTION_PATTERNS = original_patterns
 
 def test_high_entropy_heuristic():
     # Length >= 24, high entropy
@@ -193,7 +190,7 @@ def test_custom_redaction_patterns_race_condition():
         
     assert not errors, f"Exceptions occurred in threads: {errors}"
     import termstory.sanitizer
-    assert isinstance(termstory.sanitizer.CUSTOM_REDACTION_PATTERNS, tuple)
+    assert isinstance(termstory.sanitizer._cached_ignore_rules, tuple)
 
 
 def test_high_entropy_git_shas_not_redacted():


### PR DESCRIPTION
Add mtime-based caching for ignore rules so changes to ~/.termstoryignore are detected and applied during runtime without restarting the interpreter.

Closes #361

----
## Summary by Gitar

- **TUI features:**
    - Added `ChroniclePlaybackCanvas` for in-place Ghost Typer playback of Daily Chronicle narratives and commands with dynamic pacing (`compute_ghost_typing_pacing`)

<sub>This will update automatically on new commits.</sub>