### PR TITLE
[Timeline] Align fetch window with rendered days (fixes #404)

### DIFF
--- a/termstory/timeline.py
+++ b/termstory/timeline.py
@@ -56,15 +56,15 @@ def render_timeline(db: Database, days: int = 30) -> str:
     if days <= 0:
         raise ValueError("days must be greater than 0")
     now = get_current_time()
-    start_ts = int((now - timedelta(days=days)).timestamp())
-    # Fetch sessions in range
+    # Match the rendered window: oldest shown day through today, from start-of-day.
+    start_day = datetime.combine((now - timedelta(days=days - 1)).date(), datetime.min.time())
+    start_ts = int(start_day.timestamp())
     sessions = db.get_range_sessions(start_ts, int(now.timestamp()))
     daily = _aggregate_sessions_by_day(sessions)
-    # Ensure all dates are represented
     all_dates = [(now - timedelta(days=i)).strftime("%Y-%m-%d") for i in range(days - 1, -1, -1)]
     for d in all_dates:
         daily.setdefault(d, 0)
-    max_dur = max(daily.values()) if daily else 0
+    max_dur = max(daily[d] for d in all_dates)
     lines: List[str] = []
     header = f"{'Date':<12} | Activity"
     separator = "-" * (len(header) + 2)

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -83,7 +83,7 @@ def test_render_timeline_invalid_days(tmp_path):
         render_timeline(db, days=-5)
 
 
-def test_render_timeline_scales_only_visible_days(tmp_path):
+def test_render_timeline_scales_only_visible_days(tmp_path, monkeypatch):
     """A heavy day just outside the window must not shrink the visible bars."""
     from termstory.timeline import render_timeline
 
@@ -91,7 +91,11 @@ def test_render_timeline_scales_only_visible_days(tmp_path):
     db = Database(str(db_file))
     db.init_db()
 
-    now = datetime.now()
+    # Freeze the clock. The pre-fix window started at ``now - days``, so the session
+    # planted at midday below only fell inside it when the suite happened to run
+    # before noon; pinning a morning time keeps the guard effective around the clock.
+    now = datetime.now().replace(hour=8, minute=30, second=0, microsecond=0)
+    monkeypatch.setattr("termstory.timeline.get_current_time", lambda: now)
     days = 3
     # One calendar day before the oldest rendered date (old code fetched this).
     outside = datetime.combine((now - timedelta(days=days)).date(), datetime.min.time()) + timedelta(hours=12)

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -81,3 +81,45 @@ def test_render_timeline_invalid_days(tmp_path):
         
     with pytest.raises(ValueError, match="days must be greater than 0"):
         render_timeline(db, days=-5)
+
+
+def test_render_timeline_scales_only_visible_days(tmp_path):
+    """A heavy day just outside the window must not shrink the visible bars."""
+    from termstory.timeline import render_timeline
+
+    db_file = tmp_path / "test_timeline_window.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    now = datetime.now()
+    days = 3
+    # One calendar day before the oldest rendered date (old code fetched this).
+    outside = datetime.combine((now - timedelta(days=days)).date(), datetime.min.time()) + timedelta(hours=12)
+    outside_ts = int(outside.timestamp())
+    today_ts = int(now.timestamp())
+
+    project = Project(
+        id=1, name="DemoProject", path="~/demo",
+        first_seen=outside_ts, last_seen=today_ts, session_count=2, total_time=1100,
+    )
+    session_outside = Session(
+        id=1, start_time=outside_ts, end_time=outside_ts + 1000,
+        duration_seconds=1000, project_id=1, commands=[],
+    )
+    session_today = Session(
+        id=2, start_time=today_ts, end_time=today_ts + 100,
+        duration_seconds=100, project_id=1, commands=[],
+    )
+    cmds = [
+        Command(timestamp=outside_ts, command="echo outside", session_id=1, project_id=1),
+        Command(timestamp=today_ts, command="echo today", session_id=2, project_id=1),
+    ]
+    db.save_data([project], [session_outside, session_today], cmds)
+
+    result = render_timeline(db, days=days)
+    today = now.strftime("%Y-%m-%d")
+    today_line = next(line for line in result.splitlines() if line.startswith(today))
+    # Today is the heaviest visible day, so its bar should be full width.
+    assert today_line.count("█") == 40
+    # The outside day must not appear in the rendered window.
+    assert outside.strftime("%Y-%m-%d") not in result


### PR DESCRIPTION
## Summary
- Fetch timeline sessions from start-of-day of the oldest rendered date so the query matches the `days` shown
- Scale bars using only visible days, so a heavy day outside the window cannot shrink on-screen bars
- Add a regression test covering the off-by-one scaling case

Fixes #404

## Test plan
- [x] `pytest tests/test_timeline.py --timeout=60 -q`
- [ ] Run `termstory timeline --days 7` and confirm exactly 7 date rows appear
- [ ] Confirm the busiest visible day gets a full-width bar