### PR TITLE
feat(export): add markdown export format

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -47,9 +47,10 @@ Generate and automatically open a beautiful, high-density HTML report of your Te
 - `termstory web`
 
 ### 📤 Export (Structured Data Export)
-Export all or filtered sessions as JSON or CSV files to share or perform custom analysis.
+Export all or filtered sessions as JSON, CSV, or Markdown to share or perform custom analysis.
 - `termstory export --format json`
 - `termstory export --format csv --output history.csv`
+- `termstory export --format markdown`
 
 ### 📊 Stats (Detailed Work Telemetry)
 Compute and display high-density, CLI-native command category breakdown tables, tool usage, and terminal telemetry.
@@ -187,6 +188,8 @@ termstory web                # Generate and open a beautiful HTML report in your
 ```bash
 termstory export --format json                           # Export all sessions as JSON to stdout
 termstory export --format csv --output ~/history.csv      # Export as CSV to a file
+termstory export --format markdown                       # Export as Markdown to stdout
+termstory export --format markdown -o sessions.md         # Export as Markdown to a file
 termstory export --project myapp --since 7               # Export last 7 days of "myapp" project
 termstory export --since 2026-06-01                      # Export sessions since specific date
 ```

--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -1254,19 +1254,19 @@ def replay_cmd(
 
 @app.command("export")
 def export_cmd(
-    format: str = typer.Option("json", "--format", "-f", help="Export format: 'json' or 'csv'"),
+    format: str = typer.Option("json", "--format", "-f", help="Export format: 'json', 'csv', or 'markdown'"),
     output: Optional[str] = typer.Option(None, "--output", "-o", help="Output file path (prints to stdout if omitted)"),
     project: Optional[str] = typer.Option(None, "--project", "-p", help="Filter by project name or path"),
     since: Optional[str] = typer.Option(None, "--since", "-s", help="Filter by since duration (e.g. '7' for 7 days, or YYYY-MM-DD)")
 ):
-    """Export history sessions and commands as JSON or CSV"""
+    """Export history sessions and commands as JSON, CSV, or Markdown"""
     db_path = get_db_path()
     db = Database(db_path)
     safe_init_db(db)
     
     run_ingestion(db)
     
-    from termstory.exporter import fetch_export_data, export_json, export_csv
+    from termstory.exporter import fetch_export_data, export_json, export_csv, export_markdown
     
     try:
         sessions = fetch_export_data(db, project_filter=project, since_str=since)
@@ -1283,8 +1283,10 @@ def export_cmd(
         export_json(sessions, db, output_file=output)
     elif fmt == "csv":
         export_csv(sessions, db, output_file=output)
+    elif fmt in ("markdown", "md"):
+        export_markdown(sessions, db, output_file=output)
     else:
-        Console(stderr=True).print(f"[bold red]Error: Unsupported format '{format}'. Use 'json' or 'csv'.[/]")
+        Console(stderr=True).print(f"[bold red]Error: Unsupported format '{format}'. Use 'json', 'csv', or 'markdown'.[/]")
         raise typer.Exit(code=1)
 
 @app.command("archive")

--- a/termstory/exporter.py
+++ b/termstory/exporter.py
@@ -281,3 +281,139 @@ def export_csv(
             write_rows(f)
     else:
         write_rows(sys.stdout)
+
+def _escape_md_table_cell(value: Any) -> str:
+    """Escape a value so it is safe to embed inside a Markdown table cell.
+
+    Pipe characters (``|``) and newlines would otherwise break the table
+    structure; backslashes are escaped first so the pipe escaping is not
+    undone. ``None`` renders as an empty string.
+    """
+    if value is None:
+        return ""
+    text = str(value)
+    text = text.replace("\\", "\\\\")
+    text = text.replace("|", "\\|")
+    # Newlines are not legal inside a table cell — collapse to spaces.
+    text = text.replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
+    return text
+
+def _md_code_fence(content: Any, lang: str = "text") -> str:
+    """Render arbitrary content inside a fenced Markdown code block.
+
+    The fence length is derived from the longest run of backticks found in
+    the content (minimum 3), so command text that itself contains backticks
+    can never prematurely close the block. Content is emitted verbatim — it
+    is *not* Markdown-rendered — which preserves commands, empty lines and
+    Markdown-special characters exactly as sanitized.
+    """
+    text = "" if content is None else str(content)
+    max_run = 0
+    run = 0
+    for ch in text:
+        if ch == "`":
+            run += 1
+            if run > max_run:
+                max_run = run
+        else:
+            run = 0
+    fence_len = max(3, max_run + 1)
+    fence = "`" * fence_len
+    return f"{fence}{lang}\n{text}\n{fence}"
+
+def _render_session_markdown(sdict: Dict[str, Any]) -> List[str]:
+    """Render a single serialized session dict as Markdown lines."""
+    session_id = _escape_md_table_cell(sdict.get("session_id", ""))
+    project_name = sdict.get("project_name") or "Other"
+    lines: List[str] = [f"## Session #{session_id} — {project_name}", ""]
+
+    start_iso = sdict.get("start_time_iso") or "—"
+    end_iso = sdict.get("end_time_iso") or "—"  # None/empty => "in progress"
+    duration_readable = sdict.get("duration_readable") or "—"
+    project_path = sdict.get("project_path")
+    is_legacy = sdict.get("is_legacy", False)
+
+    duration_display = duration_readable
+
+    # Session / project metadata as an escaped table.
+    lines.append("| Field | Value |")
+    lines.append("| --- | --- |")
+    lines.append(f"| Start | {_escape_md_table_cell(start_iso)} |")
+    lines.append(f"| End | {_escape_md_table_cell(end_iso)} |")
+    lines.append(f"| Duration | {_escape_md_table_cell(duration_display)} |")
+    lines.append(f"| Project path | {_escape_md_table_cell(project_path if project_path is not None else '—')} |")
+    lines.append(f"| Legacy session | {'Yes' if is_legacy else 'No'} |")
+    lines.append("")
+
+    # AI Summary (already sanitized). Rendered as prose; only emitted when present.
+    ai_summary = sdict.get("ai_summary")
+    if ai_summary:
+        lines.append("### AI Summary")
+        lines.append("")
+        lines.append(_escape_md_table_cell(ai_summary))
+        lines.append("")
+
+    # Commands — always fenced so multiline / Markdown-special content is safe.
+    commands = sdict.get("commands") or []
+    lines.append("### Commands")
+    lines.append("")
+    if commands:
+        cmd_texts = [c.get("command") or "" for c in commands]
+        lines.append(_md_code_fence("\n".join(cmd_texts)))
+        lines.append("")
+    else:
+        lines.append("_(no commands recorded)_")
+        lines.append("")
+
+    # Commits — rendered as an escaped table.
+    commits = sdict.get("commits") or []
+    lines.append("### Commits")
+    lines.append("")
+    if commits:
+        lines.append("| Hash | Message |")
+        lines.append("| --- | --- |")
+        for c in commits:
+            short_hash = (c.get("hash") or "")[:7]
+            msg = c.get("cleaned_message") or c.get("message") or ""
+            lines.append(
+                f"| {_escape_md_table_cell(short_hash)} | {_escape_md_table_cell(msg)} |"
+            )
+        lines.append("")
+    else:
+        lines.append("_(no commits)_")
+        lines.append("")
+
+    return lines
+
+def export_markdown(
+    sessions: List[Session],
+    db: Database,
+    output_file: Optional[str] = None
+) -> None:
+    """Export the list of sessions as a Markdown document.
+
+    Reuses :func:`serialize_sessions_to_dict`, which routes all command and
+    commit text through the shared sanitizer so secrets are redacted and
+    fully-blacklisted (security/auth) sessions render as the redaction marker
+    — exactly as in the JSON and CSV exports. Only the *rendering* differs.
+    """
+    data = serialize_sessions_to_dict(sessions, db)
+
+    lines: List[str] = ["# Termstory Export", ""]
+
+    if not data:
+        lines.append("_No sessions to export._")
+        lines.append("")
+    else:
+        for sdict in data:
+            lines.extend(_render_session_markdown(sdict))
+
+    output = "\n".join(lines)
+    if not output.endswith("\n"):
+        output += "\n"
+
+    if output_file and output_file != "-":
+        with open(output_file, "w", encoding="utf-8") as f:
+            f.write(output)
+    else:
+        sys.stdout.write(output)

--- a/termstory/exporter.py
+++ b/termstory/exporter.py
@@ -298,6 +298,29 @@ def _escape_md_table_cell(value: Any) -> str:
     text = text.replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
     return text
 
+def _escape_md_text(value: Any) -> str:
+    """Escape a value for inline Markdown rendering (headings / prose).
+
+    Collapses every line break to a single space so a value can never spawn
+    additional Markdown blocks, then backslash-escapes the Markdown
+    punctuation that could otherwise alter document structure — headings
+    (``#``), emphasis (``*``/``_``), links (``[]()``), inline code
+    (backticks), tables (``|``) and HTML (``<``/``>``). Ordinary readable
+    text is preserved verbatim. ``None`` renders as an empty string.
+    """
+    if value is None:
+        return ""
+    text = str(value)
+    # Normalize all line endings, then collapse them so the value stays on a
+    # single line and cannot spawn additional Markdown blocks.
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = " ".join(text.splitlines())
+    # Escape backslashes first so the escaping below cannot be undone.
+    text = text.replace("\\", "\\\\")
+    for ch in "`*_[]()#|<>":
+        text = text.replace(ch, "\\" + ch)
+    return text
+
 def _md_code_fence(content: Any, lang: str = "text") -> str:
     """Render arbitrary content inside a fenced Markdown code block.
 
@@ -324,7 +347,7 @@ def _md_code_fence(content: Any, lang: str = "text") -> str:
 def _render_session_markdown(sdict: Dict[str, Any]) -> List[str]:
     """Render a single serialized session dict as Markdown lines."""
     session_id = _escape_md_table_cell(sdict.get("session_id", ""))
-    project_name = sdict.get("project_name") or "Other"
+    project_name = _escape_md_text(sdict.get("project_name") or "Other")
     lines: List[str] = [f"## Session #{session_id} — {project_name}", ""]
 
     start_iso = sdict.get("start_time_iso") or "—"
@@ -345,12 +368,14 @@ def _render_session_markdown(sdict: Dict[str, Any]) -> List[str]:
     lines.append(f"| Legacy session | {'Yes' if is_legacy else 'No'} |")
     lines.append("")
 
-    # AI Summary (already sanitized). Rendered as prose; only emitted when present.
+    # AI Summary (already sanitized). Rendered as escaped prose; only emitted
+    # when present. It is not escaped as a table cell — it is prose, so the
+    # Markdown structure chars are escaped instead.
     ai_summary = sdict.get("ai_summary")
     if ai_summary:
         lines.append("### AI Summary")
         lines.append("")
-        lines.append(_escape_md_table_cell(ai_summary))
+        lines.append(_escape_md_text(ai_summary))
         lines.append("")
 
     # Commands — always fenced so multiline / Markdown-special content is safe.

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -9,7 +9,7 @@ import pytest
 from termstory.cli import app
 from termstory.database import Database
 from termstory.models import Project, Session, Command
-from termstory.exporter import parse_since, fetch_export_data, serialize_sessions_to_dict, export_json, export_csv
+from termstory.exporter import parse_since, fetch_export_data, serialize_sessions_to_dict, export_json, export_csv, export_markdown
 
 @pytest.fixture
 def temp_db(tmp_path):
@@ -351,4 +351,223 @@ def test_export_csv_blacklisted_session_redacted(tmp_path):
     content = out_file.read_text(encoding="utf-8")
     assert "aws configure" not in content
     assert "Security/Authentication Operations" in content
+
+def test_export_markdown_stdout(temp_db, capsys):
+    sessions = fetch_export_data(temp_db)
+    export_markdown(sessions, temp_db, output_file=None)
+    out = capsys.readouterr().out
+
+    assert out.startswith("# Termstory Export")
+    assert "Project Alpha" in out
+    assert "Session #1" in out
+    assert "Start" in out
+    assert "Duration" in out
+    assert "git status" in out
+    assert "a1b2c3d" in out
+    assert "init alpha" in out
+    assert "```text" in out
+
+
+def test_export_markdown_file(temp_db, tmp_path):
+    sessions = fetch_export_data(temp_db)
+    out_file = tmp_path / "export.md"
+    export_markdown(sessions, temp_db, output_file=str(out_file))
+    content = out_file.read_text(encoding="utf-8")
+
+    assert content.startswith("# Termstory Export")
+    assert "## Session #1" in content
+    assert "Project Alpha" in content
+    assert "git status" in content
+    assert content.endswith("\n")
+
+
+def test_export_markdown_multiple_sessions(temp_db, capsys):
+    sessions = fetch_export_data(temp_db)
+    export_markdown(sessions, temp_db, output_file=None)
+    out = capsys.readouterr().out
+
+    assert "## Session #1" in out
+    assert "## Session #2" in out
+    assert "## Session #3" in out
+    assert "Project Beta" in out
+    assert "Other" in out
+    assert out.count("```text") == 3
+    assert out.count("### Commits") == 3
+    assert "a1b2c3d" in out
+
+
+def test_export_markdown_empty(tmp_path, capsys):
+    db = Database(str(tmp_path / "empty_md.db"))
+    db.init_db()
+    export_markdown([], db, output_file=None)
+    out = capsys.readouterr().out
+
+    assert "# Termstory Export" in out
+    assert "No sessions to export" in out
+
+
+def test_export_markdown_sessions_without_commands_and_commits(temp_db, capsys):
+    sessions = fetch_export_data(temp_db)
+    sessions[0].commands = []
+    sessions[0].commits = []
+    export_markdown(sessions, temp_db, output_file=None)
+    out = capsys.readouterr().out
+
+    assert "# Termstory Export" in out
+    assert "_(no commands recorded)_" in out
+    assert "_(no commits)_" in out
+
+
+def test_export_markdown_null_end_time(temp_db, capsys):
+    sessions = fetch_export_data(temp_db)
+    sessions[0].end_time = None
+    export_markdown(sessions, temp_db, output_file=None)
+    out = capsys.readouterr().out
+
+    assert "## Session #1" in out
+    assert "End" in out
+
+
+def test_export_markdown_redacts_command_secret(tmp_path):
+    out_file = tmp_path / "secret.md"
+    db = _build_single_session_db(
+        tmp_path / "secret_md.db",
+        [Command(id=1, timestamp=1000,
+                 command="export AWS_SECRET_ACCESS_KEY=" + AWS_SAMPLE_SECRET,
+                 exit_code=0, session_id=1, project_id=1)],
+    )
+    export_markdown(fetch_export_data(db), db, output_file=str(out_file))
+    content = out_file.read_text(encoding="utf-8")
+    assert AWS_SAMPLE_SECRET not in content
+    assert "export AWS_SECRET_ACCESS_KEY=[REDACTED]" in content
+
+
+def test_export_markdown_redacts_commit_messages(tmp_path):
+    out_file = tmp_path / "secret_commits.md"
+    db = _build_single_session_db(
+        tmp_path / "secret_commits_md.db",
+        [Command(id=1, timestamp=1000, command="git commit", exit_code=0,
+                 session_id=1, project_id=1)],
+        commits=[{
+            "hash": "abc123def456",
+            "timestamp": 1500,
+            "message": "fix: add login password: hunter2",
+            "cleaned_message": "add login password: s3cr3t-value",
+        }],
+    )
+    export_markdown(fetch_export_data(db), db, output_file=str(out_file))
+    content = out_file.read_text(encoding="utf-8")
+    assert "hunter2" not in content
+    assert "s3cr3t-value" not in content
+    assert "[REDACTED]" in content
+    assert "abc123d" in content
+
+
+def test_export_markdown_blacklisted_session(tmp_path):
+    out_file = tmp_path / "bl.md"
+    db = _build_single_session_db(
+        tmp_path / "bl_md.db",
+        [Command(id=1, timestamp=1000, command="vault read secret/data",
+                 exit_code=0, session_id=1, project_id=1)],
+    )
+    export_markdown(fetch_export_data(db), db, output_file=str(out_file))
+    content = out_file.read_text(encoding="utf-8")
+    assert "vault read secret" not in content
+    assert "Security/Authentication Operations" in content
+
+
+def test_export_markdown_escaping(tmp_path):
+    out_file = tmp_path / "escape.md"
+    # Build special Markdown characters via chr() so the test source itself
+    # stays free of escaping pitfalls while the strings hold real bytes.
+    BT = chr(96)       # backtick
+    PIPE = chr(124)    # |
+    HASH = chr(35)     # #
+    STAR = chr(42)     # *
+    UNDER = chr(95)    # _
+    LB = chr(91)       # [
+    RB = chr(93)       # ]
+    BACK = chr(92)     # backslash
+    special_cmd = (
+        "echo " + PIPE + " " + BT + "c" + BT + " " + HASH + "d "
+        + STAR + "e" + STAR + " " + UNDER + "f" + UNDER + " "
+        + LB + "g" + RB + " " + BACK + "h"
+    )
+    multiline_cmd = "first " + PIPE + " line\nsecond " + BT + "q" + BT + " tail"
+    db = _build_single_session_db(
+        tmp_path / "escape_md.db",
+        [Command(id=1, timestamp=1000, command=special_cmd,
+                 exit_code=0, session_id=1, project_id=1),
+         Command(id=2, timestamp=1100, command=multiline_cmd,
+                 exit_code=0, session_id=1, project_id=1)],
+        commits=[{
+            "hash": "def012345678",
+            "timestamp": 1200,
+            "message": "msg with " + PIPE + " pipe",
+            "cleaned_message": "msg with " + PIPE + " pipe",
+        }],
+    )
+    export_markdown(fetch_export_data(db), db, output_file=str(out_file))
+    content = out_file.read_text(encoding="utf-8")
+
+    # Special Markdown chars inside commands are preserved verbatim within the
+    # fenced code block (code-block contents are never parsed as Markdown).
+    assert special_cmd in content
+    assert ("first " + PIPE + " line") in content
+    assert ("second " + BT + "q" + BT + " tail") in content
+
+    # The command block is a balanced fenced code block.
+    fence_lines = [ln.strip() for ln in content.splitlines() if ln.strip().startswith(BT + BT + BT)]
+    opens = [f for f in fence_lines if f.lstrip(BT) != ""]
+    closers = [f for f in fence_lines if f.lstrip(BT) == ""]
+    assert len(opens) == 1
+    assert len(closers) == 1
+    assert opens[0].startswith(BT + BT + BT + "text")
+    assert len(opens[0]) - len(opens[0].lstrip(BT)) == len(closers[0])
+
+    # A pipe in a commit message is escaped to | so the table cell is intact.
+    assert ("msg with " + BACK + PIPE + " pipe") in content
+    assert ("msg with " + PIPE + " pipe") not in content
+
+    # Markdown table separator is well-formed.
+    assert "| --- | --- |" in content
+
+
+def test_cli_export_markdown(tmp_path, monkeypatch):
+    db_file = tmp_path / "test_cli_md_export.db"
+    monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.cli.get_history_files", lambda: [])
+    monkeypatch.setattr("termstory.cli.run_ingestion", lambda db: None)
+
+    db = Database(str(db_file))
+    db.init_db()
+    p = Project(id=1, name="CLI Project", path="~/projects/cli",
+                first_seen=2000, last_seen=2000, session_count=1, total_time=100)
+    cmd = Command(id=50, timestamp=2000, command="echo 'CLI test'", exit_code=0,
+                  session_id=1, project_id=1)
+    s = Session(id=1, start_time=2000, end_time=2000, duration_seconds=100,
+                project_id=1, commands=[cmd])
+    db.save_data([p], [s], [cmd])
+
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["export", "--format", "markdown"])
+    assert result.exit_code == 0
+    assert "# Termstory Export" in result.stdout
+    assert "CLI Project" in result.stdout
+    assert "echo 'CLI test'" in result.stdout
+
+    result_md = runner.invoke(app, ["export", "-f", "md"])
+    assert result_md.exit_code == 0
+    assert "# Termstory Export" in result_md.stdout
+
+    md_path = tmp_path / "cli_out.md"
+    result_file = runner.invoke(app, ["export", "--format", "markdown", "-o", str(md_path)])
+    assert result_file.exit_code == 0
+    assert os.path.exists(md_path)
+    assert "# Termstory Export" in md_path.read_text(encoding="utf-8")
+
+    result_invalid = runner.invoke(app, ["export", "--format", "xml"])
+    assert result_invalid.exit_code == 1
 

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -533,6 +533,54 @@ def test_export_markdown_escaping(tmp_path):
     assert "| --- | --- |" in content
 
 
+def test_export_markdown_project_name_newline_escaped(tmp_path):
+    out_file = tmp_path / "proj_newline.md"
+    db = Database(str(tmp_path / "proj_newline_md.db"))
+    db.init_db()
+    # A project name containing a newline and Markdown heading syntax must not
+    # escape the session heading or introduce a new block.
+    p = Project(id=1, name="Normal Project\n# Injected Heading", path="~/proj",
+                first_seen=1000, last_seen=3000, session_count=1, total_time=100)
+    cmd = Command(id=1, timestamp=1000, command="git status", exit_code=0,
+                  session_id=1, project_id=1)
+    s = Session(id=1, start_time=1000, end_time=3000, duration_seconds=2000,
+                project_id=1, commands=[cmd])
+    db.save_data([p], [s], [cmd])
+    export_markdown(fetch_export_data(db), db, output_file=str(out_file))
+    content = out_file.read_text(encoding="utf-8")
+
+    # The newline is collapsed onto a single heading line and the injected '#'
+    # is escaped, so it stays part of the "## Session #1" heading.
+    assert "Normal Project \\# Injected Heading" in content
+    assert "## Session #1 — Normal Project \\# Injected Heading" in content
+    # The injected text cannot create a standalone heading/block.
+    assert all(not ln.startswith("# Injected Heading") for ln in content.splitlines())
+
+
+def test_export_markdown_ai_summary_heading_like_escaped(tmp_path):
+    out_file = tmp_path / "summary_heading.md"
+    db = _build_single_session_db(
+        tmp_path / "summary_heading_md.db",
+        [Command(id=1, timestamp=1000, command="git status", exit_code=0,
+                 session_id=1, project_id=1)],
+    )
+    # A heading-like AI summary must not introduce headings into the document.
+    db.save_session_ai_summary(
+        1,
+        "Normal summary\n# Injected Heading\n## Another Heading",
+    )
+    export_markdown(fetch_export_data(db), db, output_file=str(out_file))
+    content = out_file.read_text(encoding="utf-8")
+
+    assert "### AI Summary" in content
+    # The summary stays escaped prose on a single line: readable text is
+    # preserved but the '#' markers are neutralized.
+    assert "Normal summary \\# Injected Heading \\#\\# Another Heading" in content
+    # No line starts with an injected heading.
+    assert all(not ln.startswith("# Injected Heading") for ln in content.splitlines())
+    assert all(not ln.startswith("## Another Heading") for ln in content.splitlines())
+
+
 def test_cli_export_markdown(tmp_path, monkeypatch):
     db_file = tmp_path / "test_cli_md_export.db"
     monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))


### PR DESCRIPTION
Closes #426 
## Summary

Adds Markdown output support to `termstory export` via `--format markdown`.

### Changes

- Added `markdown` / `md` export format support.
- Reused the existing `serialize_sessions_to_dict()` pipeline to preserve sanitization and secret redaction behavior.
- Added safe Markdown table-cell escaping for `|`, `\`, and newlines.
- Added dynamic fenced code blocks so commands containing backticks are rendered safely.
- Added session metadata, AI summaries, commands, and commits to the Markdown output.
- Added stdout and `-o/--output` file support.
- Added CLI documentation and usage examples.
- Added comprehensive exporter and CLI regression tests.

## Testing

- `tests/test_exporter.py` — **27 passed**
- Additional fast unit tests — **95 passed**
- Manual `termstory export --format markdown` check — **passed**
- `git diff --check` — **clean**

The full test suite has unrelated pre-existing environment/collection issues involving missing `textual`, Windows-specific `os.geteuid`, file-lock permissions, and slow/network-bound stress tests.

## Example

```bash
termstory export --format markdown