### PR TITLE
fix(ask): use COALESCE for end_time in session matching

### DIFF
--- a/termstory/ask.py
+++ b/termstory/ask.py
@@ -196,7 +196,7 @@ def search_ask(query: str, db) -> List[Session]:
                 LEFT JOIN commands c ON s.id = c.session_id
                 LEFT JOIN commits co ON s.project_id = co.project_id
                     AND co.timestamp >= s.start_time - 300
-                    AND co.timestamp <= s.end_time + 600
+                    AND co.timestamp <= COALESCE(s.end_time, s.start_time) + 600
                 WHERE {" OR ".join(where_clauses)}
             """
             cursor.execute(sql, params)

--- a/termstory/ask.py
+++ b/termstory/ask.py
@@ -156,7 +156,7 @@ def search_ask(query: str, db) -> List[Session]:
                 OR (f.type = 'command' AND CAST(f.ref_id AS INTEGER) = s.id)
                 OR (f.type = 'commit' AND s.project_id = CAST(f.project_id AS INTEGER)
                     AND CAST(f.timestamp AS INTEGER) >= s.start_time - 300
-                    AND CAST(f.timestamp AS INTEGER) <= s.end_time + 600)
+                    AND CAST(f.timestamp AS INTEGER) <= COALESCE(s.end_time, s.start_time) + 600)
             )
             WHERE f.ref_id IS NOT NULL
         """


### PR DESCRIPTION
Use COALESCE(s.end_time, s.start_time) + 600 in both SQL paths in termstory/ask.py so active sessions (end_time IS NULL) are not excluded from ask context.

Closes #298