### PR TITLE
refactor: replace hardcoded sleep() magic numbers with named constants

### DIFF
--- a/termstory/ai.py
+++ b/termstory/ai.py
@@ -12,6 +12,9 @@ from termstory.sanitizer import sanitize_session_commands, redact_command
 
 logger = logging.getLogger(__name__)
 
+# Polling interval for cancellation checks during LLM retry backoff.
+_LLM_RETRY_SLEEP = 0.1
+
 _local_ai_state = threading.local()
 
 # Circuit Breaker Configuration
@@ -222,7 +225,7 @@ def _send_llm_request(
             while time.time() - sleep_start < backoff:
                 if _is_current_worker_cancelled():
                     return None
-                time.sleep(0.1)
+                time.sleep(_LLM_RETRY_SLEEP)
             backoff *= 2.0
             
         if _is_current_worker_cancelled():

--- a/termstory/database.py
+++ b/termstory/database.py
@@ -6,6 +6,9 @@ from termstory.models import Command, Session, Project
 from termstory.config import get_config_value, load_config
 import time
 
+# Delay between retries when database initialization encounters a lock.
+_RETRY_SLEEP = 0.1
+
 
 def _safe_rollback_and_reraise(conn, original_exception):
     """Roll back a failed transaction, surfacing the *original* exception.
@@ -259,7 +262,7 @@ class Database:
                 if "database is locked" in str(e).lower():
                     if conn:
                         conn.close()
-                    time.sleep(0.1)
+                    time.sleep(_RETRY_SLEEP)
                     continue
                 else:
                     if conn:

--- a/termstory/replay.py
+++ b/termstory/replay.py
@@ -10,6 +10,9 @@ from termstory.models import Session, Command, Project, format_duration
 
 console = Console()
 
+# Base delay divided by playback speed after each command is typed.
+_PLAYBACK_DIVISOR = 0.15
+
 MAX_REPLAY_GAP_SECONDS = 2.0
 INITIAL_REPLAY_PAUSE_SECONDS = 0.5
 
@@ -152,7 +155,7 @@ def run_replay(db: Database, session_id: Optional[int] = None, speed: float = 1.
                 time.sleep(char_delay)
 
             # Wait briefly after typing before executing
-            time.sleep(0.15 / speed)
+            time.sleep(_PLAYBACK_DIVISOR / speed)
             sys.stdout.write("\n")
             sys.stdout.flush()
 

--- a/termstory/tui.py
+++ b/termstory/tui.py
@@ -53,6 +53,13 @@ from termstory.config import load_config, save_config
 from termstory.ai import generate_ai_summary, generate_timeframe_summary, generate_daily_chronicle, generate_wrapped_summary
 from termstory.insights import calculate_focus_score, calculate_time_of_day_distribution, assign_daily_rpg_class
 
+# Gap before rendering a debounced search update.
+_FRAME_GAP = 0.25
+
+# Timeout between bulk-summary animation renders.
+_ANIMATION_RENDER_TIMEOUT = 2.0
+
+
 def is_worker_cancelled() -> bool:
     try:
         from textual.worker import get_current_worker, NoActiveWorker
@@ -2660,7 +2667,7 @@ class TermStoryWorkspace(App):
     @work(exclusive=True)
     async def debounce_search(self, query: str) -> None:
         """Debounced search — waits briefly then repopulates the tree."""
-        await asyncio.sleep(0.25)
+        await asyncio.sleep(_FRAME_GAP)
         tree = self.query_one("#history-navigator")
         tree.populate(self.projects, self.sessions, search_query=query, is_deep_search=getattr(self, "is_deep_search_active", False))
         self.refresh_details_canvas()
@@ -3119,7 +3126,7 @@ class TermStoryWorkspace(App):
             self.call_from_thread(update_progress)
             
             if idx < total - 1:
-                time.sleep(2.0)
+                time.sleep(_ANIMATION_RENDER_TIMEOUT)
                 
         self.bulk_running_timeframes.pop(timeframe_id, None)
         if aborted:


### PR DESCRIPTION
## Summary
Replaces hardcoded `time.sleep()`/`asyncio.sleep()` magic numbers with named module-level constants in `termstory/ai.py`, `termstory/database.py`, `termstory/replay.py`, and `termstory/tui.py`. This is a pure refactor for readability and centralized tuning — no timing values change.

---

## Changes

- **`termstory/ai.py`**: Introduced `_LLM_RETRY_SLEEP = 0.1`, replacing the inline `time.sleep(0.1)` polling interval used during LLM retry/backoff cancellation checks .
- **`termstory/database.py`**: Introduced `_RETRY_SLEEP = 0.1`, replacing the inline sleep used when `init_db()` retries after a "database is locked" error.
- **`termstory/replay.py`**: Introduced `_PLAYBACK_DIVISOR = 0.15`, replacing the inline post-typing delay divisor in `run_replay()` .
- **`termstory/tui.py`**: Introduced `_FRAME_GAP = 0.25` (search debounce delay) and `_ANIMATION_RENDER_TIMEOUT = 2.0` (bulk-summary animation render delay), replacing the corresponding inline sleeps in `debounce_search()` and the bulk timeframe progress loop.

## Fixes
- Fixes #221 — centralizes retry/backoff/debounce delay literals into named constants for easier tuning.

## Notes
- Review feedback (`gitar-bot`) flagged that an earlier version of this PR bundled an undocumented 10x NFS cache TTL change (`nfs_timeout_cache_ttl` from `60` to `600`) into what was described as a pure refactor. **That change is not present in the final diff** — only the four sleep/debounce constant renames remain, so the PR is now scoped to its stated purpose.
- All renamed constants are behaviorally equivalent to the literals they replace; no timing values were altered.