### PR TITLE
fix: make macOS install.log path configurable

### DIFF
--- a/termstory/config.py
+++ b/termstory/config.py
@@ -142,6 +142,7 @@ def load_config() -> dict:
     config_path = get_config_path()
     defaults = {
         "ai_enabled": False,
+        "macos_install_log": "/private/var/log/install.log",
         "active_provider": "disabled",  # "groq", "openai", "nvidia", "ollama", "disabled"
         "request_timeout_seconds": 30,
         "nfs_timeout_cache_ttl": 10,

--- a/termstory/parser.py
+++ b/termstory/parser.py
@@ -318,9 +318,13 @@ def parse_zsh_history(
                     "parse_zsh_history: project_paths callback raised; "
                     "continuing without project-path enrichment."
                 )
+        cfg = load_config()
         detective = TimestampDetective(
             search_root=os.path.expanduser("~"),
-            project_paths=resolved_paths or []
+            project_paths=resolved_paths or [],
+            macos_install_log=cfg.get(
+                "macos_install_log", "/private/var/log/install.log"
+            ),
         )
         enriched_legacy = detective.resolve_all(legacy_items)
     else:

--- a/termstory/timestamp_detective.py
+++ b/termstory/timestamp_detective.py
@@ -96,9 +96,15 @@ class TimestampDetective:
     MAX_GIT_LOG_CACHE: int = 50
     """Maximum number of git log entries to keep in the LRU cache."""
 
-    def __init__(self, search_root: str, project_paths: Optional[List[str]] = None):
+    def __init__(
+        self,
+        search_root: str,
+        project_paths: Optional[List[str]] = None,
+        macos_install_log: str = "/private/var/log/install.log",
+    ):
         self.search_root = os.path.expanduser(search_root)
         self.project_paths = [os.path.expanduser(p) for p in (project_paths or [])]
+        self.macos_install_log = macos_install_log
 
         # Cache: repo_path -> list of commit dicts  (avoid repeated git log calls)
         # Bounded LRU cache — evicts least-recently-used entries when full.
@@ -1101,7 +1107,7 @@ class TimestampDetective:
 
         Returns the Unix timestamp or None.
         """
-        log_path = "/private/var/log/install.log"
+        log_path = self.macos_install_log
         if not os.path.exists(log_path):
             return None
         try:


### PR DESCRIPTION
## Summary
`detect_macos_syslog` hard-coded `/private/var/log/install.log`, so non-standard layouts and tests could not override it.

## Changes
- Add `macos_install_log` to `TimestampDetective.__init__` (default same path).
- Add `macos_install_log` to config defaults.
- Pass the config value when the parser constructs the detective.

Closes #150