### PR TITLE
fix: prevent concurrent sleep daemon startup

### DIFF
--- a/termstory/reminder.py
+++ b/termstory/reminder.py
@@ -402,20 +402,62 @@ def consolidate_sleep_contexts(db, force: bool = False) -> int:
 
 
 def start_sleep_daemon(db_path: str):
-    """Spawns the sleep daemon in the background if it's not already running."""
+    """Spawns the sleep daemon in the background if it's not already running.
+
+    Daemon ownership is claimed atomically: the PID file is created with
+    ``O_CREAT | O_EXCL`` so that, of any number of concurrent invocations,
+    exactly one wins the race and goes on to spawn the daemon. Every other
+    invocation finds the file already exists and defers to the running (or
+    just-started) daemon, which later overwrites the placeholder PID with its
+    own. A stale PID file (a daemon that died without cleaning up) is reclaimed
+    so the daemon can be restarted.
+    """
     import sys
     import subprocess
-    
+
     pid_file = os.path.join(get_app_dir("data"), "sleep_daemon.pid")
-    if os.path.exists(pid_file):
+    os.makedirs(os.path.dirname(pid_file), exist_ok=True)
+
+    for attempt in range(2):
         try:
-            with open(pid_file, "r") as f:
-                pid = int(f.read().strip())
-            os.kill(pid, 0)
-            return # Already running
-        except (ValueError, OSError):
-            pass
-            
+            fd = os.open(pid_file, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o666)
+        except FileExistsError:
+            # Another invocation already owns the daemon. If its PID is alive it
+            # is (or is about to become) the running daemon — defer to it.
+            try:
+                with open(pid_file, "r") as f:
+                    pid = int(f.read().strip())
+                os.kill(pid, 0)
+                return  # Already running
+            except (ValueError, OSError):
+                if attempt == 0:
+                    # Stale PID file (a daemon died without cleaning up).
+                    # Reclaim ownership on the next attempt.
+                    try:
+                        os.remove(pid_file)
+                    except OSError:
+                        logger.exception("Failed to remove stale sleep daemon PID file %s", pid_file)
+                    continue
+            # Someone else just claimed ownership; defer to them.
+            return
+        else:
+            # We own the daemon. Record our PID as a placeholder so concurrent
+            # invocations can recognise the claim as held by a live owner.
+            try:
+                os.write(fd, str(os.getpid()).encode("ascii"))
+            except OSError:
+                logger.exception("Failed to write sleep daemon PID file %s", pid_file)
+                try:
+                    os.remove(pid_file)
+                except OSError:
+                    pass
+                return
+            finally:
+                os.close(fd)
+            break
+    else:
+        return
+
     # Inherit and configure the python path
     env = os.environ.copy()
     package_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -432,8 +474,14 @@ def start_sleep_daemon(db_path: str):
             start_new_session=True,
             env=env
         )
-    except OSError as exc:
+    except OSError:
         logger.exception("Failed to start sleep daemon")
+        # We claimed ownership but failed to spawn; release the claim so a
+        # later invocation can start the daemon.
+        try:
+            os.remove(pid_file)
+        except OSError:
+            logger.exception("Failed to remove sleep daemon PID file %s", pid_file)
 
 
 def run_sleep_daemon(db_path: str):

--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -262,6 +262,108 @@ def test_run_sleep_daemon_cleanup_on_initialization_failure(tmp_path, monkeypatc
     assert not pid_file.exists()
 
 
+def test_start_sleep_daemon_spawns_when_no_daemon_running(tmp_path, monkeypatch):
+    from unittest.mock import MagicMock
+    import subprocess
+    import termstory.reminder as reminder
+
+    monkeypatch.setattr(reminder, "get_app_dir", lambda name: str(tmp_path))
+    pid_file = tmp_path / "sleep_daemon.pid"
+
+    calls = []
+    def fake_popen(*args, **kwargs):
+        calls.append(args)
+        return MagicMock()
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    reminder.start_sleep_daemon("dummy.db")
+
+    assert len(calls) == 1
+    # The PID file is created with our PID as a placeholder for the daemon.
+    assert pid_file.read_text().strip() == str(os.getpid())
+
+
+def test_start_sleep_daemon_defers_to_running_daemon(tmp_path, monkeypatch):
+    import subprocess
+    import termstory.reminder as reminder
+
+    monkeypatch.setattr(reminder, "get_app_dir", lambda name: str(tmp_path))
+    pid_file = tmp_path / "sleep_daemon.pid"
+    # Our own process is a live PID, standing in for a running daemon. Patch
+    # os.kill so the liveness probe always reports the process alive (also
+    # keeps this deterministic on platforms where os.kill(pid, 0) misbehaves).
+    pid_file.write_text(str(os.getpid()))
+    monkeypatch.setattr(reminder.os, "kill", lambda pid, sig: None)
+
+    calls = []
+    monkeypatch.setattr(subprocess, "Popen", lambda *args, **kwargs: calls.append(args))
+
+    reminder.start_sleep_daemon("dummy.db")
+
+    assert calls == []
+    # The running daemon's PID file is left untouched.
+    assert pid_file.read_text().strip() == str(os.getpid())
+
+
+def test_start_sleep_daemon_reclaims_stale_pid_file(tmp_path, monkeypatch):
+    import subprocess
+    import termstory.reminder as reminder
+
+    monkeypatch.setattr(reminder, "get_app_dir", lambda name: str(tmp_path))
+    pid_file = tmp_path / "sleep_daemon.pid"
+    # A stale PID file left behind by a daemon that died without cleaning up.
+    pid_file.write_text("999999999")
+
+    def dead_process(pid, sig):
+        raise ProcessLookupError(pid, "no such process")
+    monkeypatch.setattr(reminder.os, "kill", dead_process)
+
+    calls = []
+    monkeypatch.setattr(subprocess, "Popen", lambda *args, **kwargs: calls.append(args))
+
+    reminder.start_sleep_daemon("dummy.db")
+
+    assert len(calls) == 1
+    # The stale PID file was reclaimed and now holds our live PID.
+    assert pid_file.read_text().strip() == str(os.getpid())
+
+
+def test_start_sleep_daemon_concurrent_invocations_spawn_once(tmp_path, monkeypatch):
+    import threading
+    from unittest.mock import MagicMock
+    import subprocess
+    import termstory.reminder as reminder
+
+    monkeypatch.setattr(reminder, "get_app_dir", lambda name: str(tmp_path))
+    # Loser invocations probe the winner's PID via os.kill(pid, 0). Patch it to
+    # always report "alive" so they defer; this also keeps the test deterministic
+    # on platforms where the real os.kill misbehaves when called from threads.
+    monkeypatch.setattr(reminder.os, "kill", lambda pid, sig: None)
+
+    calls = []
+    lock = threading.Lock()
+    def fake_popen(*args, **kwargs):
+        time.sleep(0.05)  # Widen the race window after the winner claims the PID file.
+        with lock:
+            calls.append(args)
+        return MagicMock()
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    barrier = threading.Barrier(8)
+    def worker():
+        barrier.wait()
+        reminder.start_sleep_daemon("dummy.db")
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Exactly one invocation wins the atomic claim and spawns the daemon.
+    assert len(calls) == 1
+
+
 def test_add_reminder_explicit_days_prefix_suffix_stripping(tmp_path, monkeypatch):
     reminders_file = tmp_path / "reminders.json"
     monkeypatch.setattr("termstory.reminder.get_reminders_file_path", lambda: str(reminders_file))


### PR DESCRIPTION
Closes #418
## Summary

- Replace the non-atomic PID-file check-then-spawn sequence with atomic PID-file ownership acquisition.
- Prevent concurrent TermStory invocations from spawning duplicate sleep daemons.
- Preserve stale PID recovery and existing daemon PID/cleanup behavior.
- Release the ownership claim when placeholder creation or daemon startup fails.
- Add regression coverage for normal startup, running-daemon detection, stale PID recovery, and concurrent startup.

## Implementation

`start_sleep_daemon()` now uses:

```python
os.open(pid_file, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
```

to atomically acquire ownership of the daemon PID file.

The winning caller writes a temporary live-owner PID before spawning the daemon. Existing `run_sleep_daemon()` behavior remains responsible for writing the actual daemon PID.

When another caller encounters an existing PID file, it checks whether the recorded process is alive. Live ownership causes the caller to defer rather than spawn another daemon.

Stale or invalid PID files can be reclaimed, allowing future daemon startup to proceed.

If placeholder creation or `Popen()` fails, the ownership claim is cleaned up so it does not permanently block future startup.

## Tests

Added coverage for:

- Starting when no daemon is running.
- Deferring when a live daemon PID exists.
- Reclaiming a stale PID file.
- Eight concurrent startup attempts resulting in exactly one daemon spawn.

Validation:

- New daemon tests — passed.
- Existing daemon/reminder tests — passed.
- `tests/test_sleep.py` — 4 passed.
- Ruff — no new findings.
- `git diff --check` — clean.

Some unrelated environment issues remain around RAG-stack imports and existing signal-handler/pytest-timeout behavior on this Windows environment.