### PR TITLE
[Config] Surface save_config write failures instead of swallowing the…

### DIFF
--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -1123,7 +1123,10 @@ def show_ui(
                 console.print("Continuing with legacy history fallback...")
         elif response in ("n", "no"):
             _cfg["has_seen_timestamp_prompt"] = True
-            save_config(_cfg)
+            try:
+                save_config(_cfg)
+            except OSError as e:
+                console.print(f"[bold red]Failed to save config:[/] {e}")
             console.print("Continuing with legacy history fallback...")
         else:
             console.print("Invalid response. Continuing with legacy history fallback...")
@@ -1552,8 +1555,15 @@ def config_set(key: str, value: str):
         converted_value = value
 
     set_config_value(config, key, converted_value)
-    save_config(config)
-    
+    try:
+        save_config(config)
+    except OSError as e:
+        Console(stderr=True).print(
+            f"[bold red]Failed to save config:[/] {e}\n"
+            "Check that the config directory is writable and has free disk space."
+        )
+        raise typer.Exit(code=1)
+
     set_val = get_config_value(config, key)
     from rich.markup import escape
     console.print(f"[green]Set config key '{escape(key)}' to '{escape(str(set_val))}'[/]")

--- a/termstory/config.py
+++ b/termstory/config.py
@@ -215,14 +215,6 @@ def load_config() -> dict:
             )
             config = {}
 
-        except OSError as e:
-            logger.warning(
-                "Could not read config file '%s': %s",
-                config_path,
-            e,
-            )
-            config = {}
-
     if not isinstance(config, dict):
         config = {}
             
@@ -278,7 +270,11 @@ def load_config() -> dict:
     defaults_merged = merge_defaults(config, defaults)
     
     if migrated or defaults_merged:
-        save_config(config)
+        try:
+            save_config(config)
+        except OSError:
+            # Still return the in-memory config; just don't hide a failed persist.
+            logger.exception("Failed to persist config after migration/defaults merge")
         
     return config
 
@@ -317,8 +313,8 @@ def save_config(config: dict) -> None:
     Writes to a temporary file in the same directory, then atomically
     renames it over the target path. This prevents concurrent readers
     from seeing a partially written config file.
+
+    Raises OSError (and other I/O errors from the atomic write) so callers
+    can surface a failure instead of assuming the write succeeded.
     """
-    try:
-        atomic_write_text(get_config_path(), json.dumps(config, indent=4), prefix="config_")
-    except Exception:
-        pass
+    atomic_write_text(get_config_path(), json.dumps(config, indent=4), prefix="config_")

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -475,6 +475,27 @@ def test_config_set_boolean_validation(tmp_path, monkeypatch):
         assert "Invalid boolean value" in output
 
 
+def test_config_set_reports_save_failure(tmp_path, monkeypatch):
+    """Issue #402: config set must not pretend success when the write fails."""
+    config_dir = tmp_path / "termstory"
+    config_dir.mkdir()
+    config_file = config_dir / "config.json"
+    monkeypatch.setattr("termstory.config.get_config_path", lambda: str(config_file))
+    # Seed a readable config, then lock the directory so the next save fails.
+    from termstory.config import save_config
+    save_config({"ai_enabled": False})
+    os.chmod(config_dir, 0o555)
+    try:
+        runner = CliRunner(mix_stderr=True)
+        result = runner.invoke(app, ["config", "set", "ai_enabled", "true"])
+        assert result.exit_code != 0
+        output = result.output or ""
+        assert "Failed to save config" in output
+        assert "Set config key" not in output
+    finally:
+        os.chmod(config_dir, 0o755)
+
+
 def test_config_set_api_key_preserves_leading_zeros(tmp_path, monkeypatch):
     """Issue #342: API keys must remain raw strings, no numeric conversion."""
     config_file = tmp_path / "config.json"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,7 +1,10 @@
 import os
 import time
 from datetime import datetime, timedelta
+
+import pytest
 from typer.testing import CliRunner
+
 from termstory.cli import app
 from termstory.database import Database
 from termstory.models import Project, Session, Command
@@ -475,6 +478,7 @@ def test_config_set_boolean_validation(tmp_path, monkeypatch):
         assert "Invalid boolean value" in output
 
 
+@pytest.mark.skipif(os.geteuid() == 0, reason="chmod is a no-op for root")
 def test_config_set_reports_save_failure(tmp_path, monkeypatch):
     """Issue #402: config set must not pretend success when the write fails."""
     config_dir = tmp_path / "termstory"
@@ -486,7 +490,7 @@ def test_config_set_reports_save_failure(tmp_path, monkeypatch):
     save_config({"ai_enabled": False})
     os.chmod(config_dir, 0o555)
     try:
-        runner = CliRunner(mix_stderr=True)
+        runner = CliRunner()
         result = runner.invoke(app, ["config", "set", "ai_enabled", "true"])
         assert result.exit_code != 0
         output = result.output or ""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,9 +80,25 @@ def test_load_config_missing_file(tmp_path):
         assert config["max_query_log"] == 10000
 
 def test_save_config_error_handling(tmp_path):
-    # If open fails, save_config should not raise an exception
+    # Write failures must surface so callers can report them.
     with patch("termstory.config.get_config_path", return_value="/invalid/path/that/does/not/exist/config.json"):
-        save_config({"test": "data"})  # Should silently pass
+        with pytest.raises(OSError):
+            save_config({"test": "data"})
+
+
+def test_save_config_readonly_dir_raises(tmp_path, monkeypatch):
+    """A read-only config directory must not look like a successful save."""
+    config_dir = tmp_path / "termstory"
+    config_dir.mkdir()
+    config_file = config_dir / "config.json"
+    monkeypatch.setattr("termstory.config.get_config_path", lambda: str(config_file))
+    os.chmod(config_dir, 0o555)
+    try:
+        with pytest.raises(OSError):
+            save_config({"ai_enabled": True})
+        assert not config_file.exists()
+    finally:
+        os.chmod(config_dir, 0o755)
 
 def test_env_var_overrides(tmp_path, monkeypatch):
     from termstory.config import get_db_path, get_history_files

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -86,6 +86,7 @@ def test_save_config_error_handling(tmp_path):
             save_config({"test": "data"})
 
 
+@pytest.mark.skipif(os.geteuid() == 0, reason="chmod is a no-op for root")
 def test_save_config_readonly_dir_raises(tmp_path, monkeypatch):
     """A read-only config directory must not look like a successful save."""
     config_dir = tmp_path / "termstory"


### PR DESCRIPTION
## Summary
- Stop swallowing every `save_config()` failure with a bare `except Exception: pass`
- Make `termstory config set` report a clear error and exit non-zero when the write fails
- Log migration/persist failures in `load_config()` without hiding them
- Remove the unreachable duplicate `except OSError` in `load_config()`

Fixes #402

## Test plan
- [x] `pytest tests/test_config.py tests/test_cli_commands.py::test_config_set_reports_save_failure --timeout=60 -q`
- [ ] Point config at a read-only directory and confirm `termstory config set ...` fails with `Failed to save config` (no green success line)
- [ ] Confirm a normal `termstory config set ai_enabled true` still succeeds and persists