### PR TITLE
[Config] Atomically write Hermes config and env files (fixes #405)

### DIFF
--- a/termstory/config.py
+++ b/termstory/config.py
@@ -285,6 +285,9 @@ def load_config() -> dict:
 
 def atomic_write_text(path: str, content: str, prefix: str = "tmp_") -> None:
     """Write text to *path* via tempfile + os.replace so readers never see a partial file."""
+    # Resolve symlinks first: os.replace() would swap the link itself for a regular
+    # file, silently detaching paths that are symlinked into a dotfiles repo.
+    path = os.path.realpath(path)
     dir_path = os.path.dirname(path) or "."
     os.makedirs(dir_path, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(dir=dir_path, suffix=".tmp", prefix=prefix)
@@ -293,6 +296,12 @@ def atomic_write_text(path: str, content: str, prefix: str = "tmp_") -> None:
             f.write(content)
             f.flush()
             os.fsync(f.fileno())
+        try:
+            # Carry over the existing mode; mkstemp() creates 0600, which would
+            # otherwise narrow the file's permissions on every write.
+            os.chmod(tmp_path, os.stat(path).st_mode & 0o7777)
+        except OSError:
+            pass  # new file — keep mkstemp's restrictive default
         os.replace(tmp_path, path)
     except Exception:
         try:

--- a/termstory/config.py
+++ b/termstory/config.py
@@ -283,6 +283,25 @@ def load_config() -> dict:
     return config
 
 
+def atomic_write_text(path: str, content: str, prefix: str = "tmp_") -> None:
+    """Write text to *path* via tempfile + os.replace so readers never see a partial file."""
+    dir_path = os.path.dirname(path) or "."
+    os.makedirs(dir_path, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_path, suffix=".tmp", prefix=prefix)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
 def save_config(config: dict) -> None:
     """Save configuration dictionary to disk atomically
 
@@ -290,22 +309,7 @@ def save_config(config: dict) -> None:
     renames it over the target path. This prevents concurrent readers
     from seeing a partially written config file.
     """
-    config_path = get_config_path()
-    dir_path = os.path.dirname(config_path)
     try:
-        os.makedirs(dir_path, exist_ok=True)
-        fd, tmp_path = tempfile.mkstemp(dir=dir_path, suffix=".tmp", prefix="config_")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(config, f, indent=4)
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp_path, config_path)
-        except Exception:
-            try:
-                os.unlink(tmp_path)
-            except Exception:
-                pass
-            raise
+        atomic_write_text(get_config_path(), json.dumps(config, indent=4), prefix="config_")
     except Exception:
         pass

--- a/termstory/hermes_obs.py
+++ b/termstory/hermes_obs.py
@@ -2,16 +2,18 @@ import logging
 import os
 import sys
 
+from termstory.config import atomic_write_text
+
 logger = logging.getLogger(__name__)
 
 def modify_config_yaml(file_path, enable=True):
     if not os.path.exists(file_path):
         if enable:
-            dirname = os.path.dirname(file_path)
-            if dirname:
-                os.makedirs(dirname, exist_ok=True)
-            with open(file_path, 'w', encoding='utf-8') as f:
-                f.write("plugins:\n  enabled:\n    - observability/nemo_relay\n")
+            atomic_write_text(
+                file_path,
+                "plugins:\n  enabled:\n    - observability/nemo_relay\n",
+                prefix="hermes_",
+            )
             return True
         return False
 
@@ -77,8 +79,7 @@ def modify_config_yaml(file_path, enable=True):
             indent_str = " " * list_indent
             lines.insert(enabled_idx + 1, f"{indent_str}- observability/nemo_relay\n")
 
-        with open(file_path, 'w', encoding='utf-8') as f:
-            f.writelines(lines)
+        atomic_write_text(file_path, "".join(lines), prefix="hermes_")
         return True
 
     else:
@@ -122,19 +123,18 @@ def modify_config_yaml(file_path, enable=True):
             if not has_other_plugins_keys:
                 lines.pop(plugins_idx)
 
-        with open(file_path, 'w', encoding='utf-8') as f:
-            f.writelines(lines)
+        atomic_write_text(file_path, "".join(lines), prefix="hermes_")
         return True
 
 
 def modify_env_file(file_path, enable=True):
     if not os.path.exists(file_path):
         if enable:
-            dirname = os.path.dirname(file_path)
-            if dirname:
-                os.makedirs(dirname, exist_ok=True)
-            with open(file_path, 'w', encoding='utf-8') as f:
-                f.write("HERMES_NEMO_RELAY_ATOF_ENABLED=true\nHERMES_NEMO_RELAY_ATIF_ENABLED=true\n")
+            atomic_write_text(
+                file_path,
+                "HERMES_NEMO_RELAY_ATOF_ENABLED=true\nHERMES_NEMO_RELAY_ATIF_ENABLED=true\n",
+                prefix="hermes_",
+            )
             return True
         return False
 
@@ -192,8 +192,7 @@ def modify_env_file(file_path, enable=True):
         lines = new_lines
 
     if changed:
-        with open(file_path, 'w', encoding='utf-8') as f:
-            f.writelines(lines)
+        atomic_write_text(file_path, "".join(lines), prefix="hermes_")
     return changed
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -103,3 +103,43 @@ def test_env_var_overrides(tmp_path, monkeypatch):
     assert len(files) == 2
     assert os.path.realpath(str(hist_file_1)) in files
     assert os.path.realpath(str(hist_file_2)) in files
+
+
+def test_atomic_write_text_writes_through_symlinks(tmp_path):
+    """A config symlinked into a dotfiles repo must stay a symlink after a write."""
+    from termstory.config import atomic_write_text
+
+    target = tmp_path / "real.yaml"
+    target.write_text("old\n")
+    link = tmp_path / "link.yaml"
+    link.symlink_to(target)
+
+    atomic_write_text(str(link), "new\n")
+
+    assert link.is_symlink(), "atomic write replaced the symlink with a regular file"
+    assert target.read_text() == "new\n"
+
+
+def test_atomic_write_text_preserves_existing_mode(tmp_path):
+    """mkstemp() creates 0600; an existing file must not be narrowed on every write."""
+    from termstory.config import atomic_write_text
+
+    path = tmp_path / "config.yaml"
+    path.write_text("old\n")
+    os.chmod(path, 0o644)
+
+    atomic_write_text(str(path), "new\n")
+
+    assert oct(path.stat().st_mode & 0o777) == "0o644"
+    assert path.read_text() == "new\n"
+
+
+def test_atomic_write_text_new_file_is_private(tmp_path):
+    """A file created from scratch keeps mkstemp's restrictive default."""
+    from termstory.config import atomic_write_text
+
+    path = tmp_path / "nested" / ".env"
+    atomic_write_text(str(path), "SECRET=1\n")
+
+    assert path.read_text() == "SECRET=1\n"
+    assert oct(path.stat().st_mode & 0o777) == "0o600"


### PR DESCRIPTION
## Summary
- Extract `atomic_write_text()` from the existing `save_config()` mkstemp + fsync + `os.replace` pattern
- Use it in `modify_config_yaml()` and `modify_env_file()` so Hermes `config.yaml` / `.env` are never truncated mid-write
- Leave the optional backup copy and `--enable`/`--disable` CLI work for a follow-up

Fixes #405

## Test plan
- [x] `pytest tests/test_hermes_obs.py tests/test_config.py --timeout=60 -q`
- [ ] Enable then disable `termstory obs` against a temp Hermes config and confirm contents round-trip cleanly
- [ ] Confirm no leftover `hermes_*.tmp` files remain beside the target after a successful write