### PR TITLE
fix: sanitize MCP snapshot environment data

### DIFF
--- a/termstory/mcp_snapshot.py
+++ b/termstory/mcp_snapshot.py
@@ -1,31 +1,54 @@
+import getpass
 import logging
 import os
+import re
 import sqlite3
 import subprocess
 import time
 from typing import Dict, Any, List
 
+from termstory.sanitizer import redact_command
+
 logger = logging.getLogger(__name__)
 
+# IDE/editor environment variable prefixes. Their *presence* drives IDE
+# detection, but their values are never persisted: they routinely hold socket
+# paths (e.g. VSCODE_IPC_HOOK_CLI, NVIM_LISTEN_ADDRESS), askpass helpers,
+# session identifiers, or license/locally-identifying data.
+IDE_PREFIXES = ("VSCODE_", "IDEA_", "JETBRAINS_", "XCODE_", "NVIM_", "CURSOR_")
+
+# General editor detection signals. TERM_PROGRAM is a program name (safe to
+# persist verbatim); EDITOR/VISUAL normally name an editor binary, so only
+# the trailing command name is retained (no home/username path component).
+GENERAL_EDITOR_SIGNALS = ("EDITOR", "VISUAL")
+
 def capture_ide_state() -> Dict[str, Any]:
-    """Capture active IDE state from environment variables"""
-    ide_vars = {}
+    """Capture active IDE state from environment variables.
+
+    IDE detection relies on the *presence* of IDE-prefixed environment
+    variables and on a small set of safe signals (TERM_PROGRAM, EDITOR,
+    VISUAL). Raw values of IDE-prefixed variables are deliberately not
+    persisted because they frequently contain sockets, tokens, session
+    identifiers or other locally-identifying data.
+    """
+    ide_vars: Dict[str, Any] = {}
     ide_name = "Unknown"
-    
-    # Look at TERM_PROGRAM
+
+    # TERM_PROGRAM is a terminal/IDE program name (never a path), so its value
+    # is safe to expose and directly identifies VS Code / Cursor.
     term_prog = os.environ.get("TERM_PROGRAM")
     if term_prog:
-        ide_vars["TERM_PROGRAM"] = term_prog
+        ide_vars["TERM_PROGRAM"] = redact_command(term_prog)
         if "vscode" in term_prog.lower():
             ide_name = "VS Code"
         elif "cursor" in term_prog.lower():
             ide_name = "Cursor"
-            
-    # Scan environment for IDE/editor related variables
-    for k, v in os.environ.items():
+
+    # Scan environment variable *names* for IDE prefixes. Detection is based
+    # on presence only; values are intentionally not stored.
+    for k in os.environ:
         k_upper = k.upper()
-        if any(term in k_upper for term in ["VSCODE_", "IDEA_", "JETBRAINS_", "XCODE_", "NVIM_", "CURSOR_"]):
-            ide_vars[k] = v
+        if any(term in k_upper for term in IDE_PREFIXES):
             if "VSCODE_" in k_upper and ide_name == "Unknown":
                 ide_name = "VS Code"
             elif "CURSOR_" in k_upper and ide_name == "Unknown":
@@ -36,24 +59,86 @@ def capture_ide_state() -> Dict[str, Any]:
                 ide_name = "Xcode"
             elif "NVIM_" in k_upper and ide_name == "Unknown":
                 ide_name = "Neovim"
-                
-    # Check general editors
-    for var in ["EDITOR", "VISUAL"]:
+
+    # General editors. EDITOR/VISUAL may point at a binary path; only the
+    # trailing command name is retained so no locally-identifying path
+    # component (home directory, username) is persisted.
+    for var in GENERAL_EDITOR_SIGNALS:
         val = os.environ.get(var)
         if val:
-            ide_vars[var] = val
             if ide_name == "Unknown":
-                if "nvim" in val.lower():
+                low = val.lower()
+                if "nvim" in low:
                     ide_name = "Neovim"
-                elif "vim" in val.lower():
+                elif "vim" in low:
                     ide_name = "Vim"
-                elif "code" in val.lower():
+                elif "code" in low:
                     ide_name = "VS Code"
-                    
+            cmd = val.strip()
+            cmd_name = cmd.split(" ", 1)[0] if cmd else val
+            cmd_name = cmd_name.replace("\\", "/").rsplit("/", 1)[-1]
+            ide_vars[var] = redact_command(cmd_name)
+
     return {
         "ide_name": ide_name,
         "env_vars": ide_vars
     }
+
+def _home_dirs() -> List[str]:
+    """Candidate home directory strings for the current user."""
+    homes: List[str] = []
+    for key in ("HOME", "USERPROFILE"):
+        val = os.environ.get(key)
+        if val and val not in homes:
+            homes.append(val)
+    try:
+        expanded = os.path.expanduser("~")
+        if expanded and expanded not in homes:
+            homes.append(expanded)
+    except Exception:
+        pass
+    return homes
+
+
+def _user_names() -> List[str]:
+    """Candidate username strings for the current user."""
+    names: List[str] = []
+    for key in ("USERNAME", "USER"):
+        val = os.environ.get(key)
+        if val and val not in names:
+            names.append(val)
+    try:
+        uname = getpass.getuser()
+        if uname and uname not in names:
+            names.append(uname)
+    except Exception:
+        pass
+    return names
+
+
+def _scrub_git_path(line: str) -> str:
+    """Scrub locally-identifying path components from a raw git-status line.
+
+    Replaces the user's home directory and any username appearing as a path
+    component with redaction placeholders, then runs the value through the
+    standard command redaction pipeline as a final defensive pass.
+    """
+    scrubbed = line
+    for home in _home_dirs():
+        if home:
+            scrubbed = scrubbed.replace(home, "<REDACTED_HOME>")
+    for name in _user_names():
+        # Only match whole path segments (word-boundary delimited) and skip
+        # trivial single-character names so ordinary file names are not
+        # needlessly corrupted.
+        if name and len(name) >= 2:
+            scrubbed = re.sub(
+                r"(?<![A-Za-z0-9_]){}(?![A-Za-z0-9_])".format(re.escape(name)),
+                "<REDACTED_USER>",
+                scrubbed,
+            )
+    return redact_command(scrubbed)
+
 
 def capture_git_status(cwd: str) -> Dict[str, Any]:
     """Capture Git status (branch, uncommitted files) for the given directory"""
@@ -109,7 +194,7 @@ def capture_git_status(cwd: str) -> Dict[str, Any]:
             uncommitted = []
             for line in status_res.stdout.splitlines():
                 if line.strip():
-                    uncommitted.append(line.strip())
+                    uncommitted.append(_scrub_git_path(line.strip()))
             result["uncommitted_files"] = uncommitted
             
     except (subprocess.TimeoutExpired, OSError):

--- a/tests/test_mcp_snapshot.py
+++ b/tests/test_mcp_snapshot.py
@@ -29,14 +29,16 @@ def test_capture_ide_state():
         state = capture_ide_state()
         assert state["ide_name"] == "VS Code"
         assert state["env_vars"]["TERM_PROGRAM"] == "vscode"
-        assert state["env_vars"]["VSCODE_GIT_IPC_HANDLE"] == "1234"
+        # The value of an IDE-prefixed variable must NOT be persisted.
+        assert "VSCODE_GIT_IPC_HANDLE" not in state["env_vars"]
 
     # Test with Cursor environment variables
     with patch.dict(os.environ, {"TERM_PROGRAM": "Cursor", "CURSOR_PID": "5678"}, clear=True):
         state = capture_ide_state()
         assert state["ide_name"] == "Cursor"
         assert state["env_vars"]["TERM_PROGRAM"] == "Cursor"
-        assert state["env_vars"]["CURSOR_PID"] == "5678"
+        # The value of an IDE-prefixed variable must NOT be persisted.
+        assert "CURSOR_PID" not in state["env_vars"]
 
     # Test with Neovim environment variables
     with patch.dict(os.environ, {"EDITOR": "nvim"}, clear=True):
@@ -45,12 +47,164 @@ def test_capture_ide_state():
         assert state["env_vars"]["EDITOR"] == "nvim"
 
 
+def test_capture_ide_state_does_not_persist_sensitive_values():
+    # VS Code: socket handles and askpass helper paths must not leak.
+    vscode_env = {
+        "VSCODE_IPC_HOOK_CLI": "/tmp/vscode-ipc-user-123.sock",
+        "VSCODE_GIT_ASKPASS_NODE": "/home/user/.vscode/extensions/example/node",
+        "VSCODE_GIT_ASKPASS_MAIN": "/home/user/.vscode/extensions/example/main.js",
+        "VSCODE_GIT_IPC_HANDLE": "/tmp/vscode-git-abc.sock",
+    }
+    with patch.dict(os.environ, vscode_env, clear=True):
+        state = capture_ide_state()
+        assert state["ide_name"] == "VS Code"
+        assert state["env_vars"] == {}
+        payload = json.dumps(state)
+        assert "/tmp/vscode-ipc-user-123.sock" not in payload
+        assert "/home/user/.vscode/extensions" not in payload
+        assert "vscode-ipc-user" not in payload
+
+    # Neovim: the session socket path must not persist.
+    with patch.dict(os.environ, {"NVIM_LISTEN_ADDRESS": "/tmp/nvim-user/session.sock"}, clear=True):
+        state = capture_ide_state()
+        assert state["ide_name"] == "Neovim"
+        assert state["env_vars"] == {}
+        assert "/tmp/nvim-user/session.sock" not in json.dumps(state)
+
+    # JetBrains: representative variable value must not reach the payload.
+    jetbrains_env = {
+        "JETBRAINS_GATEWAY_CMD": "/home/user/.local/share/JetBrains/RemoteDev/session/socket",
+        "IDEA_INITIAL_DIRECTORY": "/home/user/IdeaProjects/myproj",
+    }
+    with patch.dict(os.environ, jetbrains_env, clear=True):
+        state = capture_ide_state()
+        assert state["ide_name"] == "JetBrains"
+        assert state["env_vars"] == {}
+        payload = json.dumps(state)
+        assert "/home/user/.local/share/JetBrains" not in payload
+        assert "/home/user/IdeaProjects/myproj" not in payload
+
+
+def test_capture_ide_state_detection_signals():
+    # Detection via IDE-prefixed variable presence only.
+    with patch.dict(os.environ, {"XCODE_DEVELOPER_DIR": "/Applications/Xcode.app"}, clear=True):
+        assert capture_ide_state()["ide_name"] == "Xcode"
+    with patch.dict(os.environ, {"CURSOR_TRACE_ID": "abc123"}, clear=True):
+        assert capture_ide_state()["ide_name"] == "Cursor"
+    with patch.dict(os.environ, {"IDEA_JDK": "/opt/jdk"}, clear=True):
+        assert capture_ide_state()["ide_name"] == "JetBrains"
+    with patch.dict(os.environ, {"NVIM_APPNAME": "nvim"}, clear=True):
+        assert capture_ide_state()["ide_name"] == "Neovim"
+
+    # Detection via EDITOR / VISUAL values (Vim + VS Code).
+    with patch.dict(os.environ, {"VISUAL": "/usr/bin/vim"}, clear=True):
+        state = capture_ide_state()
+        assert state["ide_name"] == "Vim"
+        # Only the command name is retained, not the path.
+        assert state["env_vars"]["VISUAL"] == "vim"
+    with patch.dict(os.environ, {"EDITOR": "/usr/local/bin/code --wait"}, clear=True):
+        state = capture_ide_state()
+        assert state["ide_name"] == "VS Code"
+        assert state["env_vars"]["EDITOR"] == "code"
+
+
 def test_capture_git_status():
     # Test with non-existent directory
     status = capture_git_status("/non/existent/path")
     assert not status["is_repo"]
     assert status["branch"] is None
     assert len(status["uncommitted_files"]) == 0
+
+
+def _git_porcelain_completed_process(args, stdout):
+    return subprocess.CompletedProcess(args, 0, stdout, "")
+
+
+def _git_status_side_effect(*args, **kwargs):
+    cmd_args = args[0]
+    last = cmd_args[-1]
+    if last == "--is-inside-work-tree":
+        return _git_porcelain_completed_process(cmd_args, "true\n")
+    if last == "HEAD":
+        return _git_porcelain_completed_process(cmd_args, "main\n")
+    if last == "--porcelain":
+        return _git_porcelain_completed_process(cmd_args, _GIT_STATUS_STDOUT)
+    raise AssertionError(f"Unexpected git args: {cmd_args}")
+
+
+_GIT_STATUS_STDOUT = "\n".join([
+    " M termstory/cli.py",
+    "?? /home/user/private_notes/secret.txt",
+    "D  /home/user/.config/termstory/backup.db",
+    "R  /home/user/docs/old.txt -> /home/user/docs/new.txt",
+    "",
+])
+
+
+def test_capture_git_status_sanitizes_uncommitted_files():
+    with patch.dict(os.environ, {"HOME": "/home/user", "USERNAME": "user"}, clear=False), \
+         patch("termstory.mcp_snapshot.os.path.exists", return_value=True), \
+         patch("termstory.mcp_snapshot.os.path.isdir", return_value=True), \
+         patch("termstory.mcp_snapshot.subprocess.run", side_effect=_git_status_side_effect):
+        status = capture_git_status("/home/user/project")
+
+    assert status["is_repo"] is True
+    assert status["branch"] == "main"
+
+    raw_lines = [
+        "?? /home/user/private_notes/secret.txt",
+        "D  /home/user/.config/termstory/backup.db",
+        "R  /home/user/docs/old.txt -> /home/user/docs/new.txt",
+    ]
+    joined = "\n".join(status["uncommitted_files"])
+    for raw in raw_lines:
+        assert raw not in status["uncommitted_files"]
+        assert raw not in joined
+    # The locally-identifying home-directory / username component is gone.
+    assert "/home/user" not in joined
+
+    # Non-sensitive relative paths must be preserved for consumers.
+    assert any("termstory/cli.py" in item for item in status["uncommitted_files"])
+
+
+def test_capture_and_store_mcp_snapshot_no_sensitive_data_persisted():
+    db = MagicMock()
+    db.get_latest_session_id.return_value = 1
+    db.get_mcp_snapshots.return_value = []
+
+    env = {
+        "TERM_PROGRAM": "vscode",
+        "VSCODE_IPC_HOOK_CLI": "/tmp/vscode-ipc-user-123.sock",
+        "VSCODE_GIT_ASKPASS_NODE": "/home/user/.vscode/extensions/example/node",
+        "NVIM_LISTEN_ADDRESS": "/tmp/nvim-user/session.sock",
+        "HOME": "/home/user",
+        "USERNAME": "user",
+    }
+    with patch.dict(os.environ, env, clear=True), \
+         patch("termstory.mcp_snapshot.os.getcwd", return_value="/home/user/project"), \
+         patch("termstory.mcp_snapshot.os.path.exists", return_value=True), \
+         patch("termstory.mcp_snapshot.os.path.isdir", return_value=True), \
+         patch("termstory.mcp_snapshot.subprocess.run", side_effect=_git_status_side_effect):
+        capture_and_store_mcp_snapshot(db)
+
+    assert db.save_mcp_snapshot.called
+    payload = db.save_mcp_snapshot.call_args.kwargs.get("payload")
+    if payload is None:
+        payload = db.save_mcp_snapshot.call_args.args[2]
+    payload_text = json.dumps(payload)
+
+    # No raw sensitive environment values may reach the persisted payload.
+    assert "/tmp/vscode-ipc-user-123.sock" not in payload_text
+    assert "/home/user/.vscode/extensions" not in payload_text
+    assert "/tmp/nvim-user/session.sock" not in payload_text
+
+    # IDE detection must still work.
+    assert payload["ide"]["ide_name"] == "VS Code"
+
+    # No raw git-status path may reach the persisted payload.
+    git_files = json.dumps(payload["git"]["uncommitted_files"])
+    assert "/home/user" not in git_files
+    assert "?? /home/user/private_notes/secret.txt" not in git_files
 
 
 def test_mcp_snapshots_database_integration():


### PR DESCRIPTION
Closes #399
## Summary

- Stop persisting raw IDE-prefixed environment variable values in MCP snapshots.
- Preserve IDE detection using safe signals while keeping sensitive environment values out of `env_vars`.
- Sanitize uncommitted Git file paths before they are persisted.
- Reuse the existing `redact_command()` sanitizer.
- Add regression tests covering sensitive IDE environment values, IDE detection, Git paths, and persisted snapshot payloads.

## Testing

- `python -m pytest tests/test_mcp_snapshot.py -q` — 13 passed
- `tests/test_replay.py` + `tests/test_sanitizer.py` — 35 passed
- `tests/test_mcp_snapshot.py` + `tests/test_database.py` — 28 passed
- `git diff --check` — clean

The CLI test collection has a pre-existing Windows-specific failure because `os.geteuid()` is unavailable on Windows; this is unrelated to the changes in this PR.

## Validation

A smoke test against the real environment confirmed VS Code detection still works while `env_vars` remains empty, preventing raw IDE environment values from being persisted.