### PR TITLE
feat(export): add since and until date filters

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -192,7 +192,16 @@ termstory export --format markdown                       # Export as Markdown to
 termstory export --format markdown -o sessions.md         # Export as Markdown to a file
 termstory export --project myapp --since 7               # Export last 7 days of "myapp" project
 termstory export --since 2026-06-01                      # Export sessions since specific date
+termstory export --since 2026-06-01 --until 2026-06-30   # Export a specific date range
+termstory export --since 7d                              # Export last 7 days
+termstory export --since 1w --until yesterday            # Export from 1 week ago through yesterday
 ```
+
+The `--since` option defines the lower bound, and `--until` defines the inclusive
+upper bound of the exported range (both applied to each session's start time).
+`--until` is optional and, when given a date only (e.g. `2026-06-10`), includes
+the entire specified day. Relative expressions such as `7d`, `1w`, and
+`yesterday` are also supported.
 
 ### Tags
 

--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -1257,7 +1257,8 @@ def export_cmd(
     format: str = typer.Option("json", "--format", "-f", help="Export format: 'json', 'csv', or 'markdown'"),
     output: Optional[str] = typer.Option(None, "--output", "-o", help="Output file path (prints to stdout if omitted)"),
     project: Optional[str] = typer.Option(None, "--project", "-p", help="Filter by project name or path"),
-    since: Optional[str] = typer.Option(None, "--since", "-s", help="Filter by since duration (e.g. '7' for 7 days, or YYYY-MM-DD)")
+    since: Optional[str] = typer.Option(None, "--since", "-s", help="Filter by since duration (e.g. '7' for 7 days, or YYYY-MM-DD)"),
+    until: Optional[str] = typer.Option(None, "--until", help="Filter by until date (inclusive; e.g. '7d', '1w', 'yesterday', or YYYY-MM-DD)")
 ):
     """Export history sessions and commands as JSON, CSV, or Markdown"""
     db_path = get_db_path()
@@ -1269,7 +1270,7 @@ def export_cmd(
     from termstory.exporter import fetch_export_data, export_json, export_csv, export_markdown
     
     try:
-        sessions = fetch_export_data(db, project_filter=project, since_str=since)
+        sessions = fetch_export_data(db, project_filter=project, since_str=since, until_str=until)
     except ValueError as e:
         Console(stderr=True).print(f"[bold red]Error:[/] {e}")
         raise typer.Exit(code=1)

--- a/termstory/exporter.py
+++ b/termstory/exporter.py
@@ -1,6 +1,7 @@
 import csv
 import json
 import os
+import re
 import sys
 from datetime import datetime, timedelta, timezone
 from termstory import date_utils
@@ -43,40 +44,135 @@ def _safe_fromtimestamp(ts: float) -> datetime:
         local_dt = utc_dt.astimezone(timezone(local_offset))
     return local_dt.replace(tzinfo=None)
 
+def _parse_relative_offset(expr: str) -> Optional[timedelta]:
+    """Parse a relative day/week expression like ``7d`` or ``1w`` into a timedelta.
+
+    Returns ``None`` when the expression is not a relative day/week offset, so
+    callers can fall back to other formats.
+    """
+    m = re.match(r"^(\d+)\s*(d|w)$", expr.strip().lower())
+    if not m:
+        return None
+    num = int(m.group(1))
+    unit = m.group(2)
+    # A week is always 7 days for this purpose (matches timedelta(weeks=...)).
+    return timedelta(days=num) if unit == "d" else timedelta(weeks=num)
+
+
 def parse_since(since_str: Optional[str]) -> Optional[int]:
-    """Parse a since string (either number of days or a date string) into a Unix timestamp."""
+    """Parse a since string into a Unix timestamp (inclusive lower bound).
+
+    Supported formats, resolved via :func:`termstory.date_utils.get_current_time`
+    so ``TERMSTORY_DATE_OVERRIDE`` is respected for relative expressions:
+
+    * ``3`` (number of days) / ``7d`` / ``1w`` / ``yesterday`` — start of that day
+    * any ISO 8601 date parsed by dateutil (e.g. ``2026-06-01``)
+    """
     if not since_str:
         return None
-    
+
     since_str = since_str.strip()
-    if since_str.isdigit():
-        days = int(since_str)
-        now = date_utils.get_current_time()
-        dt = now - timedelta(days=days)
-        # Start of that day
+    now = date_utils.get_current_time()
+
+    # Relative day/week expression, e.g. "7d" or "1w"
+    delta = _parse_relative_offset(since_str)
+    if delta is not None:
+        dt = now - delta
         start_of_day = datetime.combine(dt.date(), datetime.min.time())
         return _get_timestamp(start_of_day)
-    
+
+    if since_str.lower() == "yesterday":
+        dt = now - timedelta(days=1)
+        start_of_day = datetime.combine(dt.date(), datetime.min.time())
+        return _get_timestamp(start_of_day)
+
+    # Numeric day count (existing legacy behavior): start of that day
+    if since_str.isdigit():
+        days = int(since_str)
+        dt = now - timedelta(days=days)
+        start_of_day = datetime.combine(dt.date(), datetime.min.time())
+        return _get_timestamp(start_of_day)
+
     try:
         dt = date_parser.parse(since_str)
         return _get_timestamp(dt)
     except Exception as e:
         raise ValueError(f"Invalid date or day count format '{since_str}': {e}")
 
+
+def parse_until(until_str: Optional[str]) -> Optional[int]:
+    """Parse an until string into an inclusive upper-bound Unix timestamp.
+
+    Supported formats, resolved via :func:`termstory.date_utils.get_current_time`
+    so ``TERMSTORY_DATE_OVERRIDE`` is respected for relative expressions:
+
+    * ``7d`` / ``1w`` / ``yesterday`` — end of that day
+    * any ISO 8601 date parsed by dateutil (e.g. ``2026-06-01``)
+
+    A date-only value always resolves to the *end* of that day (23:59:59) so that
+    the entire specified day is included in the range.
+    """
+    if not until_str:
+        return None
+
+    until_str = until_str.strip()
+    now = date_utils.get_current_time()
+
+    # Relative day/week expression, e.g. "7d" or "1w"
+    delta = _parse_relative_offset(until_str)
+    if delta is not None:
+        dt = now - delta
+        end_of_day = datetime.combine(dt.date(), datetime.max.time())
+        return _get_timestamp(end_of_day)
+
+    if until_str.lower() == "yesterday":
+        dt = now - timedelta(days=1)
+        end_of_day = datetime.combine(dt.date(), datetime.max.time())
+        return _get_timestamp(end_of_day)
+
+    try:
+        dt = date_parser.parse(until_str)
+        # Inclusive: a date-only --until covers the entire specified day.
+        end_of_day = datetime.combine(dt.date(), datetime.max.time())
+        return _get_timestamp(end_of_day)
+    except Exception as e:
+        raise ValueError(f"Invalid date or day count format '{until_str}': {e}")
+
+
 def fetch_export_data(
     db: Database,
     project_filter: Optional[str] = None,
-    since_str: Optional[str] = None
+    since_str: Optional[str] = None,
+    until_str: Optional[str] = None
 ) -> List[Session]:
-    """Fetch and filter sessions with their commands and commits from the database."""
+    """Fetch and filter sessions with their commands and commits from the database.
+
+    Both date bounds are inclusive over ``session.start_time``:
+
+        since_ts <= session.start_time <= until_ts
+
+    ``since_str`` / ``until_str`` are optional; when omitted the corresponding
+    bound is left open (all history, or far into the future for ``until_str``).
+    """
     start_ts = 0
     if since_str:
         since_ts = parse_since(since_str)
         if since_ts is not None:
             start_ts = since_ts
-            
+
+    end_ts = _FAR_FUTURE_TS
+    if until_str:
+        until_ts = parse_until(until_str)
+        if until_ts is not None:
+            end_ts = until_ts
+
+    if start_ts > end_ts:
+        raise ValueError(
+            "Invalid date range: --since must not be after --until."
+        )
+
     # Fetch all sessions in the range (up to far in the future)
-    sessions = db.get_range_sessions(start_ts, _FAR_FUTURE_TS)
+    sessions = db.get_range_sessions(start_ts, end_ts)
     
     # Get project info to map names/paths
     project_ids = list(set(s.project_id for s in sessions if s.project_id is not None))

--- a/termstory/exporter.py
+++ b/termstory/exporter.py
@@ -130,9 +130,16 @@ def parse_until(until_str: Optional[str]) -> Optional[int]:
         end_of_day = datetime.combine(dt.date(), datetime.max.time())
         return _get_timestamp(end_of_day)
 
+    # Parse the ISO 8601 date string. Detect whether the user supplied an
+    # explicit time component: dateutil normalizes "2026-06-10" and
+    # "2026-06-10T00:00:00" both to midnight, so we inspect the raw string.
+    _has_time = bool(re.search(r"[T\s]\d{1,2}:\d{2}", until_str))
     try:
         dt = date_parser.parse(until_str)
-        # Inclusive: a date-only --until covers the entire specified day.
+        if _has_time:
+            # Explicit time was given — preserve it exactly.
+            return _get_timestamp(dt)
+        # Date-only: snap to end-of-day so the entire day is included.
         end_of_day = datetime.combine(dt.date(), datetime.max.time())
         return _get_timestamp(end_of_day)
     except Exception as e:

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -864,3 +864,14 @@ def test_fetch_export_data_reversed_range(tmp_path):
     with pytest.raises(ValueError):
         fetch_export_data(db, since_str="2026-06-30", until_str="2026-06-01")
 
+
+def test_parse_until_preserves_explicit_time():
+    # Regression: a timestamped --until (e.g. "2026-06-10T12:00:00") must
+    # preserve the explicit time instead of snapping to 23:59:59. Only
+    # date-only inputs get end-of-day normalization.
+    assert parse_until("2026-06-10") == int(datetime(2026, 6, 10, 23, 59, 59).timestamp())
+    assert parse_until("2026-06-10T12:00:00") == int(datetime(2026, 6, 10, 12, 0, 0).timestamp())
+    assert parse_until("2026-06-10 14:30:00") == int(datetime(2026, 6, 10, 14, 30, 0).timestamp())
+    # Explicit midnight must NOT be expanded to end-of-day — the user asked for 00:00:00.
+    assert parse_until("2026-06-10T00:00:00") == int(datetime(2026, 6, 10, 0, 0, 0).timestamp())
+

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -9,7 +9,7 @@ import pytest
 from termstory.cli import app
 from termstory.database import Database
 from termstory.models import Project, Session, Command
-from termstory.exporter import parse_since, fetch_export_data, serialize_sessions_to_dict, export_json, export_csv, export_markdown
+from termstory.exporter import parse_since, parse_until, fetch_export_data, serialize_sessions_to_dict, export_json, export_csv, export_markdown
 
 @pytest.fixture
 def temp_db(tmp_path):
@@ -618,4 +618,248 @@ def test_cli_export_markdown(tmp_path, monkeypatch):
 
     result_invalid = runner.invoke(app, ["export", "--format", "xml"])
     assert result_invalid.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #434: --since / --until date filters for `termstory export`
+# ---------------------------------------------------------------------------
+
+def _build_session_db(db_path, sessions_and_projects):
+    """Create a DB with the given (start_ts, project_name_or_None) sessions.
+
+    Returns a fresh :class:`Database` populated with one project per unique name
+    and one (command-less) session per entry.
+    """
+    db = Database(str(db_path))
+    db.init_db()
+    projects = {}
+    session_rows = []
+    commands = []
+    for start_ts, proj_name in sessions_and_projects:
+        pid = None
+        if proj_name is not None:
+            if proj_name not in projects:
+                proj_id = len(projects) + 1
+                projects[proj_name] = Project(
+                    id=proj_id, name=proj_name, path=f"~/src/{proj_name.lower()}",
+                    first_seen=start_ts, last_seen=start_ts, session_count=1, total_time=0,
+                )
+                pid = proj_id
+            else:
+                pid = projects[proj_name].id
+        session_rows.append(
+            Session(id=len(session_rows) + 1, start_time=int(start_ts), end_time=int(start_ts),
+                    duration_seconds=0, project_id=pid, commands=[])
+        )
+    db.save_data(list(projects.values()), session_rows, commands)
+    return db
+
+
+def test_parse_since_relative_expressions(monkeypatch):
+    monkeypatch.setenv("TERMSTORY_DATE_OVERRIDE", "2026-06-10 12:00:00")
+    # 7d -> start of the day 7 days before Jun 10 (Jun 3)
+    assert parse_since("7d") == int(datetime(2026, 6, 3, 0, 0).timestamp())
+    # 1w -> start of the day 1 week before Jun 10 (Jun 3)
+    assert parse_since("1w") == int(datetime(2026, 6, 3, 0, 0).timestamp())
+    # yesterday -> start of Jun 9
+    assert parse_since("yesterday") == int(datetime(2026, 6, 9, 0, 0).timestamp())
+
+
+def test_parse_until_relative_expressions(monkeypatch):
+    monkeypatch.setenv("TERMSTORY_DATE_OVERRIDE", "2026-06-10 12:00:00")
+    # 7d -> end of the day 7 days before Jun 10 (Jun 3)
+    assert parse_until("7d") == int(datetime(2026, 6, 3, 23, 59, 59).timestamp())
+    # 1w -> end of the day 1 week before Jun 10 (Jun 3)
+    assert parse_until("1w") == int(datetime(2026, 6, 3, 23, 59, 59).timestamp())
+    # yesterday -> end of Jun 9
+    assert parse_until("yesterday") == int(datetime(2026, 6, 9, 23, 59, 59).timestamp())
+
+
+def test_parse_until_iso_includes_whole_day():
+    # A date-only --until includes the entire specified day.
+    assert parse_until("2026-06-10") == int(datetime(2026, 6, 10, 23, 59, 59).timestamp())
+
+
+def test_parse_until_invalid():
+    with pytest.raises(ValueError):
+        parse_until("not-a-real-date")
+    with pytest.raises(ValueError):
+        parse_until("zzz")
+
+
+
+def test_fetch_export_data_until_boundary(tmp_path):
+    db = _build_session_db(tmp_path / "until.db", [
+        (datetime(2026, 5, 31, 12, 0).timestamp(), None),   # before since  -> excluded
+        (datetime(2026, 6, 1, 0, 0).timestamp(), None),    # exact since    -> included
+        (datetime(2026, 6, 5, 12, 0).timestamp(), None),    # inside range   -> included
+        (datetime(2026, 6, 10, 23, 59).timestamp(), None),  # exact until    -> included
+        (datetime(2026, 6, 11, 0, 0).timestamp(), None),   # after until    -> excluded
+    ])
+    sessions = fetch_export_data(db, since_str="2026-06-01", until_str="2026-06-10")
+    start_ids = sorted(s.start_time for s in sessions)
+    assert start_ids == [
+        int(datetime(2026, 6, 1, 0, 0).timestamp()),
+        int(datetime(2026, 6, 5, 12, 0).timestamp()),
+        int(datetime(2026, 6, 10, 23, 59).timestamp()),
+    ]
+
+
+def test_fetch_export_data_since_only(tmp_path):
+    db = _build_session_db(tmp_path / "since_only.db", [
+        (datetime(2026, 5, 31, 12, 0).timestamp(), None),
+        (datetime(2026, 6, 3, 9, 0).timestamp(), None),
+        (datetime(2026, 6, 10, 23, 59).timestamp(), None),
+    ])
+    # Without --until the upper bound remains open (far future).
+    sessions = fetch_export_data(db, since_str="2026-06-01")
+    assert len(sessions) == 2
+
+
+def test_fetch_export_data_until_only(tmp_path):
+    db = _build_session_db(tmp_path / "until_only.db", [
+        (datetime(2026, 5, 30, 12, 0).timestamp(), None),
+        (datetime(2026, 6, 10, 23, 59).timestamp(), None),
+        (datetime(2026, 6, 12, 0, 0).timestamp(), None),
+    ])
+    # Without --since the lower bound remains open (0).
+    sessions = fetch_export_data(db, until_str="2026-06-10")
+    assert len(sessions) == 2
+
+
+def test_fetch_export_data_until_full_day(tmp_path):
+    # --until 2026-06-10 must include the entire day at multiple times.
+    db = _build_session_db(tmp_path / "full_day.db", [
+        (datetime(2026, 6, 10, 0, 0).timestamp(), None),
+        (datetime(2026, 6, 10, 12, 0).timestamp(), None),
+        (datetime(2026, 6, 10, 23, 59).timestamp(), None),
+        (datetime(2026, 6, 11, 0, 0).timestamp(), None),  # next day -> excluded
+    ])
+    sessions = fetch_export_data(db, until_str="2026-06-10")
+    assert len(sessions) == 3
+    assert all(s.start_time <= int(datetime(2026, 6, 10, 23, 59, 59).timestamp())
+               for s in sessions)
+
+
+def test_fetch_export_data_relative_range(tmp_path, monkeypatch):
+    monkeypatch.setenv("TERMSTORY_DATE_OVERRIDE", "2026-06-10 12:00:00")
+    # 1w (Jun 3 00:00) .. yesterday (Jun 9 23:59:59)
+    db = _build_session_db(tmp_path / "rel_range.db", [
+        (datetime(2026, 6, 2, 23, 59).timestamp(), None),  # before -> excluded
+        (datetime(2026, 6, 3, 0, 0).timestamp(), None),    # exact since -> included
+        (datetime(2026, 6, 9, 23, 59).timestamp(), None),  # exact until -> included
+        (datetime(2026, 6, 10, 0, 0).timestamp(), None),   # after -> excluded
+    ])
+    sessions = fetch_export_data(db, since_str="1w", until_str="yesterday")
+    assert len(sessions) == 2
+
+
+def test_fetch_export_data_project_and_date(tmp_path):
+    db = _build_session_db(tmp_path / "proj_date.db", [
+        (datetime(2026, 6, 2, 12, 0).timestamp(), "Alpha"),
+        (datetime(2026, 6, 8, 12, 0).timestamp(), "Alpha"),
+        (datetime(2026, 6, 8, 14, 0).timestamp(), "Beta"),  # different time, same day
+        (datetime(2026, 6, 20, 12, 0).timestamp(), "Alpha"),
+    ])
+    sessions = fetch_export_data(
+        db, project_filter="alpha", since_str="2026-06-01", until_str="2026-06-10"
+    )
+    # Only Alpha sessions within Jun 1..Jun 10: the two on Jun 2 and Jun 8.
+    assert len(sessions) == 2
+
+
+def test_fetch_export_data_backward_compatible_since_only(tmp_path):
+    # Existing callers calling fetch_export_data(since_str=...) with no until_str
+    # must continue working unchanged.
+    db = _build_session_db(tmp_path / "bc.db", [
+        (datetime(2026, 5, 30, 12, 0).timestamp(), None),
+        (datetime(2026, 6, 5, 12, 0).timestamp(), None),
+    ])
+    sessions = fetch_export_data(db, since_str="2026-06-01")
+    assert len(sessions) == 1
+    assert sessions[0].start_time == int(datetime(2026, 6, 5, 12, 0).timestamp())
+
+
+
+def test_parse_since_relative_uses_get_current_time(monkeypatch):
+    # Relative expressions must honour TERMSTORY_DATE_OVERRIDE via get_current_time().
+    monkeypatch.setenv("TERMSTORY_DATE_OVERRIDE", "2026-06-10 12:00:00")
+    assert parse_since("7d") == int(datetime(2026, 6, 3, 0, 0).timestamp())
+
+
+def test_cli_export_with_until(tmp_path, monkeypatch):
+    db_file = tmp_path / "cli_until.db"
+    monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.cli.get_history_files", lambda: [])
+    monkeypatch.setattr("termstory.cli.run_ingestion", lambda db: None)
+
+    db = Database(str(db_file))
+    db.init_db()
+    p = Project(id=1, name="CLI Project", path="~/projects/cli",
+                first_seen=2000, last_seen=2000, session_count=1, total_time=100)
+    cmd = Command(id=60, timestamp=2000, command="echo hi", exit_code=0,
+                  session_id=1, project_id=1)
+    s = Session(id=1, start_time=2000, end_time=2000, duration_seconds=100,
+                project_id=1, commands=[cmd])
+    db.save_data([p], [s], [cmd])
+
+    runner = CliRunner()
+
+    # Both values reach the export layer: an early --until excludes the session
+    # (timestamp ~1970-01-01).
+    result = runner.invoke(app, ["export", "--format", "json",
+                                "--since", "2026-01-01", "--until", "2026-01-31"])
+    combined = (result.stderr or "") + (result.stdout or "")
+    assert "No sessions found matching filters" in combined
+
+    # A wide range that brackets the session includes it.
+    result_all = runner.invoke(app, ["export", "--format", "json",
+                                     "--since", "1969-01-01", "--until", "1971-01-01"])
+    assert result_all.exit_code == 0
+    data = json.loads(result_all.stdout)
+    assert len(data) == 1
+
+
+def test_cli_export_reversed_range_error(tmp_path, monkeypatch):
+    db_file = tmp_path / "cli_reversed.db"
+    monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.cli.get_history_files", lambda: [])
+    monkeypatch.setattr("termstory.cli.run_ingestion", lambda db: None)
+
+    db = Database(str(db_file))
+    db.init_db()
+    runner = CliRunner()
+    result = runner.invoke(app, ["export", "--format", "json",
+                                 "--since", "2026-06-30", "--until", "2026-06-01"])
+    assert result.exit_code == 1
+    combined = (result.stderr or "") + (result.stdout or "")
+    assert "Invalid date range" in combined
+
+
+def test_cli_export_invalid_until_error(tmp_path, monkeypatch):
+    db_file = tmp_path / "cli_invalid_until.db"
+    monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.cli.get_history_files", lambda: [])
+    monkeypatch.setattr("termstory.cli.run_ingestion", lambda db: None)
+
+    db = Database(str(db_file))
+    db.init_db()
+    runner = CliRunner()
+    result = runner.invoke(app, ["export", "--format", "json", "--until", "invalid"])
+    assert result.exit_code == 1
+    combined = (result.stderr or "") + (result.stdout or "")
+    assert "Error" in combined
+
+
+
+
+def test_fetch_export_data_reversed_range(tmp_path):
+    db = _build_session_db(tmp_path / "reversed.db", [
+        (datetime(2026, 6, 5, 12, 0).timestamp(), None),
+    ])
+    with pytest.raises(ValueError):
+        fetch_export_data(db, since_str="2026-06-30", until_str="2026-06-01")
 

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -810,8 +810,9 @@ def test_cli_export_with_until(tmp_path, monkeypatch):
     # (timestamp ~1970-01-01).
     result = runner.invoke(app, ["export", "--format", "json",
                                 "--since", "2026-01-01", "--until", "2026-01-31"])
-    combined = (result.stderr or "") + (result.stdout or "")
-    assert "No sessions found matching filters" in combined
+    # result.output merges stdout/stderr, so it works whether or not the installed
+    # Click separately captures stderr (e.g. older Click on Python 3.9 CI).
+    assert "No sessions found matching filters" in result.output
 
     # A wide range that brackets the session includes it.
     result_all = runner.invoke(app, ["export", "--format", "json",
@@ -834,8 +835,8 @@ def test_cli_export_reversed_range_error(tmp_path, monkeypatch):
     result = runner.invoke(app, ["export", "--format", "json",
                                  "--since", "2026-06-30", "--until", "2026-06-01"])
     assert result.exit_code == 1
-    combined = (result.stderr or "") + (result.stdout or "")
-    assert "Invalid date range" in combined
+    # result.output merges stdout/stderr, so it works across Click versions.
+    assert "Invalid date range" in result.output
 
 
 def test_cli_export_invalid_until_error(tmp_path, monkeypatch):
@@ -850,8 +851,8 @@ def test_cli_export_invalid_until_error(tmp_path, monkeypatch):
     runner = CliRunner()
     result = runner.invoke(app, ["export", "--format", "json", "--until", "invalid"])
     assert result.exit_code == 1
-    combined = (result.stderr or "") + (result.stdout or "")
-    assert "Error" in combined
+    # result.output merges stdout/stderr, so it works across Click versions.
+    assert "Error" in result.output
 
 
 


### PR DESCRIPTION
Closes #434

## Summary

Adds an optional `--until` date filter to `termstory export`, complementing the existing `--since` filter.

## Changes

- Added `--until` support to `termstory export`.
- Extended date parsing to support ISO 8601 dates, `7d`, `1w`, and `yesterday`.
- Preserved the existing numeric `--since` behavior.
- Added `parse_until()` with date-only values resolving to the end of the specified day.
- Added inclusive `[since, until]` session filtering based on `session.start_time`.
- Added reversed-range validation with a clear CLI error.
- Relative date calculations use `get_current_time()`, preserving `TERMSTORY_DATE_OVERRIDE`.
- Preserved backward compatibility for existing `fetch_export_data()` callers.
- Existing JSON, CSV, and Markdown export pipelines remain unchanged.
- Added regression coverage for date parsing, boundaries, relative expressions, CLI handling, project filtering, and backward compatibility.
- Updated CLI documentation with `--until` examples and date-range semantics.

## Date Semantics

Examples:

~~~bash
termstory export --since 2026-06-01 --until 2026-06-10
termstory export --since 7d
termstory export --since 1w --until yesterday
~~~

Date-only `--since` values resolve to the beginning of the specified day.

Date-only `--until` values resolve to the end of the specified day, so the complete specified day is included.

Relative expressions such as `7d`, `1w`, and `yesterday` are resolved using `get_current_time()`, so `TERMSTORY_DATE_OVERRIDE` continues to work correctly.

Filtering is inclusive:

~~~text
since_ts <= session.start_time <= until_ts
~~~

When `--until` is omitted, the upper bound remains open and existing export behavior is preserved.

When `--since` is omitted, the lower bound remains open.

Reversed ranges are rejected with a clear error instead of executing an invalid query.

## Examples

Export sessions from June 1 through June 10:

~~~bash
termstory export --since 2026-06-01 --until 2026-06-10
~~~

Export the last 7 days:

~~~bash
termstory export --since 7d
~~~

Export from one week ago through yesterday:

~~~bash
termstory export --since 1w --until yesterday
~~~

Filter by both project and date range:

~~~bash
termstory export --project myapp --since 2026-06-01 --until 2026-06-10
~~~

## Implementation

### `termstory/exporter.py`

- Added `_parse_relative_offset()` to parse relative day/week expressions such as `7d` and `1w`.
- Extended `parse_since()` to support `7d`, `1w`, and `yesterday`.
- Added `parse_until()` for the inclusive upper date bound.
- Date-only `--until` values resolve to `23:59:59` of the specified day.
- Extended `fetch_export_data()` with the optional `until_str` parameter.
- Added validation to reject ranges where `--since` is later than `--until`.
- Passed both date bounds to the existing `Database.get_range_sessions()` query.
- Kept the existing serialization and sanitization pipeline unchanged.

### `termstory/cli.py`

- Added the optional `--until` option to `termstory export`.
- Passed the value through to `fetch_export_data()`.
- Reused the existing `ValueError` handling for invalid dates and reversed ranges.

### `tests/test_exporter.py`

Added regression coverage for:

- Relative `--since` expressions.
- Relative `--until` expressions.
- `yesterday`.
- ISO date parsing.
- Full-day `--until` behavior.
- Inclusive lower and upper boundaries.
- `--since` only.
- `--until` only.
- Combined `--since` and `--until`.
- Relative date ranges.
- Project + date filtering.
- `TERMSTORY_DATE_OVERRIDE`.
- Backward compatibility for existing `fetch_export_data()` callers.
- Reversed date ranges.
- Invalid `--until` values.
- CLI handling of `--until`.

## Testing

Relevant test suites were run:

~~~text
tests/test_exporter.py
tests/test_date_utils.py
tests/test_notebook.py
~~~

Result:

~~~text
65 passed
~~~

The new regression tests were also verified against the pre-change implementation and failed as expected, confirming that they cover the newly introduced behavior.

## Validation

- `git diff --check` — clean.
- Working tree is clean after commit.
- Only the following four files were modified:
  - `docs/cli-reference.md`
  - `termstory/cli.py`
  - `termstory/exporter.py`
  - `tests/test_exporter.py`
- No database schema changes.
- No migrations.
- No changes to session creation.
- No changes to sanitization.
- No changes to notebook behavior.
- No changes to existing JSON, CSV, or Markdown serialization behavior.
- No external dependencies were added.

## Compatibility

Existing commands without `--until` continue to work unchanged.

Examples:

~~~bash
termstory export --since 7
termstory export --since 2026-06-01
termstory export --project myapp
termstory export
~~~

When `until_str` is not provided to `fetch_export_data()`, the existing far-future upper bound is preserved.

## Environment Note

The full CLI test collection has a pre-existing Windows compatibility issue involving `os.geteuid()`, which is unavailable on Windows. This issue is unrelated to the changes in this PR.

The relevant exporter, date utility, and notebook test suites pass successfully.