### PR TITLE
fix: prevent backup filename collisions

### DIFF
--- a/termstory/backup.py
+++ b/termstory/backup.py
@@ -20,6 +20,11 @@ def _get_backup_dir() -> str:
 def backup_db() -> str:
     """Create a timestamped backup of the TermStory database.
 
+    Backup filenames use a microsecond-precision timestamp
+    (``termstory_backup_YYYYMMDD_HHMMSS_mmmmmm.db``) so back-to-back backups
+    never collide. The fixed-width timestamp keeps filenames lexicographically
+    sortable, which backup rotation relies on to find the oldest backups.
+
     Returns:
         The absolute path to the created backup file.
     """
@@ -28,7 +33,9 @@ def backup_db() -> str:
         raise FileNotFoundError(f"TermStory database not found at {db_path}")
     backup_dir = _get_backup_dir()
     # Wall-clock intentionally: backup filenames must be unique on disk.
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    # Microsecond precision (%f) keeps consecutive backups distinct while the
+    # fixed-width suffix preserves lexicographic = chronological ordering.
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
     backup_path = os.path.join(backup_dir, f"termstory_backup_{timestamp}.db")
 
     # Safely backup the SQLite database using backup API

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sqlite3
 import pytest
 from termstory.backup import backup_db, restore_db
 from termstory.database import Database
@@ -77,14 +78,17 @@ def test_backup_rotation(tmp_path, monkeypatch):
 
     monkeypatch.setattr("termstory.backup.datetime", MockDatetime)
 
-    for _ in range(12):
-        backup_db()
+    created = [backup_db() for _ in range(12)]
 
     from termstory.backup import _get_backup_dir
     backup_dir = _get_backup_dir()
     import glob
     remaining = glob.glob(os.path.join(backup_dir, "termstory_backup_*.db"))
     assert len(remaining) == 10
+
+    # The two oldest backups must have been deleted first.
+    for oldest in sorted(created)[:2]:
+        assert not os.path.exists(oldest)
 
 
 def test_backup_survives_rotation_failure(tmp_path, monkeypatch, caplog):
@@ -128,3 +132,33 @@ def test_backup_survives_rotation_failure(tmp_path, monkeypatch, caplog):
         "Failed to rotate old backups" in record.message
         for record in caplog.records
     )
+
+
+def test_backup_consecutive_calls_unique(tmp_path, monkeypatch):
+    # Regression for #416: two immediate backup_db() calls must produce distinct
+    # files. The test intentionally avoids sleep()/timing so a second-level
+    # timestamp would collide and fail here.
+    db_file = tmp_path / "test_consecutive.db"
+    db_path = str(db_file)
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: db_path)
+    monkeypatch.setattr("termstory.backup.get_db_path", lambda: db_path)
+
+    db = Database(db_path)
+    db.init_db()
+
+    backup_one = backup_db()
+    backup_two = backup_db()
+
+    assert backup_one != backup_two, "consecutive backups must not collide"
+    assert os.path.isfile(backup_one), "first backup file was not created"
+    assert os.path.isfile(backup_two), "second backup file was not created"
+
+    # Both backups must contain valid SQLite data.
+    for backup_path in (backup_one, backup_two):
+        conn = sqlite3.connect(backup_path)
+        try:
+            integrity = conn.execute("PRAGMA integrity_check").fetchone()
+            assert integrity[0] == "ok"
+        finally:
+            conn.close()


### PR DESCRIPTION
Closes #416
## Summary

- Add microsecond precision to backup filenames to prevent rapid consecutive backups from overwriting each other.
- Preserve lexicographic ordering so existing backup rotation continues to remove the oldest backups first.
- Add a regression test verifying that two immediate backup calls create distinct valid SQLite files.
- Strengthen backup rotation coverage to verify oldest-first deletion.

## Implementation

`backup_db()` now generates filenames using:

```text
termstory_backup_YYYYMMDD_HHMMSS_microseconds.db
```

The fixed-width microsecond component preserves chronological ordering while allowing multiple backups within the same second to have distinct filenames.

The implementation continues to use `datetime.now()`, preserving compatibility with the existing `MockDatetime` tests.

## Tests

- `python -m pytest tests/test_backup.py -q` — 4 passed
- `python -m pytest tests/test_cli_restore_confirmation.py -q` — 9 passed
- `python -m pytest tests/test_database.py tests/test_database_queries.py tests/test_archive.py tests/test_corrupt_db.py tests/test_corrupt_db2.py tests/test_corrupt_db3.py tests/test_save_data_none_safety.py tests/test_fts5.py tests/test_fts5_new.py -q` — 32 passed
- `git diff --check` — clean

The full test suite has pre-existing Windows/environment-specific collection failures involving `textual`, `os.geteuid`/`os.getuid`, and Windows process/file-lock behavior. These are unrelated to this change.

## Additional Verification

- `restore_db()` remains unchanged.
- The CLI continues to display the path returned by `backup_db()`.
- No database schema changes were required.
- Backup rotation continues to retain a maximum of 10 backups and removes the oldest backups first.
