### PR TITLE
[Agy] Drop blacklisted sessions, not just matching commands (fixes #403)

### DIFF
--- a/termstory/agy.py
+++ b/termstory/agy.py
@@ -14,7 +14,7 @@ Design
   :func:`termstory.sanitizer.redact_command` before it leaves the local
   machine.  Sessions containing blacklisted commands (vault logins,
   ``aws configure``, etc.) are dropped entirely via
-  :func:`termstory.sanitizer.should_blacklist_command`.
+  :func:`termstory.sanitizer.sanitize_session_commands`.
 * **Graceful degradation** — if ``agy`` is not on ``PATH``, the command
   prints a friendly installation hint and exits ``1``.  If the TermStory
   database is empty or missing, the bridge still launches ``agy`` but
@@ -32,13 +32,13 @@ import os
 import shutil
 import subprocess
 import tempfile
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from rich.console import Console
 
 from termstory.config import get_db_path
 from termstory.database import Database
-from termstory.sanitizer import redact_command, should_blacklist_command
+from termstory.sanitizer import redact_command, sanitize_session_commands
 
 console = Console()
 
@@ -66,29 +66,64 @@ EXIT_INTERRUPTED = 130
 def _gather_recent_commands(db: Database, limit: int) -> List[str]:
     """Return up to *limit* most recent commands, sanitized for AI export.
 
-    Commands are redacted with :func:`redact_command`.  Any command that
-    triggers :func:`should_blacklist_command` is skipped entirely so
-    that credential-bearing commands never reach the AI session.
+    Commands are redacted with :func:`redact_command`.  Sessions that contain
+    any blacklisted command are dropped entirely via
+    :func:`sanitize_session_commands`, so surrounding context cannot leak
+    what a secret was for.  We over-fetch before filtering so the caller
+    still gets up to *limit* safe commands when blacklisted rows are removed.
     """
+    # Over-fetch so dropped sessions don't leave the result short of *limit*.
+    fetch_limit = min(max(limit * 3, limit + 32), MAX_CONTEXT_COMMANDS * 2)
+
     conn = db.get_connection()
     try:
         cursor = conn.cursor()
         cursor.execute(
-            "SELECT command FROM commands ORDER BY timestamp DESC LIMIT ?",
-            (limit,),
+            "SELECT command, session_id FROM commands "
+            "ORDER BY timestamp DESC LIMIT ?",
+            (fetch_limit,),
         )
         rows = cursor.fetchall()
+
+        session_ids = {sid for _, sid in rows if sid is not None}
+        blacklisted_sessions = set()
+        if session_ids:
+            # Gate on the full session, not just the recent slice — a
+            # sensitive command earlier in the session must still drop siblings.
+            placeholders = ",".join("?" for _ in session_ids)
+            cursor.execute(
+                f"SELECT session_id, command FROM commands "
+                f"WHERE session_id IN ({placeholders})",
+                tuple(session_ids),
+            )
+            by_session: Dict[int, List[str]] = {}
+            for sid, cmd in cursor.fetchall():
+                if not cmd:
+                    continue
+                by_session.setdefault(sid, []).append(cmd)
+            for sid, cmds in by_session.items():
+                _, is_blacklisted = sanitize_session_commands(cmds)
+                if is_blacklisted:
+                    blacklisted_sessions.add(sid)
+
+        safe_commands: List[str] = []
+        for raw_cmd, session_id in rows:
+            if not raw_cmd:
+                continue
+            if session_id is None:
+                sanitized, is_blacklisted = sanitize_session_commands([raw_cmd])
+                if is_blacklisted:
+                    continue
+                safe_commands.append(sanitized[0])
+            else:
+                if session_id in blacklisted_sessions:
+                    continue
+                safe_commands.append(redact_command(raw_cmd))
+            if len(safe_commands) >= limit:
+                break
+        return safe_commands
     finally:
         conn.close()
-
-    safe_commands: List[str] = []
-    for (raw_cmd,) in rows:
-        if not raw_cmd:
-            continue
-        if should_blacklist_command(raw_cmd):
-            continue
-        safe_commands.append(redact_command(raw_cmd))
-    return safe_commands
 
 
 def _gather_recent_commits(db: Database, limit: int) -> List[str]:

--- a/tests/test_agy.py
+++ b/tests/test_agy.py
@@ -3,7 +3,7 @@ test_agy.py — Tests for the TermStory → agy AI Pair Programmer Bridge
 
 Covers:
   - Context gathering (recent commands, commits, project detection)
-  - Privacy redaction (blacklisted commands are dropped, secrets are redacted)
+  - Privacy redaction (blacklisted sessions are dropped, secrets are redacted)
   - Graceful failure when ``agy`` is not on PATH
   - Subprocess invocation (correct args, temp file cleanup, exit code propagation)
   - ``--no-context`` legacy mode
@@ -120,7 +120,7 @@ class TestGatherRecentCommands:
         assert "git status" in commands[2]
 
     def test_skips_blacklisted_commands(self, populated_db):
-        """Commands matching BLACKLIST_PATTERNS must be dropped."""
+        """A lone blacklisted command (no session_id) must be dropped."""
         conn = populated_db.get_connection()
         cursor = conn.cursor()
         cursor.execute(
@@ -133,6 +133,78 @@ class TestGatherRecentCommands:
         commands = _gather_recent_commands(populated_db, limit=10)
         assert not any("aws configure" in c for c in commands)
         assert len(commands) == 3
+
+    def test_drops_entire_blacklisted_session(self, populated_db):
+        """Sibling commands in a blacklisted session must not reach the bridge."""
+        conn = populated_db.get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO sessions (start_time, end_time, duration_seconds, project_id) "
+            "VALUES (?, ?, ?, ?)",
+            (1700000200, 1700000300, 100, 1),
+        )
+        sid = cursor.lastrowid
+        cursor.executemany(
+            "INSERT INTO commands (command, timestamp, session_id, project_id) "
+            "VALUES (?, ?, ?, ?)",
+            [
+                ("vault login -method=oidc", 1700000210, sid, 1),
+                ("export DATABASE_URL=postgres://prod", 1700000220, sid, 1),
+                ("psql -h prod-db", 1700000230, sid, 1),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        commands = _gather_recent_commands(populated_db, limit=10)
+        joined = "\n".join(commands)
+        assert "vault" not in joined.lower()
+        assert "DATABASE_URL" not in joined
+        assert "psql" not in joined
+        # Original safe session is still available.
+        assert len(commands) == 3
+
+    def test_overfetches_to_meet_requested_limit(self, tmp_path, monkeypatch):
+        """Blacklisted rows must not quietly shrink the returned command count."""
+        db_path = str(tmp_path / "test_agy_overfetch.db")
+        monkeypatch.setattr("termstory.agy.get_db_path", lambda: db_path)
+        db = Database(db_path)
+        db.init_db()
+
+        conn = db.get_connection()
+        cursor = conn.cursor()
+        # Interleave blacklisted sessions with safe one-command sessions.
+        ts = 1700001000
+        for i in range(5):
+            cursor.execute(
+                "INSERT INTO sessions (start_time, end_time, duration_seconds) "
+                "VALUES (?, ?, ?)",
+                (ts, ts + 10, 10),
+            )
+            bad_sid = cursor.lastrowid
+            cursor.execute(
+                "INSERT INTO commands (command, timestamp, session_id) VALUES (?, ?, ?)",
+                ("aws configure", ts + 1, bad_sid),
+            )
+            ts += 20
+            cursor.execute(
+                "INSERT INTO sessions (start_time, end_time, duration_seconds) "
+                "VALUES (?, ?, ?)",
+                (ts, ts + 10, 10),
+            )
+            good_sid = cursor.lastrowid
+            cursor.execute(
+                "INSERT INTO commands (command, timestamp, session_id) VALUES (?, ?, ?)",
+                (f"echo safe-{i}", ts + 1, good_sid),
+            )
+            ts += 20
+        conn.commit()
+        conn.close()
+
+        commands = _gather_recent_commands(db, limit=5)
+        assert len(commands) == 5
+        assert all("safe-" in c for c in commands)
+        assert not any("aws configure" in c for c in commands)
 
     def test_redacts_secrets_in_commands(self, populated_db):
         """Secrets in commands must be redacted before returning.


### PR DESCRIPTION
## Summary
- Route agy context gathering through `sanitize_session_commands()` so blacklisted sessions are dropped entirely, matching the module docstring and `ai.py` / `ask.py`
- Gate on the full session contents, not only the recent command slice
- Over-fetch before filtering so a requested command count is still met after drops
- Add regression coverage for the vault/session leak case and the under-filled limit case

Fixes #403

## Test plan
- [x] `pytest tests/test_agy.py --timeout=60 -q`
- [ ] Confirm a session with `vault login` plus follow-up commands contributes nothing to the agy context bridge
- [ ] Confirm non-blacklisted secrets are still redacted (not dropped) in returned commands