### PR TITLE
[Archive] Batch command inserts with executemany (fixes #406)

### DIFF
--- a/termstory/archive.py
+++ b/termstory/archive.py
@@ -185,25 +185,35 @@ def archive_old_data(main_db_path: str, archive_db_path: str, days: int) -> Dict
                     VALUES (?, 'session_summary', ?, ?, ?)
                 """, (ai_summary, str(new_sess_id), new_proj_id, start_time))
 
-            # Fetch and insert commands
+            # Fetch and batch-insert commands (same new_sess_id for the whole session)
             cursor.execute("""
                 SELECT timestamp, command, exit_code, project_id, created_at, recovery_source, is_legacy
                 FROM main.commands WHERE session_id = ?
             """, (old_sess_id,))
             commands = cursor.fetchall()
-            for cmd_ts, cmd_str, exit_code, old_cmd_proj_id, cmd_ca, rec_src, is_leg in commands:
-                new_cmd_proj_id = project_id_map.get(old_cmd_proj_id)
-                cursor.execute("""
+            if commands:
+                cmd_rows = []
+                fts_rows = []
+                for cmd_ts, cmd_str, exit_code, old_cmd_proj_id, cmd_ca, rec_src, is_leg in commands:
+                    new_cmd_proj_id = project_id_map.get(old_cmd_proj_id)
+                    cmd_rows.append((
+                        cmd_ts, cmd_str, exit_code, new_sess_id,
+                        new_cmd_proj_id, cmd_ca, rec_src, is_leg,
+                    ))
+                    if has_archive_fts5:
+                        fts_rows.append((cmd_str, str(new_sess_id), new_cmd_proj_id, cmd_ts))
+
+                cursor.executemany("""
                     INSERT INTO archive.commands (timestamp, command, exit_code, session_id, project_id, created_at, recovery_source, is_legacy)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """, (cmd_ts, cmd_str, exit_code, new_sess_id, new_cmd_proj_id, cmd_ca, rec_src, is_leg))
-                stats["commands"] += 1
+                """, cmd_rows)
+                stats["commands"] += len(cmd_rows)
 
-                if has_archive_fts5:
-                    cursor.execute("""
+                if fts_rows:
+                    cursor.executemany("""
                         INSERT INTO archive.search_index (content, type, ref_id, project_id, timestamp)
                         VALUES (?, 'command', ?, ?, ?)
-                    """, (cmd_str, str(new_sess_id), new_cmd_proj_id, cmd_ts))
+                    """, fts_rows)
 
         # Archive Commits
         for c_hash in commit_hashes:

--- a/tests/stress/test_massive_history_ingestion.py
+++ b/tests/stress/test_massive_history_ingestion.py
@@ -4,6 +4,7 @@ import threading
 import time
 import os
 import random
+from datetime import datetime
 from termstory.database import Database
 from termstory.models import Project, Session, Command
 def writer_worker(db_path, base_path, worker_id, num_sessions, commands_per_session, errors):
@@ -162,4 +163,62 @@ def test_massive_history_ingestion(tmp_path):
         assert sess_count == (num_writers * sessions_per_writer), "All sessions should be ingested"
         assert proj_count == (num_writers * sessions_per_writer), "All projects should be ingested"
     finally:
-        conn.close()
+        conn.close()
+
+def test_archive_batched_inserts_timing(tmp_path, monkeypatch):
+    """Archive a large history fast enough that a per-command INSERT regression is obvious."""
+    from termstory.archive import archive_old_data
+
+    monkeypatch.setenv("TERMSTORY_DATE_OVERRIDE", "2026-06-14 12:00:00")
+    db_path = str(tmp_path / "archive_stress.db")
+    archive_db_path = str(tmp_path / "archive_stress_out.db")
+
+    db = Database(db_path)
+    db.init_db()
+
+    # 50 sessions x 200 commands = 10,000 commands — enough to expose the old loop.
+    num_sessions = 50
+    commands_per_session = 200
+    base_time = int(datetime(2026, 1, 1, 12, 0, 0).timestamp())
+
+    projects = []
+    sessions = []
+    commands = []
+    for s in range(num_sessions):
+        session_id = s + 1
+        start = base_time + s * 3600
+        projects.append(Project(
+            id=session_id,
+            name=f"archive_proj_{s}",
+            path=os.path.join(str(tmp_path), f"archive_proj_{s}"),
+            first_seen=start,
+            last_seen=start + 400,
+            session_count=1,
+            total_time=400,
+        ))
+        sessions.append(Session(
+            id=session_id,
+            start_time=start,
+            end_time=start + 400,
+            duration_seconds=400,
+            project_id=session_id,
+            commands=[],
+        ))
+        for c in range(commands_per_session):
+            commands.append(Command(
+                timestamp=start + c,
+                command=f"echo archive-batch {s} {c}",
+                exit_code=0,
+                session_id=session_id,
+                project_id=session_id,
+            ))
+
+    db.save_data(projects, sessions, commands)
+
+    started = time.perf_counter()
+    stats = archive_old_data(db_path, archive_db_path, days=30)
+    elapsed = time.perf_counter() - started
+
+    assert stats["sessions"] == num_sessions
+    assert stats["commands"] == num_sessions * commands_per_session
+    assert elapsed < 30.0, f"archive of {stats['commands']} commands took {elapsed:.1f}s"


### PR DESCRIPTION
## Summary
- Batches per-session `commands` and FTS `search_index` inserts in `archive_old_data` using `executemany` instead of per-row `execute` calls, while keeping the outer session loop serial so `cursor.lastrowid` correctly remaps `new_sess_id` for FK integrity <cite repo="bitflicker64/Termstory" path="termstory/archive.py" start="188-206" end="188-206" />.
- Adds a stress test to catch any regression back to per-row inserts when archiving 10k commands.

## Changes
- `termstory/archive.py`: collect `cmd_rows` and `fts_rows` per session, then `cursor.executemany(...)` into `archive.commands` and `archive.search_index`, guarding the FTS batch with `if fts_rows:` <cite repo="bitflicker64/Termstory" path="termstory/archive.py" start="193-206" end="193-206" />.
- `stats["commands"]` now incremented by `len(cmd_rows)` instead of once per row, preserving the same stats semantics.
- The session-level loop over `session_ids` remains serial (`for old_sess_id in session_ids:`), since each session's `new_sess_id` comes from `cursor.lastrowid` after the `archive.sessions` insert and must stay fixed for every command in that session <cite repo="bitflicker64/Termstory" path="termstory/archive.py" start="157-180" end="157-180" />.
- `tests/stress/test_massive_history_ingestion.py`: new `test_archive_batched_inserts_timing` seeds 50 sessions × 200 commands (10k total) and asserts `archive_old_data` completes in under 30s, plus correctness of `stats["sessions"]` and `stats["commands"]`.

## Fixes
- Fixes #406 — per-row `INSERT` during archiving was slow for large histories.

## Testing
- `pytest tests/test_archive.py tests/test_archive_validation.py --timeout=60 -q`
- `pytest tests/stress/test_massive_history_ingestion.py::test_archive_batched_inserts_timing --timeout=60 -q`
- Manual spot-check recommended (per PR checklist): verify archived sessions still remap `session_id` correctly and FTS command rows land in the archive DB.

## Notes
- Automated review from `git-miku[bot]` confirmed the FK-remap logic is correct since `new_sess_id` is fixed per session and reused across batched `cmd_rows`.
- `coderabbitai[bot]` review was rate-limited and did not run; author notes the `git-miku` review index may be stale for current commits, so treat both as informational only, not a substitute for manual review.