### PR TITLE
fix: redact commands and commits in exports

### DIFF
--- a/termstory/exporter.py
+++ b/termstory/exporter.py
@@ -10,8 +10,15 @@ from dateutil import parser as date_parser
 from termstory.database import Database
 from termstory.date_utils import get_current_time
 from termstory.models import Session, Command, Project
+from termstory.sanitizer import redact_command, sanitize_session_commands
 
 _FAR_FUTURE_TS: int = 9_999_999_999 # ~year 2286, safely beyond any real session timestamp
+
+# Placeholder rendered in place of commands when a session is fully blacklisted
+# (e.g. ``vault`` / ``aws configure`` / ``gh auth`` operations). Reuses the
+# semantics documented in CONTRIBUTING.md so that raw security/authentication
+# command text can never reach disk via the export paths.
+_BLACKLISTED_SESSION_MARKER = "[REDACTED: Security/Authentication Operations]"
 
 def _get_timestamp(dt: datetime) -> int:
     """Safely get Unix timestamp from datetime object on all platforms, including Windows."""
@@ -93,16 +100,21 @@ def fetch_export_data(
     return sessions
 
 def serialize_sessions_to_dict(sessions: List[Session], db: Database) -> List[Dict[str, Any]]:
-    """Convert a list of Session objects into a serializable list of dictionaries."""
+    """Convert a list of Session objects into a serializable list of dictionaries.
+
+    All command and commit text is routed through the shared sanitizer so that
+    secrets are redacted and fully-blacklisted (security/auth) sessions cannot
+    leak raw commands. See :mod:`termstory.sanitizer`.
+    """
     # Pre-fetch project info
     project_ids = list(set(s.project_id for s in sessions if s.project_id is not None))
     projects = db.get_projects_by_ids(project_ids)
     project_map = {p.id: p for p in projects}
-    
+
     serialized = []
     for s in sessions:
         proj = project_map.get(s.project_id) if s.project_id is not None else None
-        
+
         session_dict = {
             "session_id": s.id,
             "start_time": s.start_time,
@@ -119,29 +131,41 @@ def serialize_sessions_to_dict(sessions: List[Session], db: Database) -> List[Di
             "commands": [],
             "commits": []
         }
-        
-        for cmd in s.commands:
+
+        # Session-level blacklist gate + per-command redaction via the shared
+        # sanitizer. A fully-blacklisted session (any command matching a
+        # security/auth pattern) must never emit raw commands.
+        raw_cmd_strings = [cmd.command for cmd in s.commands]
+        sanitized_cmds, is_blacklisted = sanitize_session_commands(raw_cmd_strings)
+        if is_blacklisted:
+            command_texts = [_BLACKLISTED_SESSION_MARKER for _ in s.commands]
+        else:
+            command_texts = sanitized_cmds or []
+
+        for idx, cmd in enumerate(s.commands):
             session_dict["commands"].append({
                 "command_id": cmd.id,
                 "timestamp": cmd.timestamp,
                 "timestamp_iso": _safe_fromtimestamp(cmd.timestamp).isoformat(),
-                "command": cmd.command,
+                "command": command_texts[idx] if idx < len(command_texts) else _BLACKLISTED_SESSION_MARKER,
                 "exit_code": cmd.exit_code,
                 "is_legacy": cmd.is_legacy,
                 "recovery_source": cmd.recovery_source
             })
-            
+
         for commit in s.commits:
+            raw_message = commit.get("message")
+            raw_cleaned = commit.get("cleaned_message")
             session_dict["commits"].append({
                 "hash": commit.get("hash"),
                 "timestamp": commit.get("timestamp"),
                 "timestamp_iso": _safe_fromtimestamp(commit.get("timestamp")).isoformat() if commit.get("timestamp") else None,
-                "message": commit.get("message"),
-                "cleaned_message": commit.get("cleaned_message")
+                "message": redact_command(raw_message) if raw_message else raw_message,
+                "cleaned_message": redact_command(raw_cleaned) if raw_cleaned else raw_cleaned
             })
-            
+
         serialized.append(session_dict)
-        
+
     return serialized
 
 def export_json(
@@ -164,12 +188,17 @@ def export_csv(
     db: Database,
     output_file: Optional[str] = None
 ) -> None:
-    """Export the list of sessions as CSV, with one row per command."""
+    """Export the list of sessions as CSV, with one row per command.
+
+    All command and commit text is routed through the shared sanitizer so that
+    secrets are redacted and fully-blacklisted (security/auth) sessions cannot
+    leak raw commands.
+    """
     # Pre-fetch project info
     project_ids = list(set(s.project_id for s in sessions if s.project_id is not None))
     projects = db.get_projects_by_ids(project_ids)
     project_map = {p.id: p for p in projects}
-    
+
     fieldnames = [
         "session_id",
         "session_start_time",
@@ -186,25 +215,35 @@ def export_csv(
         "command_is_legacy",
         "session_commits"
     ]
-    
+
     # Write helper
     def write_rows(f):
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
-        
+
         for s in sessions:
             proj = project_map.get(s.project_id) if s.project_id is not None else None
-            
-            # Serialize commits to a semicolon-separated string
+
+            # Serialize commits to a semicolon-separated string (redacted)
             commits_str = "; ".join(
-                f"{c.get('hash', '')[:7]}: {c.get('cleaned_message', '')}"
+                f"{c.get('hash', '')[:7]}: {redact_command(c.get('cleaned_message') or '')}"
                 for c in s.commits
             )
-            
+
             # Since every session must have at least one command, we iterate commands.
             # In case a session is somehow empty, we still write it.
             commands = s.commands if s.commands else [None]
-            
+
+            # Session-level blacklist gate + per-command redaction via the shared
+            # sanitizer. A fully-blacklisted session must never emit raw commands.
+            raw_cmd_strings = [cmd.command for cmd in commands if cmd is not None]
+            sanitized_cmds, is_blacklisted = sanitize_session_commands(raw_cmd_strings)
+            if is_blacklisted:
+                command_texts = [_BLACKLISTED_SESSION_MARKER for _ in raw_cmd_strings]
+            else:
+                command_texts = sanitized_cmds or []
+
+            text_iter = iter(command_texts)
             for cmd in commands:
                 row = {
                     "session_id": s.id,
@@ -217,12 +256,12 @@ def export_csv(
                     "session_is_legacy": s.is_legacy,
                     "session_commits": commits_str
                 }
-                
+
                 if cmd:
                     row.update({
                         "command_id": cmd.id,
                         "command_timestamp": _safe_fromtimestamp(cmd.timestamp).isoformat(),
-                        "command_text": cmd.command,
+                        "command_text": next(text_iter, _BLACKLISTED_SESSION_MARKER),
                         "command_exit_code": cmd.exit_code,
                         "command_is_legacy": cmd.is_legacy
                     })
@@ -234,7 +273,7 @@ def export_csv(
                         "command_exit_code": "",
                         "command_is_legacy": ""
                     })
-                    
+
                 writer.writerow(row)
 
     if output_file and output_file != "-":

--- a/termstory/notebook.py
+++ b/termstory/notebook.py
@@ -5,6 +5,13 @@ from typing import List, Dict, Any, Optional
 from termstory.database import Database
 from termstory.models import Session, Command, Project, format_duration
 from termstory.formatter import _is_noise_command
+from termstory.sanitizer import redact_command, sanitize_session_commands
+
+# Placeholder rendered in place of commands when a session is fully blacklisted
+# (e.g. ``vault`` / ``aws configure`` / ``gh auth`` operations). Reuses the
+# semantics documented in CONTRIBUTING.md so raw security/auth command text can
+# never reach the generated notebook.
+_BLACKLISTED_SESSION_MARKER = "[REDACTED: Security/Authentication Operations]"
 
 def generate_notebook(
     sessions: List[Session],
@@ -114,6 +121,7 @@ def generate_notebook(
                     for commit in s.commits:
                         short_hash = commit.get("hash", "")[:7]
                         msg = commit.get("cleaned_message") or commit.get("message") or ""
+                        msg = redact_command(msg)
                         msg = msg.split("\n")[0].strip()
                         lines.append(f"    - `{short_hash}`: {msg}")
 
@@ -125,8 +133,14 @@ def generate_notebook(
                 if commands:
                     lines.append("  - **Commands**:")
                     lines.append("    ```bash")
-                    for cmd in commands:
-                        lines.append(f"    {cmd.command}")
+                    _, is_blacklisted = sanitize_session_commands(
+                        [cmd.command for cmd in s.commands]
+                    )
+                    if is_blacklisted:
+                        lines.append(f"    {_BLACKLISTED_SESSION_MARKER}")
+                    else:
+                        for cmd in commands:
+                            lines.append(f"    {redact_command(cmd.command)}")
                     lines.append("    ```")
 
         # Add empty line separator between days

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -255,3 +255,100 @@ def test_export_csv_null_end_time(temp_db, capsys):
     assert len(rows) == 4
     assert rows[0]["session_end_time"] == ""
 
+
+AWS_SAMPLE_SECRET = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+
+def _build_single_session_db(db_path, commands, commits=None):
+    """Create an in-memory-on-disk DB with an optional single-session export."""
+    db = Database(str(db_path))
+    db.init_db()
+    p = Project(id=1, name="Proj", path="~/proj", first_seen=1000, last_seen=3000,
+                session_count=1, total_time=100)
+    s = Session(id=1, start_time=1000, end_time=3000, duration_seconds=2000,
+                project_id=1, commands=commands)
+    db.save_data([p], [s], commands)
+    if commits:
+        db.save_commits(1, commits)
+    return db
+
+
+def test_export_json_redacts_command_secret(tmp_path):
+    db = _build_single_session_db(
+        tmp_path / "secret_json.db",
+        [Command(id=1, timestamp=1000,
+                 command=f"export AWS_SECRET_ACCESS_KEY={AWS_SAMPLE_SECRET}",
+                 exit_code=0, session_id=1, project_id=1)],
+    )
+    data = serialize_sessions_to_dict(fetch_export_data(db), db)
+    raw = json.dumps(data)
+    assert AWS_SAMPLE_SECRET not in raw
+    assert "export AWS_SECRET_ACCESS_KEY=[REDACTED]" in raw
+
+
+def test_export_json_redacts_commit_messages(tmp_path):
+    db = _build_single_session_db(
+        tmp_path / "secret_commits_json.db",
+        [Command(id=1, timestamp=1000, command="git commit", exit_code=0,
+                 session_id=1, project_id=1)],
+        commits=[{
+            "hash": "abc123def456",
+            "timestamp": 1500,
+            "message": "fix: add login password: hunter2",
+            "cleaned_message": "add login password: s3cr3t-value",
+        }],
+    )
+    data = serialize_sessions_to_dict(fetch_export_data(db), db)
+    raw = json.dumps(data)
+    assert "hunter2" not in raw
+    assert "s3cr3t-value" not in raw
+    assert "[REDACTED]" in raw
+
+
+def test_export_csv_redacts_command_and_commit(tmp_path):
+    out_file = tmp_path / "secret.csv"
+    db = _build_single_session_db(
+        tmp_path / "secret_csv.db",
+        [Command(id=1, timestamp=1000,
+                 command=f"export AWS_SECRET_ACCESS_KEY={AWS_SAMPLE_SECRET}",
+                 exit_code=0, session_id=1, project_id=1)],
+        commits=[{
+            "hash": "abc123def456",
+            "timestamp": 1500,
+            "message": "fix: add login password: hunter2",
+            "cleaned_message": "add login password: s3cr3t-value",
+        }],
+    )
+    export_csv(fetch_export_data(db), db, output_file=str(out_file))
+    content = out_file.read_text(encoding="utf-8")
+    assert AWS_SAMPLE_SECRET not in content
+    assert "hunter2" not in content
+    assert "s3cr3t-value" not in content
+    assert "[REDACTED]" in content
+
+
+def test_export_json_blacklisted_session_redacted(tmp_path):
+    db = _build_single_session_db(
+        tmp_path / "bl_json.db",
+        [Command(id=1, timestamp=1000, command="vault read secret/data",
+                 exit_code=0, session_id=1, project_id=1)],
+    )
+    data = serialize_sessions_to_dict(fetch_export_data(db), db)
+    raw = json.dumps(data)
+    assert "vault read secret" not in raw
+    assert "Security/Authentication Operations" in raw
+
+
+def test_export_csv_blacklisted_session_redacted(tmp_path):
+    out_file = tmp_path / "bl.csv"
+    db = _build_single_session_db(
+        tmp_path / "bl_csv.db",
+        [Command(id=1, timestamp=1000,
+                 command="aws configure set aws_secret_access_key ABC",
+                 exit_code=0, session_id=1, project_id=1)],
+    )
+    export_csv(fetch_export_data(db), db, output_file=str(out_file))
+    content = out_file.read_text(encoding="utf-8")
+    assert "aws configure" not in content
+    assert "Security/Authentication Operations" in content
+

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -146,3 +146,40 @@ def test_generate_notebook_multiline_commit(temp_db):
     markdown = generate_notebook([s], temp_db)
     assert "feat: add first feature" in markdown
     assert "Here is a detailed explanation" not in markdown
+
+
+AWS_SAMPLE_SECRET = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+
+def test_generate_notebook_redacts_secret_command(temp_db):
+    cmd = Command(id=501, timestamp=1000,
+                  command=f"export AWS_SECRET_ACCESS_KEY={AWS_SAMPLE_SECRET}",
+                  exit_code=0, session_id=1, project_id=1)
+    s = Session(id=1, start_time=1000, end_time=2000, duration_seconds=1000,
+                project_id=1, commands=[cmd])
+    markdown = generate_notebook([s], temp_db, all_commands=True)
+    assert AWS_SAMPLE_SECRET not in markdown
+    assert "export AWS_SECRET_ACCESS_KEY=[REDACTED]" in markdown
+
+
+def test_generate_notebook_blacklisted_session_redacted(temp_db):
+    cmd = Command(id=502, timestamp=1000, command="vault read secret/data",
+                  exit_code=0, session_id=1, project_id=1)
+    s = Session(id=1, start_time=1000, end_time=2000, duration_seconds=1000,
+                project_id=1, commands=[cmd])
+    markdown = generate_notebook([s], temp_db, all_commands=True)
+    assert "vault read secret" not in markdown
+    assert "Security/Authentication Operations" in markdown
+
+
+def test_generate_notebook_redacts_commit_message(temp_db):
+    s = Session(
+        id=1, start_time=1000, end_time=2000, duration_seconds=1000, project_id=1,
+        commands=[Command(id=503, timestamp=1000, command="git commit", exit_code=0,
+                          session_id=1, project_id=1)],
+        commits=[{"hash": "abc123def456", "timestamp": 1500,
+                  "message": "feat: login password: hunter2",
+                  "cleaned_message": "login password: hunter2"}],
+    )
+    markdown = generate_notebook([s], temp_db)
+    assert "hunter2" not in markdown


### PR DESCRIPTION
Closes #398
## Summary

- Redact command text in JSON and CSV exports using the existing sanitizer.
- Redact command text in generated notebooks.
- Redact commit `message` and `cleaned_message` before writing them to export or notebook output.
- Apply the existing session-level blacklist behavior to prevent security/authentication commands from being written in raw form.
- Add regression tests covering JSON, CSV, notebook, and blacklisted-session output.

## Implementation

### `termstory/exporter.py`

- Updated `serialize_sessions_to_dict()` to use `sanitize_session_commands()` for command redaction and session blacklist handling.
- Updated commit `message` and `cleaned_message` to use `redact_command()`.
- Updated `export_csv()` so both command text and serialized commit messages are sanitized.
- Prevented `cleaned_message` from bypassing the sanitizer in CSV output.

### `termstory/notebook.py`

- Updated `generate_notebook()` to redact command text before writing it to the generated notebook.
- Added session-level blacklist handling for security/authentication commands.
- Redacted commit messages before adding them to the notebook.

## Tests

Added regression coverage for:

- JSON command secret redaction.
- JSON commit message redaction.
- CSV command and commit redaction.
- JSON blacklisted-session handling.
- CSV blacklisted-session handling.
- Notebook command redaction.
- Notebook blacklisted-session handling.
- Notebook commit message redaction.

## Validation

```text
50 passed
57 passed
35 passed
43 passed
git diff --check — clean
```

The full test suite still has pre-existing environment/platform-specific collection failures involving missing `textual`, Windows `os.geteuid()` compatibility, and Windows file-locking behavior.

## Issue
