### PR TITLE
feat(security): add configurable command blacklist patterns

### DIFF
--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -39,3 +39,25 @@ No raw session data reaches `_send_llm_request()` directly.
 
 This is enforced across all three AI-facing surfaces: `generate_ai_summary()`, `generate_daily_chronicle_prompt()` (both in `ai.py`), and `generate_answer()` (in `ask.py`). See `docs/privacy.md` for the complete redaction rule table.
 
+### Extending the command blacklist
+
+The built-in session blacklist (`vault`, `aws configure`, `gh auth`, raw token strings, etc.) can be extended with your own patterns via `config.json`. These user patterns are **additive** — they never disable or replace the built-in blacklist.
+
+```json
+{
+  "command_blacklist_patterns": [
+    "doppler *",
+    "sops *",
+    "re:^op\\s+.*secret"
+  ]
+}
+```
+
+- **Plain strings** are matched as `fnmatch` **glob** patterns (case-insensitive). `"doppler *"` matches any command whose text contains `doppler` followed by anything.
+- **Strings prefixed with `re:`** are compiled as **regular expressions** (case-insensitive). `"re:^sops\\s+"` matches any command starting with `sops` followed by whitespace.
+- Matching is case-insensitive, consistent with the built-in blacklist.
+- **Invalid patterns** (e.g. a malformed regex like `"re:[invalid"`) are skipped silently — they affect only that pattern; valid user patterns and the built-in blacklist continue to work.
+- **Omitting** `command_blacklist_patterns` (or setting it to `[]`) preserves the existing behavior exactly.
+
+Because the sanitizer is the single source of truth for all AI-facing paths, configured patterns automatically apply everywhere commands are gated — `generate_ai_summary()`, `generate_daily_chronicle_prompt()`, `generate_answer()`, and the `agy` bridge.
+

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -20,6 +20,7 @@ BLACKLIST_PATTERNS = [
 ]
 ```
 
+> **Extending the blacklist:** You can add your own patterns via `config.json` → `command_blacklist_patterns`. These are additive (they never replace the built-in list). Plain strings are `fnmatch` globs; strings prefixed with `re:` are regular expressions. Both are matched case-insensitively. Invalid patterns are skipped. Omitting the setting preserves the existing behavior. See `docs/ai-integration.md`.
 ### Redaction Rules
 
 | Type | Pattern | Replacement |

--- a/termstory/config.py
+++ b/termstory/config.py
@@ -184,6 +184,7 @@ def load_config() -> dict:
         "reminder_poll_interval": 300,
         "clustering_threshold": 0.6,
         "default_branch_names": ["main"],
+        "command_blacklist_patterns": [],
         "project_roots": [
     "~/Projects",
     "~/src",

--- a/termstory/sanitizer.py
+++ b/termstory/sanitizer.py
@@ -2,12 +2,19 @@ import logging
 import re
 import os
 import math
+import json
+import fnmatch
 from typing import List, Tuple, Optional
 
 logger = logging.getLogger(__name__)
 
 _cached_ignore_rules: tuple = tuple()
 _cached_ignore_mtime: float = -1.0
+
+# User-defined command blacklist patterns (from config.json), cached by the
+# config file's mtime so config.json is not re-read/compiled on every command.
+_cached_user_blacklist: tuple = tuple()
+_cached_user_blacklist_mtime: float = -1.0
 
 def load_custom_ignore_rules() -> tuple:
     global _cached_ignore_rules
@@ -56,6 +63,75 @@ def load_custom_ignore_rules() -> tuple:
     _cached_ignore_rules = tuple(local_patterns)
     _cached_ignore_mtime = current_max_mtime
     return _cached_ignore_rules
+
+#: Prefix marking a user blacklist entry as a raw regular expression.
+USER_BLACKLIST_RE_PREFIX = "re:"
+
+
+def _compile_user_blacklist_pattern(entry: str) -> Optional[re.Pattern]:
+    """Compile one user blacklist pattern to a case-insensitive regex.
+
+    Plain strings are treated as ``fnmatch`` glob patterns; strings prefixed
+    with ``re:`` are compiled as regular expressions directly. Returns ``None``
+    (and the pattern is skipped) when an expression is malformed.
+    """
+    try:
+        if entry.startswith(USER_BLACKLIST_RE_PREFIX):
+            return re.compile(entry[len(USER_BLACKLIST_RE_PREFIX):], re.IGNORECASE)
+        return re.compile(fnmatch.translate(entry), re.IGNORECASE)
+    except (re.error, TypeError, ValueError):
+        return None
+
+
+def load_user_blacklist_patterns() -> tuple:
+    """Load user-defined command blacklist patterns from ``config.json``.
+
+    Reads the ``command_blacklist_patterns`` list from the config file and
+    returns a tuple of compiled, case-insensitive regexes. These EXTEND (never
+    replace) the built-in ``BLACKLIST_PATTERNS``. The result is cached by the
+    config file's mtime so the file is not re-read or re-compiled on every
+    command; invalid patterns are skipped without crashing Termstory.
+    """
+    global _cached_user_blacklist
+    global _cached_user_blacklist_mtime
+
+    from termstory.config import get_config_path
+
+    config_path = get_config_path()
+    try:
+        mtime = os.path.getmtime(config_path)
+    except OSError:
+        # Config file missing/unreadable -> no user patterns. Clear a stale cache.
+        if _cached_user_blacklist_mtime != -1.0:
+            _cached_user_blacklist = tuple()
+            _cached_user_blacklist_mtime = -1.0
+        return _cached_user_blacklist
+
+    if _cached_user_blacklist_mtime == mtime:
+        return _cached_user_blacklist
+
+    patterns = []
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            config = json.load(f)
+    except Exception:
+        config = {}
+
+    raw = config.get("command_blacklist_patterns") if isinstance(config, dict) else None
+    if not isinstance(raw, list):
+        raw = []
+
+    for entry in raw:
+        if not isinstance(entry, str) or not entry.strip():
+            continue
+        compiled = _compile_user_blacklist_pattern(entry.strip())
+        if compiled is not None:
+            patterns.append(compiled)
+
+    _cached_user_blacklist = tuple(patterns)
+    _cached_user_blacklist_mtime = mtime
+    return _cached_user_blacklist
+
 # Blacklist patterns - if a command matches any of these, the entire session is dropped from AI
 BLACKLIST_PATTERNS = [
     re.compile(r'\bvault\b', re.IGNORECASE),
@@ -200,8 +276,15 @@ def redact_high_entropy(cmd: str) -> str:
     return re.sub(r'\b[a-zA-Z0-9_+/=-]{16,}\b', replacer, cmd)
 
 def should_blacklist_command(cmd: str) -> bool:
-    """Check if the command is blacklisted from AI processing"""
-    return any(pattern.search(cmd) for pattern in BLACKLIST_PATTERNS)
+    """Check if the command is blacklisted from AI processing.
+
+    A command is blacklisted if it matches the built-in ``BLACKLIST_PATTERNS``
+    OR any user-configured ``command_blacklist_patterns``. User patterns are
+    always additive — they can never weaken the built-in blacklist.
+    """
+    if any(pattern.search(cmd) for pattern in BLACKLIST_PATTERNS):
+        return True
+    return any(pattern.search(cmd) for pattern in load_user_blacklist_patterns())
 
 def redact_command(cmd: str) -> str:
     """Sanitize and redact secrets from a command string"""

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -4,6 +4,8 @@ from termstory.sanitizer import (
     sanitize_session_commands
 )
 
+import json
+
 def test_blacklist_commands():
     assert should_blacklist_command("vault read secret/data") is True
     assert should_blacklist_command("aws configure set aws_access_key_id 123") is True
@@ -409,3 +411,171 @@ def test_secondary_tier_documented_false_negatives():
     assert "[REDACTED_ENTROPY]" not in redacted, (
         "MyAppBuild12345xy should not be redacted (entropy ~3.85, below 3.9 threshold)"
     )
+# ── Configurable command blacklist (config.json: command_blacklist_patterns) ──
+
+
+def _set_command_blacklist_config(tmp_path, patterns):
+    """Write a config.json with the given user blacklist and point config at it.
+
+    Resets the sanitizer's user-blacklist cache so each test starts fresh.
+    """
+    import termstory.sanitizer as sanitizer
+
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({"command_blacklist_patterns": patterns}))
+    sanitizer._cached_user_blacklist = tuple()
+    sanitizer._cached_user_blacklist_mtime = -1.0
+    patcher = patch("termstory.config.get_config_path", return_value=str(config_file))
+    patcher.start()
+    return config_file, patcher
+
+
+def test_config_pattern_blacklist(tmp_path):
+    import termstory.sanitizer as sanitizer
+
+    _, patcher = _set_command_blacklist_config(tmp_path, ["doppler *"])
+    try:
+        assert sanitizer.should_blacklist_command("doppler secrets get API_KEY") is True
+    finally:
+        patcher.stop()
+
+
+def test_user_blacklist_glob_matching(tmp_path):
+    import termstory.sanitizer as sanitizer
+
+    _, patcher = _set_command_blacklist_config(tmp_path, ["doppler *"])
+    try:
+        # Matching glob command
+        assert sanitizer.should_blacklist_command("doppler secrets get API_KEY") is True
+        # Unrelated command must not match
+        assert sanitizer.should_blacklist_command("git status") is False
+    finally:
+        patcher.stop()
+
+
+def test_user_blacklist_regex_matching(tmp_path):
+    import termstory.sanitizer as sanitizer
+
+    _, patcher = _set_command_blacklist_config(tmp_path, ["re:^sops\\s+"])
+    try:
+        assert sanitizer.should_blacklist_command("sops config set key value") is True
+        assert sanitizer.should_blacklist_command("echo sops") is False
+    finally:
+        patcher.stop()
+
+
+def test_user_blacklist_multiple_patterns(tmp_path):
+    import termstory.sanitizer as sanitizer
+
+    _, patcher = _set_command_blacklist_config(
+        tmp_path, ["doppler *", "re:^sops\\s+", "1password *"]
+    )
+    try:
+        assert sanitizer.should_blacklist_command("doppler secrets get X") is True
+        assert sanitizer.should_blacklist_command("sops set key") is True
+        assert sanitizer.should_blacklist_command("1password unlock") is True
+        assert sanitizer.should_blacklist_command("echo hi") is False
+    finally:
+        patcher.stop()
+
+
+def test_user_blacklist_extends_builtin(tmp_path):
+    import termstory.sanitizer as sanitizer
+
+    _, patcher = _set_command_blacklist_config(tmp_path, ["doppler *"])
+    try:
+        # Built-in sensitive command stays blacklisted
+        assert sanitizer.should_blacklist_command("vault read secret/data") is True
+        assert sanitizer.should_blacklist_command("aws configure set key val") is True
+        # Configured custom command is also blacklisted
+        assert sanitizer.should_blacklist_command("doppler secrets get X") is True
+    finally:
+        patcher.stop()
+
+
+def test_user_blacklist_missing_config(tmp_path):
+    import termstory.sanitizer as sanitizer
+
+    config_file = tmp_path / "config.json"
+    patcher = patch("termstory.config.get_config_path", return_value=str(config_file))
+    sanitizer._cached_user_blacklist = tuple()
+    sanitizer._cached_user_blacklist_mtime = -1.0
+    patcher.start()
+    try:
+        # No config file -> no exception, built-in behavior intact
+        assert sanitizer.should_blacklist_command("vault read secret") is True
+        assert sanitizer.should_blacklist_command("doppler secrets get X") is False
+    finally:
+        patcher.stop()
+def test_user_blacklist_empty_config(tmp_path):
+    import termstory.sanitizer as sanitizer
+
+    _, patcher = _set_command_blacklist_config(tmp_path, [])
+    try:
+        assert sanitizer.should_blacklist_command("vault read secret") is True
+        assert sanitizer.should_blacklist_command("doppler secrets get X") is False
+        assert sanitizer.should_blacklist_command("git status") is False
+    finally:
+        patcher.stop()
+
+
+def test_user_blacklist_invalid_regex_skipped(tmp_path):
+    import termstory.sanitizer as sanitizer
+
+    _, patcher = _set_command_blacklist_config(tmp_path, ["re:[invalid", "doppler *"])
+    try:
+        # No exception raised; valid patterns and built-ins still work.
+        assert sanitizer.should_blacklist_command("doppler secrets get X") is True
+        assert sanitizer.should_blacklist_command("vault read secret") is True
+        assert sanitizer.should_blacklist_command("git status") is False
+    finally:
+        patcher.stop()
+
+
+def test_user_blacklist_sanitize_session_commands(tmp_path):
+    import termstory.sanitizer as sanitizer
+
+    _, patcher = _set_command_blacklist_config(tmp_path, ["doppler *"])
+    try:
+        sanitized, is_blacklisted = sanitizer.sanitize_session_commands(
+            ["cd project", "doppler secrets get API_KEY"]
+        )
+        assert is_blacklisted is True
+        assert sanitized is None
+
+        sanitized, is_blacklisted = sanitizer.sanitize_session_commands(
+            ["cd project", "git status"]
+        )
+        assert is_blacklisted is False
+        assert sanitized == ["cd project", "git status"]
+    finally:
+        patcher.stop()
+
+
+def test_user_blacklist_case_insensitive(tmp_path):
+    import termstory.sanitizer as sanitizer
+
+    _, patcher = _set_command_blacklist_config(tmp_path, ["doppler *"])
+    try:
+        assert sanitizer.should_blacklist_command("DOPPLER secrets get X") is True
+        assert sanitizer.should_blacklist_command("Doppler secrets get X") is True
+    finally:
+        patcher.stop()
+
+
+def test_user_blacklist_persistence_via_config_system(tmp_path):
+    """The list can be stored/read through the existing config system."""
+    from termstory.config import load_config, save_config, get_config_value
+
+    config_file = tmp_path / "config.json"
+    with patch("termstory.config.get_config_path", return_value=str(config_file)):
+        config = load_config()
+        # Default when absent is an empty list.
+        assert config.get("command_blacklist_patterns") == []
+
+        config["command_blacklist_patterns"] = ["sops *"]
+        save_config(config)
+
+        loaded = load_config()
+        assert loaded["command_blacklist_patterns"] == ["sops *"]
+        assert get_config_value(loaded, "command_blacklist_patterns") == ["sops *"]


### PR DESCRIPTION
Closes #432

## Summary

Adds configurable command blacklist patterns through `config.json`, allowing users to extend Termstory's built-in security blacklist without modifying source code.

## Changes

- Added `command_blacklist_patterns` to the default configuration.
- Added support for user-defined glob patterns.
- Added support for regular expressions using the `re:` prefix.
- User-defined patterns are additive and never replace the built-in `BLACKLIST_PATTERNS`.
- Matching is case-insensitive to remain consistent with the existing blacklist behavior.
- Invalid user-supplied regular expressions are ignored safely instead of crashing the application.
- Added mtime-based caching so configuration is not repeatedly read and patterns are not recompiled for every command.
- Preserved the existing `sanitize_session_commands()` return contract and sanitization flow.
- Updated AI/security documentation with configuration examples and matching behavior.

## Configuration Example

```json
{
  "command_blacklist_patterns": [
    "doppler *",
    "sops *",
    "re:^op\\s+.*secret"
  ]
}
```

Plain patterns use glob matching, while patterns prefixed with `re:` are interpreted as regular expressions.

## Security

The configurable patterns extend the existing built-in blacklist rather than replacing it.

Existing security-sensitive commands therefore remain protected even when custom patterns are configured.

Invalid custom patterns are skipped safely and do not disable or weaken the built-in blacklist.

The existing sanitization flow remains unchanged:

```text
should_blacklist_command()
        ↓
sanitize_session_commands()
        ↓
LLM-facing consumers
```

This keeps the sanitizer as the single source of truth for command blacklist decisions.

## Tests

Added regression coverage for:

- Config-defined blacklist patterns
- Glob matching
- Regex matching
- Multiple custom patterns
- Built-in + custom blacklist behavior
- Missing configuration
- Empty configuration
- Invalid regex handling
- `sanitize_session_commands()` integration
- Case-insensitive matching
- Configuration persistence through the existing config system

## Validation

- `python -m pytest tests/test_sanitizer.py -v --tb=short` — **37 passed**
- `python -m pytest tests/test_exporter.py -q` — **16 passed**
- Relevant AI sanitization tests — **10 passed**
- `git diff --check` — **clean**

The full config/CLI test collection has a pre-existing Windows compatibility issue because those tests reference `os.geteuid`, which is unavailable on Windows. This issue is unrelated to the changes in this PR.

## Files Changed

- `termstory/sanitizer.py`
- `termstory/config.py`
- `tests/test_sanitizer.py`
- `docs/ai-integration.md`
- `docs/privacy.md`

## Compatibility

When `command_blacklist_patterns` is missing or empty, existing blacklist behavior remains unchanged.

Built-in blacklist patterns remain active at all times.

No database changes, migrations, external dependencies, or changes to the existing sanitization contract were introduced.