### PR TITLE
fix: prevent stale project root cache results

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,5 +42,6 @@ Key configuration parameters:
 - `request_timeout_seconds` (int): HTTP request timeout (in seconds) for LLM API calls. Defaults to `30`.
 - `max_query_log` (int): Maximum number of captured database query profiler entries before older entries are trimmed. Defaults to `10000`.
 - `providers.<name>.<param>`: Provider-specific endpoints, API keys, and model names.
+- `project_root_cache_ttl` (int, seconds): How long resolved project-root results are cached before being re-checked against the filesystem. A shorter value detects newly created/removed project markers (`.git`, `package.json`, ...) sooner but at the cost of more frequent filesystem walks. Defaults to `60`.
 
 ---

--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -1505,6 +1505,7 @@ def config_set(key: str, value: str):
         "reminder_poll_interval": 300,
         "clustering_threshold": 0.6,
         "nfs_timeout_cache_ttl": 60,
+        "project_root_cache_ttl": 60,
     }
 
     default_val = KNOWN_DEFAULTS.get(effective_key)

--- a/termstory/config.py
+++ b/termstory/config.py
@@ -145,6 +145,7 @@ def load_config() -> dict:
         "active_provider": "disabled",  # "groq", "openai", "nvidia", "ollama", "disabled"
         "request_timeout_seconds": 30,
         "nfs_timeout_cache_ttl": 10,
+        "project_root_cache_ttl": 60,
         "ai_max_failures": 3,
         "ai_cooldown_seconds": 60.0,
         "providers": {

--- a/termstory/project.py
+++ b/termstory/project.py
@@ -162,7 +162,7 @@ _PROJECT_ROOT_CACHE_TTL: float = _get_project_root_cache_ttl()
 
 def _find_project_root_cached(path: str) -> str:
     """TTL-bounded cached wrapper around _find_project_root_impl (Issue #417)."""
-    now = time.time()
+    now = time.monotonic()
     with _project_root_cache_lock:
         cached = _PROJECT_ROOT_CACHE.get(path)
         if cached is not None and now - cached[0] < _PROJECT_ROOT_CACHE_TTL:
@@ -177,7 +177,7 @@ def _find_project_root_cached(path: str) -> str:
         if path not in _PROJECT_ROOT_CACHE and len(_PROJECT_ROOT_CACHE) >= _PROJECT_ROOT_CACHE_MAXSIZE:
             # Evict least-recently-used entry (oldest insertion order)
             _PROJECT_ROOT_CACHE.pop(next(iter(_PROJECT_ROOT_CACHE)))
-        _PROJECT_ROOT_CACHE[path] = (time.time(), result)
+        _PROJECT_ROOT_CACHE[path] = (time.monotonic(), result)
     return result
 
 def find_project_root(path: str) -> str:

--- a/termstory/project.py
+++ b/termstory/project.py
@@ -4,7 +4,6 @@ from typing import List, Optional, Dict
 from termstory.models import Session, Project
 
 import shlex
-import functools
 import time
 
 def extract_cd_path(cmd_str: str) -> Optional[str]:
@@ -140,9 +139,46 @@ def _listdir_with_timeout(path: str, timeout: float = 0.5) -> List[str]:
         raise exception_container[0]
     return result
 
-@functools.lru_cache(maxsize=1024)
+# TTL-bounded cache for find_project_root() results (Issue #417).
+# Results are cached per input path for a bounded TTL so the performance
+# advantage of caching is preserved while filesystem changes (marker
+# creation/removal) are eventually reflected after the TTL expires.
+_PROJECT_ROOT_CACHE_MAXSIZE = 1024
+_PROJECT_ROOT_CACHE = {}  # path -> (cached_at_timestamp, project_root)
+_project_root_cache_lock = threading.Lock()
+
+
+def _get_project_root_cache_ttl() -> float:
+    """Return the TTL (seconds) for cached project-root lookups."""
+    from termstory.config import load_config
+    try:
+        return max(float(load_config().get("project_root_cache_ttl", 60)), 1.0)
+    except Exception:
+        return 60.0
+
+
+_PROJECT_ROOT_CACHE_TTL: float = _get_project_root_cache_ttl()
+
+
 def _find_project_root_cached(path: str) -> str:
-    return _find_project_root_impl(path)
+    """TTL-bounded cached wrapper around _find_project_root_impl (Issue #417)."""
+    now = time.time()
+    with _project_root_cache_lock:
+        cached = _PROJECT_ROOT_CACHE.get(path)
+        if cached is not None and now - cached[0] < _PROJECT_ROOT_CACHE_TTL:
+            # Refresh LRU position (move to most-recently-used end)
+            _PROJECT_ROOT_CACHE.pop(path, None)
+            _PROJECT_ROOT_CACHE[path] = cached
+            return cached[1]
+
+    result = _find_project_root_impl(path)
+
+    with _project_root_cache_lock:
+        if path not in _PROJECT_ROOT_CACHE and len(_PROJECT_ROOT_CACHE) >= _PROJECT_ROOT_CACHE_MAXSIZE:
+            # Evict least-recently-used entry (oldest insertion order)
+            _PROJECT_ROOT_CACHE.pop(next(iter(_PROJECT_ROOT_CACHE)))
+        _PROJECT_ROOT_CACHE[path] = (time.time(), result)
+    return result
 
 def find_project_root(path: str) -> str:
     """Find the root project directory for a given path by looking for repository/project markers, 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -79,6 +79,13 @@ def test_load_config_missing_file(tmp_path):
         assert config["max_history_age"] == 5
         assert config["max_query_log"] == 10000
 
+def test_load_config_includes_project_root_cache_ttl_default(tmp_path):
+    # #417: project_root_cache_ttl must ship with a sensible default.
+    config_file = tmp_path / "config.json"
+    with patch("termstory.config.get_config_path", return_value=str(config_file)):
+        config = load_config()
+    assert config["project_root_cache_ttl"] == 60
+
 def test_save_config_error_handling(tmp_path):
     # Write failures must surface so callers can report them.
     with patch("termstory.config.get_config_path", return_value="/invalid/path/that/does/not/exist/config.json"):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -307,6 +307,128 @@ def test_find_project_root_network_mounts_and_timeout(tmp_path, monkeypatch):
     assert t1 - t0 < 3.0  # Timeout prevents 4 calls from taking 4.0s (mock listdir sleeps 1.0s per call, 4 calls = 4.0s)
 
 
+def test_find_project_root_cache_invalidated_after_ttl_marker_creation(tmp_path, monkeypatch):
+    """#417: creating a project marker must eventually invalidate the cached result."""
+    import time
+    import termstory.project as project_module
+    from termstory.project import find_project_root, _PROJECT_ROOT_CACHE
+
+    monkeypatch.setattr("os.path.expanduser", lambda path: str(tmp_path) if path == "~" else path)
+    monkeypatch.setattr(project_module, "_PROJECT_ROOT_CACHE_TTL", 0.1)
+    _PROJECT_ROOT_CACHE.clear()
+
+    # Repo root lives 3 levels under home so the no-marker fallback (2 levels)
+    # differs from the marker-detected root.
+    repo_root = tmp_path / "code" / "work" / "my-repo"
+    nested = repo_root / "src" / "lib"
+    nested.mkdir(parents=True)
+
+    # 1. No marker yet -> fallback root (2 levels under home)
+    assert find_project_root(str(nested)) == str(tmp_path / "code" / "work")
+
+    # 2. Create the marker
+    (repo_root / ".git").mkdir()
+
+    # 3. Within the TTL the stale result is still served (caching benefit)
+    assert find_project_root(str(nested)) == str(tmp_path / "code" / "work")
+
+    # 4. After the TTL expires the newly created project root is detected
+    time.sleep(0.2)
+    assert find_project_root(str(nested)) == str(repo_root)
+
+
+def test_find_project_root_cache_invalidated_after_ttl_marker_removal(tmp_path, monkeypatch):
+    """#417: removing a project marker must eventually invalidate the cached result."""
+    import shutil
+    import time
+    import termstory.project as project_module
+    from termstory.project import find_project_root, _PROJECT_ROOT_CACHE
+
+    monkeypatch.setattr("os.path.expanduser", lambda path: str(tmp_path) if path == "~" else path)
+    monkeypatch.setattr(project_module, "_PROJECT_ROOT_CACHE_TTL", 0.1)
+    _PROJECT_ROOT_CACHE.clear()
+
+    repo_root = tmp_path / "code" / "work" / "my-repo"
+    nested = repo_root / "src"
+    nested.mkdir(parents=True)
+    (repo_root / ".git").mkdir()
+
+    # 1. Marker present -> project root detected
+    assert find_project_root(str(nested)) == str(repo_root)
+
+    # 2. Remove the marker
+    shutil.rmtree(str(repo_root / ".git"))
+
+    # 3. Within the TTL the stale root is still returned (caching benefit)
+    assert find_project_root(str(nested)) == str(repo_root)
+
+    # 4. After the TTL expires the stale project root is no longer returned
+    time.sleep(0.2)
+    assert find_project_root(str(nested)) == str(tmp_path / "code" / "work")
+
+
+def test_find_project_root_cache_serves_cached_result_within_ttl(tmp_path, monkeypatch):
+    """#417: within the TTL the cached result is reused without re-walking the filesystem."""
+    import termstory.project as project_module
+    from termstory.project import find_project_root, _PROJECT_ROOT_CACHE
+
+    monkeypatch.setattr("os.path.expanduser", lambda path: str(tmp_path) if path == "~" else path)
+    monkeypatch.setattr(project_module, "_PROJECT_ROOT_CACHE_TTL", 60)
+    _PROJECT_ROOT_CACHE.clear()
+
+    calls = {"n": 0}
+    real_impl = project_module._find_project_root_impl
+
+    def counting_impl(path):
+        calls["n"] += 1
+        return real_impl(path)
+
+    monkeypatch.setattr(project_module, "_find_project_root_impl", counting_impl)
+
+    proj_dir = tmp_path / "Projects" / "cached-repo"
+    nested = proj_dir / "sub"
+    nested.mkdir(parents=True)
+    (proj_dir / ".git").mkdir()
+
+    assert find_project_root(str(nested)) == str(proj_dir)
+    assert calls["n"] == 1
+
+    # Subsequent calls within the TTL hit the cache and do NOT re-walk the tree
+    assert find_project_root(str(nested)) == str(proj_dir)
+    assert find_project_root(str(nested)) == str(proj_dir)
+    assert calls["n"] == 1
+
+
+def test_get_project_root_cache_ttl_reads_config(tmp_path, monkeypatch):
+    """#417: project_root_cache_ttl config is respected by _get_project_root_cache_ttl."""
+    import json
+    from termstory.project import _get_project_root_cache_ttl
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_file = config_dir / "config.json"
+    config_file.write_text(json.dumps({"project_root_cache_ttl": 5}))
+
+    monkeypatch.setattr("termstory.config.get_app_dir", lambda dir_type: str(config_dir))
+    assert _get_project_root_cache_ttl() == 5.0
+
+
+def test_get_project_root_cache_ttl_default_and_clamp(monkeypatch):
+    """#417: default TTL is 60s; values below 1s are clamped; config errors fall back."""
+    from unittest.mock import patch
+    from termstory.project import _get_project_root_cache_ttl
+
+    with patch("termstory.config.load_config", return_value={}):
+        assert _get_project_root_cache_ttl() == 60.0
+
+    with patch("termstory.config.load_config", return_value={"project_root_cache_ttl": 0}):
+        assert _get_project_root_cache_ttl() == 1.0  # clamped minimum
+
+    with patch("termstory.config.load_config", side_effect=RuntimeError("boom")):
+        assert _get_project_root_cache_ttl() == 60.0  # fallback on config error
+
+
+
 def test_neighbor_propagation_next_project_only():
     """Pass 3: 'Other' session with next_project in proximity but no prev_project gets assigned to next_project."""
     # Session 1: no cd, no project

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -309,13 +309,16 @@ def test_find_project_root_network_mounts_and_timeout(tmp_path, monkeypatch):
 
 def test_find_project_root_cache_invalidated_after_ttl_marker_creation(tmp_path, monkeypatch):
     """#417: creating a project marker must eventually invalidate the cached result."""
-    import time
     import termstory.project as project_module
     from termstory.project import find_project_root, _PROJECT_ROOT_CACHE
 
     monkeypatch.setattr("os.path.expanduser", lambda path: str(tmp_path) if path == "~" else path)
-    monkeypatch.setattr(project_module, "_PROJECT_ROOT_CACHE_TTL", 0.1)
+    monkeypatch.setattr(project_module, "_PROJECT_ROOT_CACHE_TTL", 60.0)
     _PROJECT_ROOT_CACHE.clear()
+
+    # Deterministic monotonic clock so TTL expiry does not depend on real elapsed time.
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(project_module.time, "monotonic", lambda: clock["now"])
 
     # Repo root lives 3 levels under home so the no-marker fallback (2 levels)
     # differs from the marker-detected root.
@@ -332,21 +335,24 @@ def test_find_project_root_cache_invalidated_after_ttl_marker_creation(tmp_path,
     # 3. Within the TTL the stale result is still served (caching benefit)
     assert find_project_root(str(nested)) == str(tmp_path / "code" / "work")
 
-    # 4. After the TTL expires the newly created project root is detected
-    time.sleep(0.2)
+    # 4. Advance past the TTL so the newly created project root is detected
+    clock["now"] += 61.0
     assert find_project_root(str(nested)) == str(repo_root)
 
 
 def test_find_project_root_cache_invalidated_after_ttl_marker_removal(tmp_path, monkeypatch):
     """#417: removing a project marker must eventually invalidate the cached result."""
     import shutil
-    import time
     import termstory.project as project_module
     from termstory.project import find_project_root, _PROJECT_ROOT_CACHE
 
     monkeypatch.setattr("os.path.expanduser", lambda path: str(tmp_path) if path == "~" else path)
-    monkeypatch.setattr(project_module, "_PROJECT_ROOT_CACHE_TTL", 0.1)
+    monkeypatch.setattr(project_module, "_PROJECT_ROOT_CACHE_TTL", 60.0)
     _PROJECT_ROOT_CACHE.clear()
+
+    # Deterministic monotonic clock so TTL expiry does not depend on real elapsed time.
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(project_module.time, "monotonic", lambda: clock["now"])
 
     repo_root = tmp_path / "code" / "work" / "my-repo"
     nested = repo_root / "src"
@@ -362,8 +368,8 @@ def test_find_project_root_cache_invalidated_after_ttl_marker_removal(tmp_path, 
     # 3. Within the TTL the stale root is still returned (caching benefit)
     assert find_project_root(str(nested)) == str(repo_root)
 
-    # 4. After the TTL expires the stale project root is no longer returned
-    time.sleep(0.2)
+    # 4. Advance past the TTL so the stale project root is no longer returned
+    clock["now"] += 61.0
     assert find_project_root(str(nested)) == str(tmp_path / "code" / "work")
 
 


### PR DESCRIPTION
Closes #417
## Summary

- Replace the permanent `lru_cache` used for project-root detection with a bounded TTL-based LRU cache.
- Allow filesystem changes to project markers to be reflected after cache expiry.
- Preserve the existing 1024-entry cache limit and LRU behavior.
- Add a configurable `project_root_cache_ttl` setting with a 60-second default.
- Add regression tests for marker creation, marker removal, cache hits, and TTL/config behavior.
- Document the new configuration option.

## Implementation

`find_project_root()` keeps its existing public API.

The project-root cache now stores the cached result together with its timestamp and refreshes the result when the configured TTL expires.

The cache:

- Uses a 60-second default TTL.
- Preserves the existing 1024-entry maximum.
- Maintains LRU ordering.
- Uses the existing `datetime`/TTL-style caching approach used by the project.
- Avoids performing a filesystem walk on every lookup.

The existing network-mount/NFS timeout caching mechanism was left unchanged.

## Configuration

Added:

```text
project_root_cache_ttl = 60
```

The setting is registered in the configuration defaults and CLI validation and documented in `docs/configuration.md`.

## Tests

- Added regression coverage for project-marker creation after an initial lookup.
- Added regression coverage for project-marker removal after an initial lookup.
- Added coverage confirming cached results are reused within the TTL.
- Added configuration/default/clamping/fallback tests.
- `test_project.py` — 22 passed across repeated runs.
- `py_compile` — passed.
- Ruff — no new findings.
- `git diff --check` — clean.

## Known Environment Issues

The following failures are pre-existing and unrelated to this change:

- Windows symlink privilege failure in `test_find_project_root_symlink_escape`.
- Windows path mismatch in `test_detect_projects`.
- `os.geteuid()` collection failure in `tests/test_config.py` on Windows.

These were left unchanged because they are outside the scope of this issue.
