### PR TITLE
perf(database): eliminate project stats N+1 queries

### DIFF
--- a/termstory/database.py
+++ b/termstory/database.py
@@ -860,23 +860,21 @@ class Database:
             
             placeholders = ",".join("?" for _ in project_ids)
             cursor.execute(f"""
-                SELECT id, name, path, first_seen, last_seen, project_context
-                FROM projects
-                WHERE id IN ({placeholders})
+                SELECT p.id, p.name, p.path, p.first_seen, p.last_seen,
+                       COUNT(s.id) AS session_count,
+                       SUM(s.duration_seconds) AS total_time,
+                       p.project_context
+                FROM projects p
+                LEFT JOIN sessions s ON p.id = s.project_id
+                WHERE p.id IN ({placeholders})
+                GROUP BY p.id
+                ORDER BY p.id
             """, project_ids)
             
             rows = cursor.fetchall()
             projects = []
             for row in rows:
-                p_id, name, path, first, last, context = row
-                # Calculate counts dynamically based on all sessions
-                cursor.execute("""
-                    SELECT COUNT(*), SUM(duration_seconds)
-                    FROM sessions
-                    WHERE project_id = ?
-                """, (p_id,))
-                s_count, t_time = cursor.fetchone()
-                
+                p_id, name, path, first, last, s_count, t_time, context = row
                 projects.append(Project(
                     id=p_id,
                     name=name,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -401,3 +401,175 @@ def test_database_still_works_end_to_end_with_custom_timeout(tmp_path, monkeypat
 
     assert "projects" in tables
     assert db.db_timeout == 45.0
+
+
+def _seed_projects_and_sessions(db, now_ts, n_projects, sessions_per_project=1, path_prefix=""):
+    """Helper: insert n_projects projects (each with sessions_per_project sessions)
+    directly via SQL and return the list of project ids.
+
+    Used to set up deterministic data for get_projects_by_ids tests.
+    """
+    conn = db.get_connection()
+    cursor = conn.cursor()
+    project_ids = []
+    for i in range(n_projects):
+        cursor.execute(
+            "INSERT INTO projects (name, path, first_seen, last_seen, project_context) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (f"Proj {i}", f"~/proj-{path_prefix}-{i}", now_ts, now_ts + i * 10, f"ctx-{i}"),
+        )
+        pid = cursor.lastrowid
+        project_ids.append(pid)
+        for j in range(sessions_per_project):
+            cursor.execute(
+                "INSERT INTO sessions (start_time, end_time, duration_seconds, project_id) "
+                "VALUES (?, ?, ?, ?)",
+                (now_ts + i * 1000 + j, now_ts + i * 1000 + j + 50, 50 + j, pid),
+            )
+    conn.commit()
+    conn.close()
+    return project_ids
+
+
+def test_get_projects_by_ids_correctness(tmp_path):
+    """get_projects_by_ids returns correct aggregates and metadata for:
+    multiple projects with sessions, a project with zero sessions, multiple
+    sessions for one project, and preserves the original project metadata."""
+    db_file = tmp_path / "test_proj_by_ids.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    now_ts = int(time.time())
+
+    conn = db.get_connection()
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO projects (name, path, first_seen, last_seen, project_context) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("Proj A", "~/proj-a", now_ts, now_ts + 10, "ctx-a"),
+    )
+    cursor.execute(
+        "INSERT INTO projects (name, path, first_seen, last_seen, project_context) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("Proj B", "~/proj-b", now_ts, now_ts + 20, None),
+    )
+    cursor.execute(
+        "INSERT INTO projects (name, path, first_seen, last_seen, project_context) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("Proj C", "~/proj-c", now_ts, now_ts + 30, "ctx-c"),
+    )
+
+    cursor.execute("SELECT id, path FROM projects ORDER BY id")
+    path_to_id = {row[1]: row[0] for row in cursor.fetchall()}
+    a_id = path_to_id["~/proj-a"]
+    b_id = path_to_id["~/proj-b"]
+    c_id = path_to_id["~/proj-c"]
+
+    # Two sessions for Proj A (durations 100 and 200 -> count=2, total=300)
+    cursor.execute(
+        "INSERT INTO sessions (start_time, end_time, duration_seconds, project_id) "
+        "VALUES (?, ?, ?, ?)",
+        (now_ts, now_ts + 100, 100, a_id),
+    )
+    cursor.execute(
+        "INSERT INTO sessions (start_time, end_time, duration_seconds, project_id) "
+        "VALUES (?, ?, ?, ?)",
+        (now_ts + 200, now_ts + 400, 200, a_id),
+    )
+    # One session for Proj B (duration 300 -> count=1, total=300)
+    cursor.execute(
+        "INSERT INTO sessions (start_time, end_time, duration_seconds, project_id) "
+        "VALUES (?, ?, ?, ?)",
+        (now_ts, now_ts + 300, 300, b_id),
+    )
+    # Proj C: intentionally no sessions (zero-session project)
+    conn.commit()
+    conn.close()
+
+    # Pass ids in non-sorted order to verify ORDER BY p.id stabilizes output
+    projects = db.get_projects_by_ids([c_id, a_id, b_id])
+
+    assert len(projects) == 3
+    by_id = {p.id: p for p in projects}
+
+    # session_count correctness
+    assert by_id[a_id].session_count == 2
+    assert by_id[b_id].session_count == 1
+    assert by_id[c_id].session_count == 0
+
+    # total_time correctness
+    assert by_id[a_id].total_time == 300
+    assert by_id[b_id].total_time == 300
+    assert by_id[c_id].total_time == 0
+
+    # zero-session project must still be returned with zeroed aggregates
+    assert c_id in by_id
+
+    # existing project metadata remains unchanged
+    assert by_id[a_id].name == "Proj A"
+    assert by_id[a_id].path == "~/proj-a"
+    assert by_id[a_id].first_seen == now_ts
+    assert by_id[a_id].last_seen == now_ts + 10
+    assert by_id[a_id].project_context == "ctx-a"
+    assert by_id[b_id].name == "Proj B"
+    assert by_id[b_id].project_context is None
+    assert by_id[c_id].name == "Proj C"
+    assert by_id[c_id].project_context == "ctx-c"
+
+    # ORDER BY p.id is deterministic regardless of input order
+    assert [p.id for p in projects] == sorted([a_id, b_id, c_id])
+
+
+def test_get_projects_by_ids_empty(tmp_path):
+    """Empty project_ids must return [] and execute no SQL."""
+    db_file = tmp_path / "test_proj_empty.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    db.query_logs.clear()
+    assert db.get_projects_by_ids([]) == []
+    # No connection/queries should run for an empty id list.
+    assert len(db.query_logs) == 0
+
+
+def test_get_projects_by_ids_query_count_is_constant(tmp_path):
+    """Regression/perf test for issue #423: the number of SQL queries must NOT
+    grow with the number of project ids (must not be 1 + N)."""
+    db_file = tmp_path / "test_proj_perf.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    now_ts = int(time.time())
+
+    # Small workload: 3 projects, one session each.
+    small_ids = _seed_projects_and_sessions(db, now_ts, 3, sessions_per_project=1, path_prefix="a")
+
+    db.query_logs.clear()
+    projects_small = db.get_projects_by_ids(small_ids)
+    small_query_count = len(db.query_logs)
+
+    assert len(projects_small) == 3
+    # A single bulk query, not 1 + N.
+    assert small_query_count == 1
+
+    # Larger workload: 12 projects with 3 sessions each, plus a zero-session
+    # project to ensure the LEFT JOIN adds no extra queries and still returns
+    # the project with zeroed aggregates.
+    large_ids = _seed_projects_and_sessions(db, now_ts, 12, sessions_per_project=3, path_prefix="b")
+    zero_ids = _seed_projects_and_sessions(db, now_ts, 1, sessions_per_project=0, path_prefix="c")
+    all_ids = small_ids + large_ids + zero_ids
+
+    db.query_logs.clear()
+    projects_large = db.get_projects_by_ids(all_ids)
+    large_query_count = len(db.query_logs)
+
+    assert len(projects_large) == len(all_ids)
+    # The zero-session project must still be returned with zeroed aggregates.
+    zero_proj = next(p for p in projects_large if p.id == zero_ids[0])
+    assert zero_proj.session_count == 0
+    assert zero_proj.total_time == 0
+
+    # Query count must remain bounded (O(1)) as N grows, proving the N+1
+    # pattern is gone. Under the old implementation this would be 1 + N.
+    assert large_query_count == 1
+    assert large_query_count == small_query_count

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -532,44 +532,93 @@ def test_get_projects_by_ids_empty(tmp_path):
     assert len(db.query_logs) == 0
 
 
+def _bulk_project_query_count(logs):
+    """Count the relevant data-fetch SQL issued by get_projects_by_ids(): the
+    single bulk aggregate (projects LEFT JOIN sessions).
+
+    This excludes incidental connection-setup SQL such as the
+    ``PRAGMA foreign_keys = ON`` that get_connection() issues. That PRAGMA is
+    routed through the query-logging cursor only on some Python/sqlite versions
+    (e.g. the 3.9/3.10 CI jobs) and not others, so counting *all* logged
+    statements would be version-dependent. Counting only the relevant SELECT is
+    robust across versions and still proves the N+1 pattern is gone.
+    """
+    return [
+        entry["sql"]
+        for entry in logs
+        if "FROM projects" in entry["sql"] and "LEFT JOIN sessions" in entry["sql"]
+    ]
+
+
 def test_get_projects_by_ids_query_count_is_constant(tmp_path):
-    """Regression/perf test for issue #423: the number of SQL queries must NOT
-    grow with the number of project ids (must not be 1 + N)."""
+    """Regression/perf test for issue #423.
+
+    get_projects_by_ids() must issue a bounded, constant number of relevant
+    SQL queries regardless of how many project ids it is given (NOT 1 + N).
+    The old implementation issued one SELECT ... FROM projects plus a
+    per-project SELECT ... FROM sessions WHERE project_id = ? for every id, so
+    the count grew linearly with N. Compare a small (N=3) and a large (N=16)
+    workload: both must return the right projects and issue the same, bounded
+    number of relevant queries.
+    """
     db_file = tmp_path / "test_proj_perf.db"
     db = Database(str(db_file))
     db.init_db()
-
     now_ts = int(time.time())
 
-    # Small workload: 3 projects, one session each.
+    # Small workload: 3 projects, one session each (duration 50).
     small_ids = _seed_projects_and_sessions(db, now_ts, 3, sessions_per_project=1, path_prefix="a")
-
     db.query_logs.clear()
     projects_small = db.get_projects_by_ids(small_ids)
-    small_query_count = len(db.query_logs)
+    small_logs = list(db.query_logs)
+    small_relevant = _bulk_project_query_count(small_logs)
 
     assert len(projects_small) == 3
-    # A single bulk query, not 1 + N.
-    assert small_query_count == 1
+    assert all(p.session_count == 1 for p in projects_small)
+    assert all(p.total_time == 50 for p in projects_small)
 
-    # Larger workload: 12 projects with 3 sessions each, plus a zero-session
-    # project to ensure the LEFT JOIN adds no extra queries and still returns
-    # the project with zeroed aggregates.
+    # Larger workload: 12 projects with 3 sessions each (50/51/52 => 153s),
+    # plus a zero-session project, to exercise the LEFT JOIN and zero-session
+    # preservation without adding queries.
     large_ids = _seed_projects_and_sessions(db, now_ts, 12, sessions_per_project=3, path_prefix="b")
     zero_ids = _seed_projects_and_sessions(db, now_ts, 1, sessions_per_project=0, path_prefix="c")
     all_ids = small_ids + large_ids + zero_ids
-
     db.query_logs.clear()
     projects_large = db.get_projects_by_ids(all_ids)
-    large_query_count = len(db.query_logs)
+    large_logs = list(db.query_logs)
+    large_relevant = _bulk_project_query_count(large_logs)
 
     assert len(projects_large) == len(all_ids)
-    # The zero-session project must still be returned with zeroed aggregates.
+    # Multiple sessions for one project: 50 + 51 + 52 = 153s.
+    large_proj_ids = set(large_ids)
+    large_projs = [p for p in projects_large if p.id in large_proj_ids]
+    assert all(p.session_count == 3 for p in large_projs)
+    assert all(p.total_time == 153 for p in large_projs)
+    # Zero-session project still returned with zeroed aggregates (LEFT JOIN).
     zero_proj = next(p for p in projects_large if p.id == zero_ids[0])
     assert zero_proj.session_count == 0
     assert zero_proj.total_time == 0
 
-    # Query count must remain bounded (O(1)) as N grows, proving the N+1
-    # pattern is gone. Under the old implementation this would be 1 + N.
-    assert large_query_count == 1
-    assert large_query_count == small_query_count
+    # --- Core O(1) regression assertions -----------------------------------
+    # Exactly ONE bulk aggregate query for N ids, independent of N. The old
+    # N+1 implementation has no LEFT JOIN, so this filter matches 0 there --
+    # this alone rejects a regression to the old behavior.
+    assert len(small_relevant) == 1
+    assert len(large_relevant) == 1
+    assert len(small_relevant) == len(large_relevant)  # constant regardless of N
+
+    # The per-project session aggregate that characterized the old N+1 pattern
+    # (SELECT ... FROM sessions WHERE project_id = ?) must be absent entirely.
+    n_plus_1 = [
+        e["sql"] for e in large_logs
+        if "FROM sessions" in e["sql"] and "WHERE project_id = ?" in e["sql"]
+    ]
+    assert n_plus_1 == []  # would hold N entries under the old impl
+
+    # Total statements issued must be bounded and NOT grow with N. A constant
+    # connection-setup PRAGMA may be logged on some Python/sqlite versions, so
+    # compare the two workloads and demand a bound well below 1 + N.
+    assert len(large_logs) == len(small_logs)  # O(1): constant across input sizes
+    assert len(large_logs) < len(all_ids)  # bounded: not 1 + N
+    assert len(large_logs) <= 2  # 1 SELECT + optional version-dependent PRAGMA
+


### PR DESCRIPTION
Closes #423
## Summary


Eliminates the N+1 query pattern in `Database.get_projects_by_ids()`.

Previously, retrieving multiple projects executed one project query followed by a separate session aggregate query for every project. The implementation now retrieves project metadata and session statistics using a single bulk `LEFT JOIN` + `GROUP BY` query.

## Changes

- Replaced per-project session aggregate queries with a single bulk query.
- Added `LEFT JOIN` to preserve projects with zero sessions.
- Uses `COUNT(s.id)` so zero-session projects correctly return `session_count = 0`.
- Preserves `total_time = 0` for projects without sessions.
- Preserves the empty `project_ids` fast path.
- Added deterministic `ORDER BY p.id`.
- Added correctness and performance regression tests.
- No schema migrations or API changes.

## Tests

Full database test file:

```text
python -m pytest tests/test_database.py -v --tb=short