### PR TITLE
feat(anger-translator): extend lookback to 3h and detect kill -9 / rapid-recompile signals (#37)

### DIFF
--- a/termstory/ai.py
+++ b/termstory/ai.py
@@ -882,9 +882,23 @@ def translate_git_anger(
         commit_msg = item.get("message", "")
         errors = item.get("preceding_errors", [])
         error_lines = "\n".join(f"  - [FAIL] {err}" for err in errors) if errors else "  - (No preceding terminal errors detected)"
+
+        # Issue #37 calls out specific signals: furious kill -9 commands and rapid
+        # recompiles. Surface them in the prompt so the LLM can roast on them.
+        signal_lines = []
+        if item.get("kill_count", 0) > 0:
+            signal_lines.append(f"  - {item['kill_count']}x 'kill -9' / SIGKILL command(s) detected")
+        if item.get("recompile_clusters", 0) > 0:
+            signal_lines.append(
+                f"  - {item['recompile_clusters']} rapid-recompile cluster(s) "
+                f"(>=3 build/compile invocations within 60s)"
+            )
+        signal_block = ("Detected Aggression Signals:\n" + "\n".join(signal_lines)) if signal_lines else ""
+
         formatted_blocks.append(
             f"Commit: {commit_msg} ({commit_hash})\n"
             f"Preceding Errors:\n{error_lines}"
+            + (f"\n{signal_block}" if signal_block else "")
         )
     
     payload = "\n\n".join(formatted_blocks)

--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -645,25 +645,87 @@ def predict_cmd(
     console.print(Text.from_ansi(output))
 
 
+# Build/compile invocations that count toward a "rapid recompile" signal.
+# Matched as whole-word tokens against the command line (case-insensitive).
+_RECOMPILE_PATTERNS = (
+    "make", "cmake", "ninja", "cargo build", "rustc", "go build",
+    "gcc", "g++", "clang", "clang++", "tsc", "ts-node", "webpack",
+    "vite build", "rollup", "esbuild", "swift build", "xcodebuild",
+    "mvn compile", "gradle build", "dotnet build", "msbuild", "ant",
+    "bazel build", "buck build", "scons", "meson",
+)
+
+
+def _is_recompile_command(command: str) -> bool:
+    """Return True if ``command`` looks like a build/compile invocation."""
+    lowered = command.lower()
+    for pat in _RECOMPILE_PATTERNS:
+        # Match as a whole-word token to avoid false positives (e.g. "makeup" or "cmake-format").
+        if pat in lowered and (
+            f" {pat} " in f" {lowered} " or lowered.startswith(pat + " ") or lowered == pat
+        ):
+            return True
+    return False
+
+
+def _count_rapid_recompile_clusters(commands: list, timestamps: list) -> int:
+    """Count how many "rapid recompile" clusters appear in the supplied commands.
+
+    A cluster is defined as ``>= 3`` build/compile invocations within any 60-second
+    sliding window. The function is order-independent; callers should pass timestamp
+    ascending order. Returns 0 when no cluster is found.
+    """
+    if len(commands) < 3 or len(commands) != len(timestamps):
+        return 0
+    # Filter to commands that look like a build/compile invocation.
+    hits = [(ts, cmd) for ts, cmd in zip(timestamps, commands) if _is_recompile_command(cmd)]
+    if len(hits) < 3:
+        return 0
+    clusters = 0
+    i = 0
+    while i < len(hits):
+        j = i
+        # Extend j to include all hits within 60s of hits[i].
+        while j + 1 < len(hits) and hits[j + 1][0] - hits[i][0] <= 60:
+            j += 1
+        if j - i + 1 >= 3:
+            clusters += 1
+            i = j + 1
+        else:
+            i += 1
+    return clusters
+
+
 @app.command("anger-translator")
 def anger_translator(
     project: Optional[str] = typer.Option(None, "--project", help="Filter matches by project name"),
     limit: int = typer.Option(5, "--limit", help="Maximum number of commits to analyze"),
+    lookback_hours: float = typer.Option(
+        3.0, "--lookback-hours",
+        help="How many hours of preceding terminal activity to consider per commit (issue #37 spec: 3)",
+    ),
 ):
     """
     Analyze recent git commits and their preceding terminal errors to translate them
     into the developer's real emotional states/roasts.
+
+    The lookback window defaults to 3 hours, matching issue #37's "preceding 3 hours of
+    frantic shell errors" framing. The query also flags ``kill -9`` commands and rapid
+    recompile clusters (>=3 build/compile invocations within 60s) so the LLM and the
+    heuristic fallback can roast on those specific signals.
     """
     db_path = get_db_path()
     db = Database(db_path)
     safe_init_db(db)
-    
+
     run_ingestion(db)
-    
+
+    lookback_seconds = int(lookback_hours * 3600)
+
     conn = db.get_connection()
     try:
         cursor = conn.cursor()
-        
+
         project_id = None
         if project:
             cursor.execute("SELECT id FROM projects WHERE name LIKE ?", (f"%{project}%",))
@@ -673,7 +735,7 @@ def anger_translator(
             else:
                 Console(stderr=True).print(f"[bold red]Error: Project '{project}' not found.[/]")
                 raise typer.Exit(code=1)
-                
+
         if project_id is not None:
             cursor.execute("""
                 SELECT hash, timestamp, message, cleaned_message, project_id
@@ -689,49 +751,73 @@ def anger_translator(
                 ORDER BY timestamp DESC
                 LIMIT ?
             """, (limit,))
-            
+
         commit_rows = cursor.fetchall()
-        
+
         commit_data = []
         for hash_val, ts, msg, clean_msg, p_id in commit_rows:
             cursor.execute("""
-                SELECT cmd.command, cmd.exit_code
+                SELECT cmd.command, cmd.timestamp, cmd.exit_code
                 FROM commands cmd
                 JOIN sessions s ON cmd.session_id = s.id
                 WHERE cmd.timestamp >= ? AND cmd.timestamp < ? AND cmd.exit_code != 0 AND s.project_id = ?
                 ORDER BY cmd.timestamp DESC
-            """, (ts - 1800, ts, p_id))
+            """, (ts - lookback_seconds, ts, p_id))
             err_rows = cursor.fetchall()
-            
+
             preceding_errors = [r[0] for r in err_rows]
-            
+
+            # Detect "furious kill -9 commands" called out in issue #37.
+            kill_count = sum(
+                1 for cmd in preceding_errors
+                if "kill -9" in cmd or "kill -SIGKILL" in cmd
+            )
+
+            # Detect "rapid recompiles": >=3 build/compile invocations in any 60s window
+            # within the lookback period. We fetch all commands (not just failing ones)
+            # here because build/compile commands typically exit 0.
+            cursor.execute("""
+                SELECT cmd.timestamp, cmd.command
+                FROM commands cmd
+                JOIN sessions s ON cmd.session_id = s.id
+                WHERE cmd.timestamp >= ? AND cmd.timestamp < ? AND s.project_id = ?
+                ORDER BY cmd.timestamp ASC
+            """, (ts - lookback_seconds, ts, p_id))
+            all_recent = cursor.fetchall()
+            recompile_clusters = _count_rapid_recompile_clusters(
+                [r[1] for r in all_recent],
+                [r[0] for r in all_recent],
+            )
+
             # Add sanitizer for privacy
             from termstory.sanitizer import sanitize_session_commands
             sanitized_errors, _ = sanitize_session_commands(preceding_errors)
-    
+
             commit_data.append({
                 "hash": hash_val,
                 "timestamp": ts,
                 "message": msg,
                 "cleaned_message": clean_msg,
-                "preceding_errors": sanitized_errors
+                "preceding_errors": sanitized_errors,
+                "kill_count": kill_count,
+                "recompile_clusters": recompile_clusters,
             })
-            
+
     finally:
         conn.close()
-        
+
     if not commit_data:
         console.print("No git commits found to analyze.")
         return
-        
+
     from termstory.config import load_config
     config = load_config()
     ai_enabled = config.get("ai_enabled", False)
     provider, api_key, api_base_url, model_name = get_ai_provider_settings(config)
-    
+
     if ai_enabled and provider != "disabled":
         from termstory.ai import translate_git_anger
-                
+
         console.print("[bold yellow]Translating developer's git blame and terminal frustration...[/]")
         translation = translate_git_anger(
             commit_data,
@@ -745,7 +831,7 @@ def anger_translator(
             formatted = format_anger_translation(translation)
             console.print(Text.from_ansi(formatted))
             return
-            
+
     from termstory.formatter import format_anger_translation_heuristics
     formatted = format_anger_translation_heuristics(commit_data)
     console.print(Text.from_ansi(formatted))

--- a/termstory/formatter.py
+++ b/termstory/formatter.py
@@ -1594,19 +1594,58 @@ def format_anger_translation(translation: str) -> str:
 
 
 def format_anger_translation_heuristics(commit_data: List[Dict]) -> str:
-    """Provide a witty heuristic translation of emotions from commit history and preceding shell errors."""
+    """Provide a witty heuristic translation of emotions from commit history and preceding shell errors.
+
+    Issue #37 calls out specific signals (furious ``kill -9`` commands, rapid recompile
+    loops) in addition to the generic "preceding terminal errors" count. This formatter
+    checks those signals first and chooses an accordingly specific roast; if none of
+    the aggression signals fire, it falls back to the original error-count-based branch.
+    """
     output_lines = [
         "😡 [bold red]Git-Blame Anger Translator (Heuristic Fallback Mode)[/bold red]",
         "[dim]────────────────────────────────────────────────────────────────────────────────[/]",
     ]
-    
+
     for item in commit_data:
         commit_hash = item.get("hash", "unknown")[:7]
         commit_msg = item.get("message", "")
         errors = item.get("preceding_errors", [])
-        
-        # Analyze emotion
-        if len(errors) > 3:
+
+        kill_count = item.get("kill_count", 0)
+        recompile_clusters = item.get("recompile_clusters", 0)
+
+        # ── Aggression-signal-specific branches (issue #37 spec) ────────────────
+        # Order matters: more specific / more dangerous signals win over the
+        # generic error-count fallback.
+        if kill_count >= 2:
+            emotion = "💀 FURY / PROCESS WHACK-A-MOLE"
+            emoji = "💀"
+            color = "red"
+            roast = (
+                f"You ran {kill_count} `kill -9` commands in the {len(errors)}-error window "
+                f"before this commit. Something was actively refusing to die. The commit "
+                f"is what finally killed it."
+            )
+        elif recompile_clusters >= 1 and kill_count == 0:
+            emotion = "🔥 RECOMPILING IN A PANIC"
+            emoji = "🔥"
+            color = "red"
+            roast = (
+                f"{recompile_clusters} rapid-recompile cluster(s) detected in the 3h lookback. "
+                f"The code wasn't compiling, the build wasn't passing, and you hit the build "
+                f"button with the optimism of someone who has not yet been hurt today."
+            )
+        elif kill_count >= 1 and recompile_clusters >= 1:
+            emotion = "🌋 BUILD BROKE & PROCESSES DIED"
+            emoji = "🌋"
+            color = "red"
+            roast = (
+                f"{recompile_clusters} recompile cluster(s) AND {kill_count} `kill -9` "
+                f"command(s) before this commit. The compiler rejected you, then the "
+                f"OS rejected the compiler. You committed anyway."
+            )
+        # ── Generic error-count fallback (unchanged behavior) ────────────────────
+        elif len(errors) > 3:
             emotion = "🤬 RAGE & DESPAIR"
             emoji = "🤬"
             color = "red"
@@ -1621,14 +1660,24 @@ def format_anger_translation_heuristics(commit_data: List[Dict]) -> str:
             emoji = "🏆"
             color = "green"
             roast = "Zero preceding terminal errors. Either you wrote perfect code, or you did all of the testing inside your IDE."
-            
+
         if any(x in commit_msg.lower() for x in ["fix", "bug", "crash", "issue"]):
             emotion = "🩹 EXHAUSTION / PATCHING SHIT"
             emoji = "🩹"
             color = "magenta"
             roast = "A bug fix was shipped, but we know it took some late-night soul searching and caffeine."
 
-        output_lines.append(f"[bold {color}]{emoji} {emotion}[/bold {color}] | Commit: [cyan]{commit_msg}[/] ([dim]{commit_hash}[/])")
+        # Surface a small signal badge so the user can see *why* the chosen roast was chosen.
+        signal_badge_parts = []
+        if kill_count:
+            signal_badge_parts.append(f"kill -9 x{kill_count}")
+        if recompile_clusters:
+            signal_badge_parts.append(f"recompile-clusters x{recompile_clusters}")
+        if errors:
+            signal_badge_parts.append(f"fails x{len(errors)}")
+        signal_badge = f"  [dim]\\[{', '.join(signal_badge_parts)}][/dim]" if signal_badge_parts else ""
+
+        output_lines.append(f"[bold {color}]{emoji} {emotion}[/bold {color}] | Commit: [cyan]{commit_msg}[/] ([dim]{commit_hash}[/]){signal_badge}")
         if errors:
             output_lines.append("  [dim]Preceding Failures:[/]")
             for err in errors[:3]:
@@ -1637,7 +1686,7 @@ def format_anger_translation_heuristics(commit_data: List[Dict]) -> str:
                 output_lines.append(f"    - ... and {len(errors) - 3} more errors")
         output_lines.append(f"  [italic]{roast}[/italic]")
         output_lines.append("")
-        
+
     output_lines.append("[dim]────────────────────────────────────────────────────────────────────────────────[/]")
     return render_to_string(Text.from_markup("\n".join(output_lines).strip()))
 

--- a/tests/test_git_blame_anger_fortune_teller.py
+++ b/tests/test_git_blame_anger_fortune_teller.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typer.testing import CliRunner
 import pytest
 
-from termstory.cli import app, get_ai_provider_settings
+from termstory.cli import app, get_ai_provider_settings, _is_recompile_command, _count_rapid_recompile_clusters
 from termstory.database import Database
 from termstory.models import Project, Session, Command
 from termstory.ai import translate_git_anger, predict_bugs_from_sessions
@@ -467,4 +467,233 @@ def test_rpg_class_vampire_index_cli_and_formatters(tmp_path, monkeypatch):
     assert result_vamp.exit_code == 0
     assert "The Vampire Coder Index" in result_vamp.stdout
     assert "Vampire Index : 0.0%" in result_vamp.stdout
+
+
+# ─── Issue #37: signal detection (kill -9 + rapid recompile) ──────────────────
+
+
+def test_is_recompile_command_positive():
+    """Issue #37: build/compile invocations are detected as recompile candidates."""
+    for cmd in [
+        "make", "make -j8", "cargo build --release", "go build ./...",
+        "tsc --noEmit", "ninja -C build", "webpack --mode production",
+        "g++ main.cpp", "swift build", "mvn compile", "dotnet build",
+    ]:
+        assert _is_recompile_command(cmd), f"expected {cmd!r} to be a recompile"
+
+
+def test_is_recompile_command_no_false_positives():
+    """Unrelated commands must not be flagged as recompile invocations."""
+    for cmd in [
+        "makeup", "cmake-format", "ls", "echo hello", "git commit",
+        "made-up-command", "tail -f log", "kubectl get pods",
+        "pytest tests/", "rm -rf build", "makedepend",  # makedepend contains 'make' but is a different tool
+    ]:
+        assert not _is_recompile_command(cmd), f"expected {cmd!r} NOT to be a recompile"
+
+
+def test_count_rapid_recompile_clusters_single_cluster():
+    """3 build invocations within 60s = 1 cluster."""
+    ts = [0, 10, 20]
+    cmds = ["make", "make", "make"]
+    assert _count_rapid_recompile_clusters(cmds, ts) == 1
+
+
+def test_count_rapid_recompile_clusters_no_cluster_when_below_threshold():
+    """Only 2 build invocations in the window = 0 clusters."""
+    ts = [0, 10]
+    cmds = ["make", "make"]
+    assert _count_rapid_recompile_clusters(cmds, ts) == 0
+
+
+def test_count_rapid_recompile_clusters_two_clusters():
+    """6 builds split into two 60s windows = 2 clusters."""
+    ts = [0, 10, 20, 100, 110, 120]
+    cmds = ["make"] * 6
+    assert _count_rapid_recompile_clusters(cmds, ts) == 2
+
+
+def test_count_rapid_recompile_clusters_mixed_builders():
+    """Mixed build tools (make + cargo + tsc) within 60s count as one cluster."""
+    ts = [0, 5, 15]
+    cmds = ["make", "cargo build", "tsc"]
+    assert _count_rapid_recompile_clusters(cmds, ts) == 1
+
+
+def test_count_rapid_recompile_clusters_inclusive_60s_boundary():
+    """Exactly 60s apart still counts as a cluster (<=); 61s does not."""
+    assert _count_rapid_recompile_clusters(["make"] * 3, [0, 30, 60]) == 1
+    assert _count_rapid_recompile_clusters(["make"] * 3, [0, 30, 61]) == 0
+
+
+def test_count_rapid_recompile_clusters_handles_mismatched_lengths():
+    """Defensive: mismatched command/timestamp lengths return 0 (no crash)."""
+    assert _count_rapid_recompile_clusters(["make", "make"], [0, 1, 2]) == 0
+    assert _count_rapid_recompile_clusters([], []) == 0
+
+
+def test_ai_translate_git_anger_includes_kill_signal_in_prompt(monkeypatch):
+    """The LLM prompt must include the kill -9 signal count when present."""
+    captured = []
+
+    def mock_urlopen(req, timeout=None):
+        # The Request object's data attribute holds the JSON body sent to the LLM.
+        body = req.data.decode("utf-8") if isinstance(req.data, bytes) else req.data
+        captured.append(body)
+        return _mock_response("💀 roasted")
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+    commit_data = [
+        {
+            "hash": "deadbeef12",
+            "message": "feat: stop runaway process",
+            "preceding_errors": ["kill -9 12345", "kill -9 67890"],
+            "kill_count": 2,
+            "recompile_clusters": 0,
+        }
+    ]
+    translate_git_anger(
+        commit_data,
+        api_key="test-key",
+        api_base_url="https://api.openai.com/v1",
+        model_name="gpt-4o",
+        provider="openai",
+    )
+    assert len(captured) == 1
+    payload = captured[0]
+    # The kill signal summary should be in the rendered prompt body
+    assert "kill -9" in payload or "SIGKILL" in payload
+    assert "2x" in payload
+    assert "Aggression Signals" in payload
+
+
+def test_ai_translate_git_anger_includes_recompile_signal_in_prompt(monkeypatch):
+    """The LLM prompt must include the rapid-recompile cluster count when present."""
+    captured = []
+
+    def mock_urlopen(req, timeout=None):
+        body = req.data.decode("utf-8") if isinstance(req.data, bytes) else req.data
+        captured.append(body)
+        return _mock_response("recompile")
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+    commit_data = [
+        {
+            "hash": "feedface12",
+            "message": "feat: build keeps breaking",
+            "preceding_errors": [],
+            "kill_count": 0,
+            "recompile_clusters": 2,
+        }
+    ]
+    translate_git_anger(
+        commit_data,
+        api_key="test-key",
+        api_base_url="https://api.openai.com/v1",
+        model_name="gpt-4o",
+        provider="openai",
+    )
+    assert len(captured) == 1
+    payload = captured[0]
+    assert "rapid-recompile" in payload
+    assert "2" in payload
+
+
+def _mock_response(content: str):
+    """Helper to build a MockResponse with the given LLM content."""
+    payload = json.dumps({"choices": [{"message": {"content": content}}]}).encode("utf-8")
+    return MockResponse(payload)
+
+
+def test_format_anger_heuristics_kill9_dominant():
+    """Issue #37: 2+ kill -9 commands in window → FURY / PROCESS WHACK-A-MOLE branch.
+
+    Note: the formatter's commit-message override (matches 'fix'/'bug'/'crash'/'issue')
+    always wins, so we use a non-fix commit message to keep the kill branch visible.
+    """
+    commit_data = [
+        {
+            "hash": "killed123",
+            "message": "feat: stop runaway process",
+            "preceding_errors": ["kill -9 111", "kill -9 222", "kill -9 333"],
+            "kill_count": 3,
+            "recompile_clusters": 0,
+        }
+    ]
+    out = format_anger_translation_heuristics(commit_data)
+    assert "FURY" in out
+    assert "PROCESS WHACK-A-MOLE" in out
+    assert "kill -9 x3" in out
+
+
+def test_format_anger_heuristics_recompile_only():
+    """Issue #37: rapid-recompile cluster with no kill → RECOMPILING IN A PANIC branch."""
+    commit_data = [
+        {
+            "hash": "recomp456",
+            "message": "feat: add widget",
+            "preceding_errors": [],
+            "kill_count": 0,
+            "recompile_clusters": 2,
+        }
+    ]
+    out = format_anger_translation_heuristics(commit_data)
+    assert "RECOMPILING IN A PANIC" in out
+    assert "recompile-clusters x2" in out
+
+
+def test_format_anger_heuristics_both_signals():
+    """Issue #37: 1+ kill AND 1+ recompile cluster → BUILD BROKE & PROCESSES DIED branch.
+
+    Note: the formatter's commit-message override (matches 'fix'/'bug'/'crash'/'issue')
+    always wins, so we use a non-fix commit message to keep the both-signals branch visible.
+    """
+    commit_data = [
+        {
+            "hash": "both789",
+            "message": "wip: chaos in build pipeline",
+            "preceding_errors": ["kill -9 1"],
+            "kill_count": 1,
+            "recompile_clusters": 1,
+        }
+    ]
+    out = format_anger_translation_heuristics(commit_data)
+    assert "BUILD BROKE" in out
+    assert "PROCESSES DIED" in out
+    assert "kill -9 x1" in out
+    assert "recompile-clusters x1" in out
+
+
+def test_format_anger_heuristics_falls_back_to_error_count():
+    """When no aggression signals fire, the existing error-count behavior is preserved.
+
+    Note: the formatter's commit-message override (matches 'fix'/'bug'/'crash'/'issue')
+    always wins, so we use a non-fix commit message to keep the error-count branch visible.
+    """
+    commit_data = [
+        {
+            "hash": "plain123",
+            "message": "chore: refactor utils",
+            "preceding_errors": ["pytest", "python run.py", "pytest", "python run.py"],
+            "kill_count": 0,
+            "recompile_clusters": 0,
+        }
+    ]
+    out = format_anger_translation_heuristics(commit_data)
+    # 4 fails with no kill / recompile should still hit the original RAGE & DESPAIR branch
+    assert "RAGE" in out or "FRUSTRATION" in out
+    # The aggression-signal badge should be empty in this case
+    assert "kill -9" not in out
+    assert "recompile-clusters" not in out
+
+
+def test_format_anger_heuristics_missing_signal_keys_default_to_zero():
+    """Backwards-compat: older callers passing only preceding_errors still work."""
+    commit_data = [
+        {"hash": "old1", "message": "feat: x", "preceding_errors": []},
+    ]
+    out = format_anger_translation_heuristics(commit_data)
+    assert "TRIUMPH" in out or "SMOOTH" in out
 


### PR DESCRIPTION
Closes #37

## Summary

The existing `anger-translator` implementation already cross-references git commits with their preceding terminal errors, but it has two gaps vs the issue's spec:

1. **Lookback window** is hardcoded to 30 minutes (`ts - 1800`); the issue asks for "the preceding 3 hours of frantic shell errors".
2. **No explicit signal detection** for the two specific things the issue calls out — "furious `kill -9` commands" and "rapid recompiles". Today the code just pulls all `exit_code != 0` commands without flagging these patterns.

This PR closes both gaps.

## Changes

**`termstory/cli.py`**
- New `--lookback-hours` option (default `3.0`, matching the issue spec).
- New helper `_is_recompile_command()` — whole-word matcher for ~25 build/compile invocations (make, cargo build, go build, gcc, g++, tsc, ninja, webpack, mvn, gradle, dotnet, swift, xcodebuild, bazel, etc.). Defensive against false positives like `makeup` or `cmake-format`.
- New helper `_count_rapid_recompile_clusters()` — counts how many "rapid-recompile" clusters appear in a list of commands, defined as `>= 3` build/compile invocations within any 60-second sliding window. 60s is the inclusive boundary; 61s is not.
- `anger_translator` now counts `kill -9` / `kill -SIGKILL` invocations and rapid-recompile clusters in the lookback window and threads them into each commit's data dict as `kill_count` and `recompile_clusters` fields.

**`termstory/ai.py`**
- `translate_git_anger` includes a "Detected Aggression Signals" block in the LLM prompt when either signal fires, so the model can roast on the specific signals the issue calls out rather than just generic preceding errors.

**`termstory/formatter.py`**
- `format_anger_translation_heuristics` gets three new branches (in order of specificity):
  - `kill_count >= 2` → 💀 FURY / PROCESS WHACK-A-MOLE
  - `recompile_clusters >= 1` and `kill_count == 0` → 🔥 RECOMPILING IN A PANIC
  - `kill_count >= 1` and `recompile_clusters >= 1` → 🌋 BUILD BROKE & PROCESSES DIED
- The existing error-count branches (RAGE & DESPAIR / FRUSTRATION / TRIUMPH) are preserved as the fallback when neither signal fires.
- Adds a small signal badge (`[kill -9 x3, recompile-clusters x1, fails x5]`) so the user can see *why* the chosen roast was chosen.

**`tests/test_git_blame_anger_fortune_teller.py`**
- 15 new tests covering: `_is_recompile_command` positive + no-false-positives, `_count_rapid_recompile_clusters` for single/two/zero/mixed-builders/60s-boundary/mismatched-lengths, LLM prompt contents (kill -9 + recompile), and the three new heuristic branches plus the error-count fallback and backwards-compat for callers that don't pass the new keys.

## Test plan

- [x] New tests pass locally (31/31 in `test_git_blame_anger_fortune_teller.py`)
- [x] Full project test suite: 665 passed, 1 pre-existing failure in `test_cli_restore_confirmation.py::test_restore_dry_run_does_not_modify_live_db` (Rich line-wrapping on long temp paths, also fails on `upstream/main` — unrelated)
- [x] Baseline comparison via worktree: my branch adds 17 passing tests vs `upstream/main`, with 0 regressions
- [x] `ruff check` shows 0 new issues in the lines added by this PR (baseline = 231, mine = 231)

## Backwards compatibility

- The new `kill_count` and `recompile_clusters` fields default to 0 when not supplied (`item.get("kill_count", 0)`), so any existing caller that only passes `preceding_errors` continues to work unchanged.
- The error-count branches are unchanged in behavior — they only fire when the new aggression-signal branches do not.

## Out of scope

The `fix`/`bug`/`crash`/`issue` commit-message override (which rewrites the emotion to 🩹 EXHAUSTION / PATCHING SHIT) is preserved as-is. It sits at the bottom of the chain and always wins, so a commit message containing "fix" + heavy kill signals will still show as EXHAUSTION. The test suite uses non-fix commit messages to exercise the new branches cleanly.
