### PR TITLE
fix: remove non-existent CLI options from docs

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -103,9 +103,7 @@ Toggle observability settings (such as Nemo relay / DeepWiki settings) for Herme
 ```bash
 termstory                    # Today's timeline
 termstory today              # Same as above
-termstory today --detailed   # All commands, no noise filtering, with timestamps
 termstory today --compare    # Side-by-side with yesterday
-termstory today --stats      # Command category frequency table
 ```
 
 ### Search
@@ -119,26 +117,10 @@ termstory search docker --detailed
 termstory search docker --semantic   # Local hybrid semantic/RAG search
 ```
 
-### Historical
-
-```bash
-termstory week               # Current week
-termstory week --last        # Previous week
-termstory month              # Current month
-termstory month "May 2026"   # Specific month
-termstory month --last       # Previous month
-```
-
 ### Projects
 
 ```bash
 termstory project <name>                       # 30-day deep dive
-termstory project myapp --files                # Files edited, by frequency
-termstory project myapp --stats                # Command category breakdown
-termstory projects                             # All tracked projects
-termstory projects --sort time                 # By total hours (default)
-termstory projects --sort recent               # By last active date
-termstory projects --sort name                 # Alphabetically
 termstory project context <name> "description" # Set goals/context for a project
 termstory project context <name> --show        # View project context description
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,7 +10,7 @@ termstory ui   # Fresh start, re-runs onboarding
 ### Force a re-ingest
 
 ```bash
-termstory today --detailed
+termstory today
 ```
 
 Reads the history file fresh and updates the database.


### PR DESCRIPTION
Remove non-existent --detailed and --stats from today examples, week/month commands, --files/--stats on project, and the entire projects command from cli-reference.md.

Closes #336