### PR TITLE
fix: shorten onboarding modal button labels for 80-col terminals

### DIFF
--- a/termstory/tui.py
+++ b/termstory/tui.py
@@ -475,10 +475,10 @@ class OnboardingScreen(_DeferredDismissMixin, ModalScreen[dict]):
                 id="modal-desc"
             ),
             Horizontal(
-                Button("Groq [Ctrl+g]", variant="default", id="btn-select-groq"),
-                Button("OpenAI [Ctrl+a]", variant="default", id="btn-select-openai"),
-                Button("Ollama [Ctrl+l]", variant="default", id="btn-select-ollama"),
-                Button("Custom [Ctrl+c]", variant="default", id="btn-select-custom"),
+                Button("Groq", variant="default", id="btn-select-groq"),
+                Button("OpenAI", variant="default", id="btn-select-openai"),
+                Button("Ollama", variant="default", id="btn-select-ollama"),
+                Button("Custom", variant="default", id="btn-select-custom"),
                 id="modal-provider-selector"
             ),
             Vertical(

--- a/termstory/tui.py
+++ b/termstory/tui.py
@@ -439,7 +439,7 @@ class OnboardingScreen(_DeferredDismissMixin, ModalScreen[dict]):
         ("ctrl+a", "choose_openai", "Select OpenAI"),
         ("ctrl+l", "choose_ollama", "Select Ollama"),
         ("ctrl+c", "choose_custom", "Select Custom"),
-        ("ctrl+d", "choose_disabled", "Keep Local Only (No AI)"),
+        ("ctrl+d", "choose_disabled", "No AI (Local)"),
         ("escape", "dismiss_none", "Close"),
     ]
     
@@ -495,8 +495,8 @@ class OnboardingScreen(_DeferredDismissMixin, ModalScreen[dict]):
             ),
             Horizontal(
                 Button("Save & Enable", variant="success", id="btn-save"),
-                Button("Keep Local Only (No AI)", variant="error", id="btn-disable-ai"),
-                Button("Read Privacy Policy", variant="default", id="btn-read-privacy"),
+                Button("No AI (Local)", variant="error", id="btn-disable-ai"),
+                Button("Privacy Policy", variant="default", id="btn-read-privacy"),
                 id="modal-actions"
             ),
             id="modal-panel"


### PR DESCRIPTION
Shorten provider action button labels and keybind descriptions so the AI onboarding modal fits in a standard 80-column terminal without truncation.

Closes #345