### PR TITLE
fix(notebook): preserve zero-duration sessions

### DIFF
--- a/termstory/notebook.py
+++ b/termstory/notebook.py
@@ -127,7 +127,12 @@ def generate_notebook(
 
                 # Commands
                 commands = s.commands
-                if not all_commands:
+                # Zero-duration sessions (start_time == end_time) consist of a single
+                # command that *defined* the session. Surface that command even when
+                # noise filtering is active, otherwise the session renders as an empty
+                # shell with no commands (see issue #433). Non-zero-duration sessions
+                # keep their existing noise filtering unchanged.
+                if not all_commands and s.start_time != s.end_time:
                     commands = [cmd for cmd in s.commands if not _is_noise_command(cmd.command)]
 
                 if commands:

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -183,3 +183,56 @@ def test_generate_notebook_redacts_commit_message(temp_db):
     )
     markdown = generate_notebook([s], temp_db)
     assert "hunter2" not in markdown
+
+
+def test_generate_notebook_zero_duration_noise_command_rendered(temp_db):
+    """Issue #433: a zero-duration session (start_time == end_time) must still
+    render its sole command, even when it would otherwise be classified as noise.
+
+    Without the fix the session renders as an empty shell under the default
+    (all_commands=False) rendering because the only command (``echo hello``) is
+    filtered as low-value noise.
+    """
+    t = int(datetime(2026, 6, 5, 9, 0, 0).timestamp())
+    cmd = Command(id=600, timestamp=t, command="echo hello",
+                  exit_code=0, session_id=50, project_id=1)
+    s = Session(id=50, start_time=t, end_time=t, duration_seconds=0,
+                project_id=1, commands=[cmd])
+
+    markdown = generate_notebook([s], temp_db, all_commands=False)
+
+    assert "# 2026-06-05" in markdown
+    assert "* **9:00 AM (1s)**" in markdown
+    assert "echo hello" in markdown
+
+
+def test_generate_notebook_zero_duration_non_noise_command_rendered(temp_db):
+    """Issue #433: a zero-duration session with a clearly non-noise command
+    (``git commit``) must appear in the notebook under default rendering.
+    """
+    t = int(datetime(2026, 6, 5, 9, 30, 0).timestamp())
+    cmd = Command(id=601, timestamp=t, command="git commit -m 'fast fix'",
+                  exit_code=0, session_id=51, project_id=1)
+    s = Session(id=51, start_time=t, end_time=t, duration_seconds=0,
+                project_id=1, commands=[cmd])
+
+    markdown = generate_notebook([s], temp_db, all_commands=False)
+
+    assert "# 2026-06-05" in markdown
+    assert "git commit -m 'fast fix'" in markdown
+
+
+def test_generate_notebook_non_zero_noise_still_filtered(temp_db):
+    """Issue #433 regression guard: noise filtering must remain unchanged for
+    non-zero-duration sessions.
+    """
+    t = int(datetime(2026, 6, 5, 10, 0, 0).timestamp())
+    cmd = Command(id=602, timestamp=t, command="echo hello",
+                  exit_code=0, session_id=52, project_id=1)
+    s = Session(id=52, start_time=t, end_time=t + 60, duration_seconds=60,
+                project_id=1, commands=[cmd])
+
+    markdown = generate_notebook([s], temp_db, all_commands=False)
+
+    assert "# 2026-06-05" in markdown
+    assert "echo hello" not in markdown


### PR DESCRIPTION
Closes #433
## Summary

Fixes #433 by ensuring zero-duration sessions (`start_time == end_time`) are not rendered as empty sessions in generated notebooks.

## Root Cause

The issue was traced through the complete data flow:

1. `termstory/exporter.py` → `fetch_export_data()`
   - Does not filter sessions based on duration.
   - Zero-duration sessions are retrieved normally.

2. `termstory/database.py` → `get_range_sessions()`
   - Queries sessions using the start-time range.
   - No `duration_seconds` filter is applied.
   - Zero-duration sessions therefore reach the notebook generator.

3. `termstory/notebook.py` → `generate_notebook()`
   - Already handles zero-duration sessions when rendering the time range by displaying `(1s)`.
   - However, the command list was subsequently passed through noise filtering whenever `all_commands=False`.

4. `termstory/formatter.py` → `_is_noise_command()`
   - The issue reproduction command `echo hello` is classified as a noise command.
   - Therefore, the only command in a zero-duration session was filtered out.
   - The session could still render its time header, but appeared as an empty session with no commands.

The problem was therefore caused by command filtering in `generate_notebook()`, not by the database query or export data retrieval.

## Fix

Updated the command filtering logic in `termstory/notebook.py` so that noise filtering continues to apply to normal sessions but is skipped for zero-duration sessions:

```python
if not all_commands and s.start_time != s.end_time:
    commands = [cmd for cmd in s.commands if not _is_noise_command(cmd.command)]
```

This preserves the command associated with a zero-duration session while leaving the existing behavior for non-zero-duration sessions unchanged.

## Behavior

### Zero-Duration Sessions

A session where:

```text
start_time == end_time
```

and which contains commands will now appear in the generated notebook, even when `all_commands=False`.

For example:

```text
echo hello
```

will remain visible instead of being removed by noise filtering.

The existing zero-duration display format is also preserved:

```text
3:00 PM (1s)
```

### Non-Zero-Duration Sessions

Existing noise filtering remains unchanged.

For example, a normal session containing:

```text
echo hello
```

continues to have that command filtered when `all_commands=False`.

This prevents the fix from unintentionally changing notebook behavior for regular sessions.

## Tests Added

Added three regression tests to `tests/test_notebook.py`:

### `test_generate_notebook_zero_duration_noise_command_rendered`

Covers the exact issue reproduction using `echo hello` and verifies that the command appears for a zero-duration session.

### `test_generate_notebook_zero_duration_non_noise_command_rendered`

Verifies that a zero-duration session containing a non-noise command is rendered correctly.

### `test_generate_notebook_non_zero_noise_still_filtered`

Verifies that existing noise filtering remains unchanged for non-zero-duration sessions.

## Validation

### Notebook Tests

```text
11/11 tests passed
```

### Predictor Tests

```text
29/30 tests passed
```

The single predictor failure is unrelated to this change and is caused by the local environment's missing `tzdata` dependency and its fallback timezone handling.

No predictor code was modified.

## Files Changed

```text
termstory/notebook.py
tests/test_notebook.py
```

## Compatibility

- Existing non-zero-duration notebook behavior is preserved.
- Existing noise filtering remains unchanged for normal sessions.
- Zero-duration sessions with valid commands are now correctly represented.
- No changes were made to session creation.
- No changes were made to database queries.
- No changes were made to export data retrieval.
- No database schema or migration changes were required.
- No documentation changes were required.

## Verification

The fix was tested against both zero-duration and non-zero-duration sessions to ensure the change is narrowly scoped to the reported bug.

