### PR TITLE
fix: bound _git_log_cache with LRU eviction (max 50 entries)

### DIFF
--- a/termstory/timestamp_detective.py
+++ b/termstory/timestamp_detective.py
@@ -93,11 +93,15 @@ class TimestampDetective:
         be mapped to a valid git root.
     """
 
+    MAX_GIT_LOG_CACHE: int = 50
+    """Maximum number of git log entries to keep in the LRU cache."""
+
     def __init__(self, search_root: str, project_paths: Optional[List[str]] = None):
         self.search_root = os.path.expanduser(search_root)
         self.project_paths = [os.path.expanduser(p) for p in (project_paths or [])]
 
         # Cache: repo_path -> list of commit dicts  (avoid repeated git log calls)
+        # Bounded LRU cache — evicts least-recently-used entries when full.
         self._git_log_cache: OrderedDict[str, List[Dict]] = OrderedDict()
 
         # Lazily resolved package manager roots — populated on first use
@@ -251,6 +255,9 @@ class TimestampDetective:
             logger.debug("timestamp_detective probe failed: %s", e)
 
         self._git_log_cache[repo_path] = commits
+        self._git_log_cache.move_to_end(repo_path)
+        if len(self._git_log_cache) > self.MAX_GIT_LOG_CACHE:
+            self._git_log_cache.popitem(last=False)
         return commits
 
     def _clean_for_match(self, msg: str) -> str:

--- a/termstory/timestamp_detective.py
+++ b/termstory/timestamp_detective.py
@@ -72,6 +72,7 @@ import getpass
 import subprocess
 import difflib
 import site
+from collections import OrderedDict
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple
 
@@ -97,7 +98,7 @@ class TimestampDetective:
         self.project_paths = [os.path.expanduser(p) for p in (project_paths or [])]
 
         # Cache: repo_path -> list of commit dicts  (avoid repeated git log calls)
-        self._git_log_cache: Dict[str, List[Dict]] = {}
+        self._git_log_cache: OrderedDict[str, List[Dict]] = OrderedDict()
 
         # Lazily resolved package manager roots — populated on first use
         self._brew_prefix: Optional[str] = None   # e.g. /opt/homebrew
@@ -216,6 +217,7 @@ class TimestampDetective:
         Returns an empty list if the repo is invalid or git is unavailable.
         """
         if repo_path in self._git_log_cache:
+            self._git_log_cache.move_to_end(repo_path)
             return self._git_log_cache[repo_path]
 
         commits = []


### PR DESCRIPTION
## Summary
`TimestampDetective._git_log_cache` previously grew without bound as a plain `Dict`, keeping every scanned repo's commit log in memory for the lifetime of the run . This PR swaps it for an `OrderedDict`-based LRU cache capped at 50 repos so long-running or multi-repo scans can't leak memory unbounded, fixing #362.

## Changes
- Added `MAX_GIT_LOG_CACHE = 50` class constant and switched `_git_log_cache` from `Dict` to `OrderedDict` in `TimestampDetective.__init__`.
- `_load_git_log` now calls `move_to_end(repo_path)` on cache hits to promote recently-used repos.
- On cache miss, after storing the new entry, `_load_git_log` promotes it via `move_to_end` and evicts the least-recently-used entry with `popitem(last=False)` once the cache exceeds 50 entries.

## Fixes
- Fixes #362 — unbounded memory growth from the git log cache in `TimestampDetective`.

## Testing
- Run the existing suite: `python -m pytest tests/test_timestamp_detective.py`.
- Manually verify eviction by scanning >50 repos and confirming `len(detective._git_log_cache) <= 50` after repeated `_load_git_log` calls.

## Notes
- Review flagged that empty `commits` lists (from invalid/unavailable repos) still consume cache slots — not addressed in this PR, left as a possible follow-up.