### PR TITLE
[Sanitizer] Stop redacting MySQL database names after -p (fixes #401)

### DIFF
--- a/termstory/sanitizer.py
+++ b/termstory/sanitizer.py
@@ -89,8 +89,10 @@ PASSWORD_FLAG_PATTERN = re.compile(
     r'(--password=|\b--password\s+|\b--pass=|\b--pass\s+|--token=|--token\s+|--api-key=|--api-key\s+)(?!\[REDACTED)([^\s\'"]+|\'[^\']*\'|"[^"]*")',
     re.IGNORECASE
 )
+# Only the attached form (-pSECRET) carries a password on the CLI.
+# `mysql -p dbname` (space after -p) means "prompt interactively"; dbname is not a secret.
 MYSQL_PASSWORD_PATTERN = re.compile(
-    r'((?<!-)-p\s*)(?!\[REDACTED)([^\s\'"]+|\'[^\']*\'|"[^"]*")',
+    r'((?<!-)-p)(?!\[REDACTED)([^\s\'"]+|\'[^\']*\'|"[^"]*")',
     re.IGNORECASE
 )
 

--- a/termstory/sanitizer.py
+++ b/termstory/sanitizer.py
@@ -89,11 +89,11 @@ PASSWORD_FLAG_PATTERN = re.compile(
     r'(--password=|\b--password\s+|\b--pass=|\b--pass\s+|--token=|--token\s+|--api-key=|--api-key\s+)(?!\[REDACTED)([^\s\'"]+|\'[^\']*\'|"[^"]*")',
     re.IGNORECASE
 )
-# Only the attached form (-pSECRET) carries a password on the CLI.
+# Only lowercase attached -pSECRET is a password. Case-sensitive so -P3306 (port)
+# is left alone; (?<!\S) so hostnames like db-proxy are not treated as -p flags.
 # `mysql -p dbname` (space after -p) means "prompt interactively"; dbname is not a secret.
 MYSQL_PASSWORD_PATTERN = re.compile(
-    r'((?<!-)-p)(?!\[REDACTED)([^\s\'"]+|\'[^\']*\'|"[^"]*")',
-    re.IGNORECASE
+    r'((?<!\S)-p)(?!\[REDACTED)([^\s\'"]+|\'[^\']*\'|"[^"]*")',
 )
 
 IP_ADDRESS_PATTERN = re.compile(r'(?<![\d\.])(?:\d{1,3}\.){3}\d{1,3}(?![\d\.])')

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -34,6 +34,20 @@ def test_redact_password_flags():
     assert redact_command("curl -H 'Authorization: Bearer secret-token' http://api") == "curl -H 'Authorization: Bearer [REDACTED_TOKEN]' http://[REDACTED_HOST]"
     assert redact_command("cli --token secret-token-value") == "cli --token [REDACTED]"
 
+
+def test_mysql_p_space_preserves_database_name():
+    """`-p` with a following space prompts interactively; the next token is the DB name."""
+    assert redact_command("mysql -u root -p mydatabase") == "mysql -u root -p mydatabase"
+    assert (
+        redact_command("mysqldump -u root -p production_db > dump.sql")
+        == "mysqldump -u root -p production_db > dump.sql"
+    )
+    # Bare -p (interactive prompt, no secret on the CLI) must stay untouched.
+    assert redact_command("mysql -u root -p") == "mysql -u root -p"
+    # Attached form still redacts.
+    assert redact_command("mysql -u root -pSECRET") == "mysql -u root -p[REDACTED]"
+    assert redact_command("mysqldump -uroot -p'pass word' db") == "mysqldump -uroot -p[REDACTED] db"
+
 def test_redact_ips_and_fqdns():
     # IPs
     assert redact_command("ssh admin@192.168.1.105") == "ssh admin@[REDACTED_IP]"

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -48,6 +48,14 @@ def test_mysql_p_space_preserves_database_name():
     assert redact_command("mysql -u root -pSECRET") == "mysql -u root -p[REDACTED]"
     assert redact_command("mysqldump -uroot -p'pass word' db") == "mysqldump -uroot -p[REDACTED] db"
 
+
+def test_mysql_p_does_not_match_port_or_hostname():
+    """`-P` is the port flag; `-p` inside a hostname must not look like a password flag."""
+    assert redact_command("mysql -P3306 dbname") == "mysql -P3306 dbname"
+    # Host redaction may still rewrite the hostname; the password pattern must not.
+    assert "db-p[REDACTED]" not in redact_command("mysql --host=db-proxy dbname")
+    assert "db-p[REDACTED]" not in redact_command("mysqldump --host=db-proxy db")
+
 def test_redact_ips_and_fqdns():
     # IPs
     assert redact_command("ssh admin@192.168.1.105") == "ssh admin@[REDACTED_IP]"


### PR DESCRIPTION
## Summary
- Tighten `MYSQL_PASSWORD_PATTERN` so only the attached form `-pSECRET` is redacted
- Preserve database names in `mysql -p dbname` / `mysqldump -p dbname` (space means interactive prompt)
- Leave bare `mysql -p` unchanged
- Add regression tests for space-separated, bare, and attached `-p` forms

Fixes #401

## Test plan
- [x] `pytest tests/test_sanitizer.py --timeout=60 -q`
- [ ] `redact_command('mysql -u root -p mydatabase')` keeps `mydatabase`
- [ ] `redact_command('mysql -u root -pSECRET')` becomes `mysql -u root -p[REDACTED]`