### PR TITLE
fix(cli): clean error messages for invalid --since/--until dates

### DIFF
--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -227,7 +227,7 @@ def search_history(
     if until:
         try:
             until_ts = int(date_parser.parse(until).timestamp())
-        except (ValueError, OverflowError) as e:
+        except Exception:
             Console(stderr=True).print(f"[bold red]Error: Invalid date '{until}'. Expected YYYY-MM-DD.[/]")
             raise typer.Exit(code=1)
             

--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -219,7 +219,7 @@ def search_history(
     if since:
         try:
             since_ts = int(date_parser.parse(since).timestamp())
-        except (ValueError, OverflowError) as e:
+        except Exception:
             Console(stderr=True).print(f"[bold red]Error: Invalid date '{since}'. Expected YYYY-MM-DD.[/]")
             raise typer.Exit(code=1)
             


### PR DESCRIPTION
Use a clean 'Invalid date ... Expected YYYY-MM-DD.' message instead of leaking raw dateutil.parser internals.

Closes #256