### PR TITLE
[Date] Honor TERMSTORY_DATE_OVERRIDE at remaining datetime.now() site…

### DIFF
--- a/termstory/backup.py
+++ b/termstory/backup.py
@@ -27,6 +27,7 @@ def backup_db() -> str:
     if not os.path.isfile(db_path):
         raise FileNotFoundError(f"TermStory database not found at {db_path}")
     backup_dir = _get_backup_dir()
+    # Wall-clock intentionally: backup filenames must be unique on disk.
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     backup_path = os.path.join(backup_dir, f"termstory_backup_{timestamp}.db")
 

--- a/termstory/database.py
+++ b/termstory/database.py
@@ -275,7 +275,7 @@ class Database:
         try:
             cursor.execute("SELECT created_at FROM macro_summaries WHERE timeframe_id = 'last_vacuum'")
             row = cursor.fetchone()
-            current_time = int(datetime.utcnow().timestamp())
+            current_time = int(get_current_time().timestamp())
             if not row or (current_time - row[0]) >= 7 * 24 * 3600:
                 cursor.execute("VACUUM;")
                 cursor.execute("""

--- a/termstory/database.py
+++ b/termstory/database.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import List, Dict, Optional
 from termstory.models import Command, Session, Project
 from termstory.config import get_config_value, load_config
+from termstory.date_utils import get_current_time
 import time
 
 # Delay between retries when database initialization encounters a lock.
@@ -732,7 +733,7 @@ class Database:
             cursor.execute("""
                 INSERT OR REPLACE INTO macro_summaries (timeframe_id, type, summary, created_at)
                 VALUES ('last_ingestion', 'system', 'ingestion', ?)
-            """, (int(datetime.now().timestamp()),))
+            """, (int(get_current_time().timestamp()),))
 
             conn.commit()
         except Exception as e:

--- a/termstory/exporter.py
+++ b/termstory/exporter.py
@@ -19,6 +19,7 @@ def _get_timestamp(dt: datetime) -> int:
         try:
             dt = dt.astimezone()
         except OSError:
+            # Wall-clock intentionally: need the real local UTC offset on Windows.
             local_offset = datetime.now().astimezone().utcoffset()
             dt = dt.replace(tzinfo=timezone(local_offset))
     epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
@@ -30,6 +31,7 @@ def _safe_fromtimestamp(ts: float) -> datetime:
     try:
         local_dt = utc_dt.astimezone()
     except OSError:
+        # Wall-clock intentionally: need the real local UTC offset on Windows.
         local_offset = datetime.now().astimezone().utcoffset()
         local_dt = utc_dt.astimezone(timezone(local_offset))
     return local_dt.replace(tzinfo=None)

--- a/termstory/parser.py
+++ b/termstory/parser.py
@@ -5,6 +5,7 @@ import sqlite3
 from datetime import datetime, timedelta
 from typing import List, Optional, Dict, Any, Union, Callable
 from termstory.models import Command
+from termstory.date_utils import get_current_time
 from termstory.timestamp_detective import TimestampDetective
 
 logger = logging.getLogger(__name__)
@@ -245,7 +246,7 @@ def parse_zsh_history(
             "parse_zsh_history: failed to stat %r for mtime; using current time as anchor.",
             filepath,
         )
-        file_mtime = int(datetime.now().timestamp())
+        file_mtime = int(get_current_time().timestamp())
 
     n_legacy = len(legacy_items)
 
@@ -257,7 +258,7 @@ def parse_zsh_history(
     # or recent activity, we enforce a strict 30-day buffer from file_mtime.
     BUFFER_30_DAYS = 30 * 86400
 
-    now_temp = int(datetime.now().timestamp())
+    now_temp = int(get_current_time().timestamp())
     from termstory.config import load_config
     max_history_age_temp = load_config().get("max_history_age", 5)
     five_years_ago_temp = now_temp - (max_history_age_temp * 365 * 24 * 60 * 60)
@@ -445,7 +446,7 @@ def parse_zsh_history(
         ))
 
     # Standard filtering: drop impossibly old or future-dated commands
-    now = int(datetime.now().timestamp())
+    now = int(get_current_time().timestamp())
     from termstory.config import load_config
     max_history_age = load_config().get("max_history_age", 5)
     five_years_ago = now - (max_history_age * 365 * 24 * 60 * 60)
@@ -476,7 +477,7 @@ def parse_bash_history(
             "parse_bash_history: failed to stat %r for mtime; using current time as anchor.",
             filepath,
         )
-        mtime = int(datetime.now().timestamp())
+        mtime = int(get_current_time().timestamp())
 
     raw_lines = []
     with open(filepath, 'r', encoding='utf-8', errors='replace') as f:
@@ -737,7 +738,7 @@ def _assign_missing_timestamps_fallback(
             ))
             
     # Standard filtering (older than max_history_age or future timestamps)
-    now = int(datetime.now().timestamp())
+    now = int(get_current_time().timestamp())
     from termstory.config import load_config
     max_history_age = load_config().get("max_history_age", 5)
     five_years_ago = now - (max_history_age * 365 * 24 * 60 * 60)
@@ -770,7 +771,7 @@ def parse_fish_history(
             "parse_fish_history: failed to stat %r for mtime; using current time as anchor.",
             filepath,
         )
-        mtime = int(datetime.now().timestamp())
+        mtime = int(get_current_time().timestamp())
         
     temp_commands = []
     with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
@@ -820,7 +821,7 @@ def parse_powershell_history(
             "parse_powershell_history: failed to stat %r for mtime; using current time as anchor.",
             filepath,
         )
-        mtime = int(datetime.now().timestamp())
+        mtime = int(get_current_time().timestamp())
         
     raw_lines = []
     with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:

--- a/termstory/predict.py
+++ b/termstory/predict.py
@@ -18,6 +18,7 @@ from collections import Counter, defaultdict
 from typing import List, Dict, Optional, Tuple
 
 from termstory.database import Database
+from termstory.date_utils import get_current_time
 from termstory.formatter import _is_noise_command
 
 
@@ -310,7 +311,7 @@ class Predictor:
             raise ValueError("days must be greater than 0")
 
         if now is None:
-            now = datetime.now()
+            now = get_current_time()
         tz = now.tzinfo
 
         cutoff_time = None

--- a/termstory/timeline.py
+++ b/termstory/timeline.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta
 from typing import Dict, List
 
 from termstory.database import Database
+from termstory.date_utils import get_current_time
 from termstory.models import Session
 
 def _aggregate_sessions_by_day(sessions: List[Session]) -> Dict[str, int]:
@@ -54,7 +55,7 @@ def render_timeline(db: Database, days: int = 30) -> str:
     """
     if days <= 0:
         raise ValueError("days must be greater than 0")
-    now = datetime.now()
+    now = get_current_time()
     start_ts = int((now - timedelta(days=days)).timestamp())
     # Fetch sessions in range
     sessions = db.get_range_sessions(start_ts, int(now.timestamp()))

--- a/termstory/timestamp_detective.py
+++ b/termstory/timestamp_detective.py
@@ -76,6 +76,8 @@ from collections import OrderedDict
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple
 
+from termstory.date_utils import get_current_time
+
 
 class TimestampDetective:
     """
@@ -110,7 +112,7 @@ class TimestampDetective:
         self._npm_global_root: Optional[str] = None  # e.g. /usr/local/lib/node_modules
 
         # Snapshot of "now" used for timestamp validity guards throughout the run
-        self.now = int(datetime.now().timestamp())
+        self.now = int(get_current_time().timestamp())
         self.five_years_ago = self.now - (5 * 365 * 24 * 60 * 60)
 
     # =========================================================================
@@ -1085,7 +1087,7 @@ class TimestampDetective:
             dt = datetime.strptime(date_str, "%a %b %d %H:%M")
         except ValueError:
             return None
-        now = datetime.now()
+        now = get_current_time()
         dt = dt.replace(year=now.year)
         if dt.timestamp() > now.timestamp():
             dt = dt.replace(year=now.year - 1)

--- a/termstory/tui.py
+++ b/termstory/tui.py
@@ -26,6 +26,7 @@ def _handle_exception(exc_type, exc, tb):
     log_path = os.path.expanduser("~/.termstory.error.log")
     try:
         with open(log_path, "a") as f:
+            # Wall-clock intentionally: error log timestamps should reflect real write time.
             f.write(f"\n--- {datetime.now()} ---\n")
             traceback.print_exception(exc_type, exc, tb, file=f)
     except Exception as log_exc:

--- a/termstory/web.py
+++ b/termstory/web.py
@@ -8,6 +8,7 @@ from termstory.insights import analyze_all
 from termstory.formatter import _is_noise_command
 from termstory.sanitizer import redact_command
 from termstory.database import Database
+from termstory.date_utils import get_current_time
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +18,6 @@ AI_HIGHLIGHT_LIMIT = 15
 
 def get_web_data(db: Database, start_ts: Optional[int] = None, end_ts: Optional[int] = None) -> dict:
     """Gather stats, project list, timeline, and AI highlights from the database, filtering by date range if provided."""
-    import time
     from datetime import datetime, timedelta
     
     # 1. Base Stats
@@ -207,8 +207,8 @@ def get_web_data(db: Database, start_ts: Optional[int] = None, end_ts: Optional[
     highlights_data = ai_sessions[:AI_HIGHLIGHT_LIMIT]
 
     # 5. Calculate daily activity for the last 90 days for the heatmap
-    now_dt = datetime.now()
-    ninety_days_ago_ts = int(time.time() - 90 * 86400)
+    now_dt = get_current_time()
+    ninety_days_ago_ts = int(now_dt.timestamp() - 90 * 86400)
     
     daily_activity = {}
     for i in range(90):

--- a/tests/test_date_utils.py
+++ b/tests/test_date_utils.py
@@ -1,7 +1,17 @@
 import pytest
 import os
+import re
+from pathlib import Path
 from datetime import datetime
 from termstory.date_utils import get_current_time, get_today_range, get_week_range, get_month_range, format_date_range
+
+# Call sites that intentionally use wall-clock time instead of get_current_time().
+_DATETIME_NOW_ALLOWLIST = {
+    "termstory/date_utils.py",  # implementation of get_current_time()
+    "termstory/exporter.py",   # Windows UTC-offset fallback
+    "termstory/tui.py",         # error log write time
+    "termstory/backup.py",      # unique backup filenames
+}
 
 def test_get_current_time(monkeypatch):
     # Without override
@@ -104,3 +114,21 @@ def test_parse_date_range_helper_chains_underlying_error():
     with pytest.raises(ValueError) as exc:
         parse_date_range_helper("not-a-real-date-at-all-zzzzz")
     assert exc.value.__cause__ is not None, "ValueError must chain the underlying parse error"
+
+def test_datetime_now_only_used_on_allowlisted_sites():
+    """Semantic 'now' must go through get_current_time() so TERMSTORY_DATE_OVERRIDE sticks."""
+    root = Path(__file__).resolve().parents[1] / "termstory"
+    offenders = []
+    for path in sorted(root.glob("*.py")):
+        rel = f"termstory/{path.name}"
+        if rel in _DATETIME_NOW_ALLOWLIST:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for i, line in enumerate(text.splitlines(), 1):
+            if re.search(r"datetime\.now\s*\(", line):
+                offenders.append(f"{rel}:{i}: {line.strip()}")
+    assert not offenders, (
+        "datetime.now() outside the allowlist — use get_current_time() for semantic now, "
+        "or add the file to _DATETIME_NOW_ALLOWLIST with a comment at the call site:\n"
+        + "\n".join(offenders)
+    )

--- a/tests/test_date_utils.py
+++ b/tests/test_date_utils.py
@@ -119,16 +119,16 @@ def test_datetime_now_only_used_on_allowlisted_sites():
     """Semantic 'now' must go through get_current_time() so TERMSTORY_DATE_OVERRIDE sticks."""
     root = Path(__file__).resolve().parents[1] / "termstory"
     offenders = []
-    for path in sorted(root.glob("*.py")):
-        rel = f"termstory/{path.name}"
+    for path in sorted(root.rglob("*.py")):
+        rel = path.relative_to(root.parent).as_posix()
         if rel in _DATETIME_NOW_ALLOWLIST:
             continue
         text = path.read_text(encoding="utf-8")
         for i, line in enumerate(text.splitlines(), 1):
-            if re.search(r"datetime\.now\s*\(", line):
+            if re.search(r"\bdatetime\.(now|utcnow)\s*\(|\bdate\.today\s*\(", line):
                 offenders.append(f"{rel}:{i}: {line.strip()}")
     assert not offenders, (
-        "datetime.now() outside the allowlist — use get_current_time() for semantic now, "
+        "raw clock call outside the allowlist — use get_current_time() for semantic now, "
         "or add the file to _DATETIME_NOW_ALLOWLIST with a comment at the call site:\n"
         + "\n".join(offenders)
     )


### PR DESCRIPTION
## Summary
- Route semantic "now" through `date_utils.get_current_time()` in parser, predict, timeline, web, database, and timestamp_detective so `TERMSTORY_DATE_OVERRIDE` applies consistently
- Leave intentional wall-clock `datetime.now()` call sites in exporter, tui, and backup, with short comments explaining why
- Add an allowlist regression test so new bypasses don't slip back in

Fixes #407

## Test plan
- [x] `pytest tests/test_date_utils.py tests/test_timeline.py tests/test_predict.py tests/test_exporter.py tests/test_backup.py tests/test_timestamp_detective.py --timeout=60 -q`
- [ ] Set `TERMSTORY_DATE_OVERRIDE=2026-06-03 12:00:00` and confirm `termstory timeline` / `termstory predict` use that date
- [ ] Confirm backup filenames still use real wall-clock time