### PR TITLE
fix: make macOS install.log path configurable (#150)

### DIFF
--- a/termstory/config.py
+++ b/termstory/config.py
@@ -191,6 +191,8 @@ def load_config() -> dict:
     "~/Work",
     "~",
 ],
+        "nfs_timeout_cache_ttl": 60,
+        "macos_install_log": "/private/var/log/install.log",
     }
     
     config = {}

--- a/termstory/config.py
+++ b/termstory/config.py
@@ -191,7 +191,6 @@ def load_config() -> dict:
     "~/Work",
     "~",
 ],
-        "nfs_timeout_cache_ttl": 60,
         "macos_install_log": "/private/var/log/install.log",
     }
     

--- a/termstory/parser.py
+++ b/termstory/parser.py
@@ -318,9 +318,11 @@ def parse_zsh_history(
                     "parse_zsh_history: project_paths callback raised; "
                     "continuing without project-path enrichment."
                 )
+        _td_config = load_config()
         detective = TimestampDetective(
             search_root=os.path.expanduser("~"),
-            project_paths=resolved_paths or []
+            project_paths=resolved_paths or [],
+            macos_install_log=_td_config.get("macos_install_log", "/private/var/log/install.log")
         )
         enriched_legacy = detective.resolve_all(legacy_items)
     else:

--- a/termstory/timestamp_detective.py
+++ b/termstory/timestamp_detective.py
@@ -96,9 +96,10 @@ class TimestampDetective:
     MAX_GIT_LOG_CACHE: int = 50
     """Maximum number of git log entries to keep in the LRU cache."""
 
-    def __init__(self, search_root: str, project_paths: Optional[List[str]] = None):
+    def __init__(self, search_root: str, project_paths: Optional[List[str]] = None, macos_install_log: str = "/private/var/log/install.log"):
         self.search_root = os.path.expanduser(search_root)
         self.project_paths = [os.path.expanduser(p) for p in (project_paths or [])]
+        self.macos_install_log = macos_install_log
 
         # Cache: repo_path -> list of commit dicts  (avoid repeated git log calls)
         # Bounded LRU cache — evicts least-recently-used entries when full.
@@ -1101,7 +1102,7 @@ class TimestampDetective:
 
         Returns the Unix timestamp or None.
         """
-        log_path = "/private/var/log/install.log"
+        log_path = self.macos_install_log
         if not os.path.exists(log_path):
             return None
         try:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -202,20 +202,20 @@ def test_parse_all_histories_project_paths_propagation(monkeypatch, tmp_path):
     monkeypatch.delenv("TERMSTORY_MISSING_TIMESTAMPS", raising=False)
     temp_file = tmp_path / "zsh_test_history"
     temp_file.write_text("git status\n")
-    
+
     received_project_paths = []
-    
+
     class MockTimestampDetective:
-        def __init__(self, search_root, project_paths):
+        def __init__(self, search_root, project_paths, **kwargs):
             received_project_paths.extend(project_paths)
-            
+
         def resolve_all(self, items):
             return [{"command": "git status", "is_legacy_still": True, "detected_ts": 1748851220, "detected_source": "Mock"}]
-            
+
     monkeypatch.setattr("termstory.parser.TimestampDetective", MockTimestampDetective)
-    
+
     parse_all_histories([str(temp_file)], project_paths=["/path/to/project-a", "/path/to/project-b"])
-    
+
     assert "/path/to/project-a" in received_project_paths
     assert "/path/to/project-b" in received_project_paths
 
@@ -224,16 +224,16 @@ def test_parse_all_histories_project_paths_propagation_callable(monkeypatch, tmp
     monkeypatch.delenv("TERMSTORY_MISSING_TIMESTAMPS", raising=False)
     temp_file = tmp_path / "zsh_test_history"
     temp_file.write_text("git status\n")
-    
+
     received_project_paths = []
-    
+
     class MockTimestampDetective:
-        def __init__(self, search_root, project_paths):
+        def __init__(self, search_root, project_paths, **kwargs):
             received_project_paths.extend(project_paths)
-            
+
         def resolve_all(self, items):
             return [{"command": "git status", "is_legacy_still": True, "detected_ts": 1748851220, "detected_source": "Mock"}]
-            
+
     monkeypatch.setattr("termstory.parser.TimestampDetective", MockTimestampDetective)
     
     callable_called = False

--- a/tests/test_timestamp_detective.py
+++ b/tests/test_timestamp_detective.py
@@ -994,6 +994,41 @@ class TestDetectMacosSystemLog(unittest.TestCase):
                     "alice ttys000 Thu Jun 5 09:14 still logged in"
                 )
 
+    def test_detect_macos_syslog_uses_configured_path(self):
+        """The macos_install_log constructor parameter controls which log is scanned.
+
+        Regression coverage for #150 — users with non-standard macOS setups
+        (relocated log, Docker-based macOS, test harness) can now point
+        TimestampDetective at an alternate log file without monkey-patching
+        os.path.exists or builtins.open.
+        """
+        tmp = tempfile.mkdtemp()
+        try:
+            log_path = os.path.join(tmp, "custom_install.log")
+            dt = datetime.fromtimestamp(FOUR_YEARS_AGO, tz=timezone.utc)
+            stamp = dt.strftime("%Y-%m-%d %H:%M:%S")
+            with open(log_path, "w") as f:
+                f.write(f"{stamp}+00 host installd[1]: Installed: jq\n")
+
+            # Build a detective pointed at the custom log; default /private/var/log/install.log
+            # is guaranteed not to exist in CI, so the only way the lookup succeeds is
+            # if the constructor parameter is honored.
+            d = make_detective(macos_install_log=log_path)
+            ts = d.detect_macos_syslog("jq")
+            self.assertIsNotNone(ts)
+            self.assertEqual(ts, int(dt.timestamp()))
+            # Default value preserved for callers that don't pass the kwarg.
+            self.assertEqual(d.macos_install_log, log_path)
+        finally:
+            import shutil
+
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_detect_macos_syslog_default_path_when_unset(self):
+        """Constructor default for macos_install_log matches the previously hardcoded path."""
+        d = make_detective()
+        self.assertEqual(d.macos_install_log, "/private/var/log/install.log")
+
     def test_detect_macos_syslog_missing_file(self):
         """When install.log doesn't exist (e.g. on Linux), return None."""
         self.assertIsNone(self.d.detect_macos_syslog("jq"))


### PR DESCRIPTION
Closes #150

## Summary

Promotes the hardcoded `/private/var/log/install.log` path inside `detect_macos_syslog()` to a configurable `macos_install_log` constructor parameter on `TimestampDetective`, threads it through `parse_zsh_history()` from the user config, and adds regression coverage that exercises the new parameter end-to-end without monkey-patching `os.path.exists`.

## Changes

**`termstory/timestamp_detective.py`**
- `TimestampDetective.__init__` gains a `macos_install_log: str = "/private/var/log/install.log"` kwarg, stored as `self.macos_install_log`.
- `detect_macos_syslog()` now reads `self.macos_install_log` instead of the literal.

**`termstory/config.py`**
- Adds `"macos_install_log": "/private/var/log/install.log"` to the defaults dict so users can override the path in their config file.

**`termstory/parser.py`**
- `parse_zsh_history()` reads `load_config().get("macos_install_log", "/private/var/log/install.log")` and passes it to `TimestampDetective`. Local default keeps the call working when the key is absent.

**`tests/test_timestamp_detective.py`**
- New `test_detect_macos_syslog_uses_configured_path` — passes a temp `custom_install.log` via the constructor and asserts the timestamp is recovered without any `os.path.exists` patching.
- New `test_detect_macos_syslog_default_path_when_unset` — locks in the default value for backward compatibility.

**`tests/test_parser.py`**
- Both `MockTimestampDetective` classes now accept `**kwargs` so they stay compatible with `parse_zsh_history` passing the new parameter.

## Background

Issue #150 noted that `detect_macos_syslog()` hardcoded the macOS `installd` log path, so users with non-standard setups (relocated log, Docker-based macOS, test harness) couldn't override it without patching source. A previous attempt at this fix (#388) was closed because the diff accidentally bundled 25 unrelated files. This PR contains only the files relevant to #150 (rebased on current `main`).

## Test plan

- [x] New tests pass locally
- [x] Full `tests/test_timestamp_detective.py` and `tests/test_parser.py` (107 tests) pass
- [x] Full project test suite: 650 passed, 1 pre-existing failure in `test_cli_restore_confirmation.py` (Rich line-wrapping issue on long temp paths, also fails on `upstream/main` — unrelated)
- [x] `ruff check` shows no new issues in the lines added by this PR

## Out of scope

This PR intentionally does **not** refactor `List`/`Tuple`/`Optional` typing, fix the `datetime.now(tz=...)` warnings, or address the `F601` duplicate-key warning on `nfs_timeout_cache_ttl` — all of these are pre-existing across the touched files and belong in their own PRs.
