### PR TITLE
feat: add stats json output

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -72,7 +72,10 @@ machine-readable integrations. The output is pure JSON on stdout. The JSON inclu
   and `last_seen`
 
 Project names follow the same semantics as the human-readable output, i.e. the
-empty/`General / No Project` bucket is reported as `Other`. On an empty
+empty/`General / No Project` bucket is reported as `Other`. Unlike the
+human table, JSON entries are keyed by project identity (`id`), so two distinct
+projects that happen to share a display name are listed as separate entries with
+their own `id`/`path` and statistics rather than being merged. On an empty
 database, `stats --json` reports zero totals, an empty `projects` list, and a
 `time_range` of `{"earliest": null, "latest": null}`.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -55,6 +55,26 @@ Export all or filtered sessions as JSON, CSV, or Markdown to share or perform cu
 ### 📊 Stats (Detailed Work Telemetry)
 Compute and display high-density, CLI-native command category breakdown tables, tool usage, and terminal telemetry.
 - `termstory stats`
+- `termstory stats --json`
+
+`termstory stats --json` emits machine-readable JSON (instead of the Rich/human
+dashboard) intended for CI/CD pipelines, dashboards, scripts, and other
+machine-readable integrations. The output is pure JSON on stdout. The JSON includes:
+
+- `total_sessions` — total session count (`int`)
+- `total_commands` — total command count (`int`)
+- `total_projects` — total project count (`int`)
+- `time_range` — activity window:
+  - `earliest` — ISO-8601 timestamp of earliest activity, or `null`
+  - `latest` — ISO-8601 timestamp of latest activity, or `null`
+- `projects` — per-project breakdown list where each entry has `name`, `id`,
+  `path`, `commands_count`, `total_duration`, `sessions_count`, `first_seen`,
+  and `last_seen`
+
+Project names follow the same semantics as the human-readable output, i.e. the
+empty/`General / No Project` bucket is reported as `Other`. On an empty
+database, `stats --json` reports zero totals, an empty `projects` list, and a
+`time_range` of `{"earliest": null, "latest": null}`.
 
 ### 🏷️ Tags (Session Classification)
 Auto-classify and tag sessions (`deploy`, `debug`, `setup`, `test`, `docs`) based on shell commands and git commit messages.
@@ -149,6 +169,7 @@ termstory anger-translator   # Translate recent commits/errors into emotional st
 
 ```bash
 termstory stats              # Detailed, high-density work statistics and telemetry
+termstory stats --json       # Output session statistics as machine-readable JSON
 ```
 
 ### Ask

--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -418,7 +418,9 @@ def show_insights():
 
 
 @app.command("stats")
-def show_stats():
+def show_stats(
+    json_out: bool = typer.Option(False, "--json", help="Output session statistics as machine-readable JSON"),
+):
     """Show detailed, high-density work statistics and telemetry"""
     db_path = get_db_path()
     db = Database(db_path)
@@ -426,6 +428,12 @@ def show_stats():
     
     run_ingestion(db)
     
+    if json_out:
+        import json
+        from termstory.stats import stats_json
+        print(json.dumps(stats_json(db), indent=2))
+        return
+
     output = format_stats_output(db)
     from rich.text import Text
     console.print(Text.from_ansi(output))

--- a/termstory/stats.py
+++ b/termstory/stats.py
@@ -157,6 +157,92 @@ def project_breakdown(db: Database) -> Dict[str, Dict[str, Any]]:
         
     return breakdown
 
+def stats_json(db: Database) -> Dict[str, Any]:
+    """Assemble a plain, machine-readable statistics payload.
+
+    Reuses the existing ``project_breakdown()`` calculation (including the
+    ``General / No Project`` -> ``Other`` mapping) instead of duplicating it, and
+    computes the top-level session/command/project totals plus the overall activity
+    time window directly from the database.
+
+    All return values are plain JSON-compatible primitives (ints, strings or None) so
+    the result can be passed straight to ``json.dumps()`` with no custom serializer.
+
+    Returns a dict shaped as::
+
+        {
+            "total_sessions": int,
+            "total_commands": int,
+            "total_projects": int,
+            "time_range": {"earliest": str | None, "latest": str | None},
+            "projects": [
+                {"name", "id", "path", "commands_count", "total_duration",
+                 "sessions_count", "first_seen", "last_seen"}, ...
+            ],
+        }
+
+    For an empty database, all totals are 0, ``projects`` is ``[]`` and the time
+    range is ``{"earliest": None, "latest": None}``.
+    """
+    conn = db.get_connection()
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM sessions")
+        total_sessions = cursor.fetchone()[0]
+        cursor.execute("SELECT COUNT(*) FROM commands")
+        total_commands = cursor.fetchone()[0]
+        cursor.execute("SELECT COUNT(*) FROM projects")
+        total_projects = cursor.fetchone()[0]
+
+        # Overall activity window covering both sessions and commands.
+        cursor.execute(
+            "SELECT MIN(start_time), MAX(end_time) FROM sessions "
+            "WHERE start_time IS NOT NULL"
+        )
+        s_min, s_max = cursor.fetchone()
+        cursor.execute(
+            "SELECT MIN(timestamp), MAX(timestamp) FROM commands "
+            "WHERE timestamp IS NOT NULL"
+        )
+        c_min, c_max = cursor.fetchone()
+    finally:
+        conn.close()
+
+    times = [t for t in (s_min, s_max, c_min, c_max) if t is not None]
+    if times:
+        earliest = datetime.fromtimestamp(min(times)).isoformat()
+        latest = datetime.fromtimestamp(max(times)).isoformat()
+    else:
+        earliest = None
+        latest = None
+
+    projects = []
+    for name, stats in project_breakdown(db).items():
+        projects.append({
+            "name": name,
+            "id": stats["id"],
+            "path": stats["path"],
+            "commands_count": stats["commands_count"],
+            "total_duration": stats["total_duration"],
+            "sessions_count": stats["sessions_count"],
+            "first_seen": (
+                datetime.fromtimestamp(stats["first_seen"]).isoformat()
+                if stats["first_seen"] is not None else None
+            ),
+            "last_seen": (
+                datetime.fromtimestamp(stats["last_seen"]).isoformat()
+                if stats["last_seen"] is not None else None
+            ),
+        })
+
+    return {
+        "total_sessions": total_sessions,
+        "total_commands": total_commands,
+        "total_projects": total_projects,
+        "time_range": {"earliest": earliest, "latest": latest},
+        "projects": projects,
+    }
+
 _LANG_CACHE = {}
 
 def detect_project_language_from_files(path: str) -> Optional[str]:

--- a/termstory/stats.py
+++ b/termstory/stats.py
@@ -157,13 +157,128 @@ def project_breakdown(db: Database) -> Dict[str, Dict[str, Any]]:
         
     return breakdown
 
+def _project_display_name(name):
+    """Map empty/'General / No Project' project names to 'Other'.
+
+    Mirrors the display-name rule used by ``project_breakdown()`` so machine-readable
+    output stays label-consistent with the human-readable dashboard.
+    """
+    if not name or name == "General / No Project":
+        return "Other"
+    return name
+
+def _safe_datetime_from_ts(ts):
+    """Convert a Unix timestamp to a ``datetime``, skipping invalid values.
+
+    Returns ``None`` for ``None``/out-of-range input instead of raising, following
+    the existing repository convention (see ``insights.analyze_all``, which wraps
+    ``datetime.fromtimestamp`` in ``except (OSError, ValueError, OverflowError)``)
+    so a single malformed row cannot crash ``stats --json``.
+    """
+    if ts is None:
+        return None
+    try:
+        return datetime.fromtimestamp(ts)
+    except (OSError, ValueError, OverflowError):
+        return None
+
+def _iso_from_ts(ts):
+    """Convert a Unix timestamp to a stable ISO-8601 string (or ``None``)."""
+    dt = _safe_datetime_from_ts(ts)
+    return dt.isoformat() if dt is not None else None
+
+def project_breakdown_json(db: Database):
+    """Identity-keyed variant of :func:`project_breakdown` for JSON output.
+
+    ``project_breakdown()`` aggregates into a name-keyed dict, which silently merges
+    two distinct projects that share a display name (keeping only one id/path). This
+    variant keys each aggregate by the project's stable ``id`` so same-named projects
+    stay separate rows, while preserving:
+
+    * the ``General / No Project`` -> ``Other`` display-name mapping, and
+    * folding project-less activity (``project_id IS NULL``) into a single
+      ``Other`` bucket (dropped when it has no activity), like project_breakdown().
+
+    Returns a list of plain dicts sorted deterministically by
+    ``(-total_duration, name, id)`` so JSON output is stable across runs.
+    """
+    conn = db.get_connection()
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT id, name, path, first_seen, last_seen FROM projects")
+        projects = cursor.fetchall()
+
+        cursor.execute("SELECT project_id, COUNT(*) FROM commands GROUP BY project_id")
+        cmd_counts = dict(cursor.fetchall())
+
+        cursor.execute(
+            "SELECT project_id, COUNT(*), SUM(duration_seconds) "
+            "FROM sessions GROUP BY project_id"
+        )
+        session_stats = {row[0]: (row[1], row[2] or 0) for row in cursor.fetchall()}
+
+        # First/last activity for project-less rows (mirrors project_breakdown).
+        cursor.execute(
+            "SELECT MIN(timestamp), MAX(timestamp) FROM commands WHERE project_id IS NULL"
+        )
+        c_min, c_max = cursor.fetchone()
+        cursor.execute(
+            "SELECT MIN(start_time), MAX(end_time) FROM sessions WHERE project_id IS NULL"
+        )
+        s_min, s_max = cursor.fetchone()
+    finally:
+        conn.close()
+
+    entries = {}
+    for p_id, name, path, first_seen, last_seen in projects:
+        sess_count, total_dur = session_stats.get(p_id, (0, 0))
+        entries[p_id] = {
+            "name": _project_display_name(name),
+            "id": p_id,
+            "path": path,
+            "commands_count": cmd_counts.get(p_id, 0),
+            "total_duration": total_dur,
+            "sessions_count": sess_count,
+            "first_seen": first_seen,
+            "last_seen": last_seen,
+        }
+
+    null_sess, null_dur = session_stats.get(None, (0, 0))
+    null_cmds = cmd_counts.get(None, 0)
+    if null_cmds or null_sess or null_dur:
+        times = [t for t in (c_min, c_max, s_min, s_max) if t is not None]
+        entries[None] = {
+            "name": "Other",
+            "id": None,
+            "path": None,
+            "commands_count": null_cmds,
+            "total_duration": null_dur,
+            "sessions_count": null_sess,
+            "first_seen": min(times) if times else None,
+            "last_seen": max(times) if times else None,
+        }
+
+    def _sort_key(p_id):
+        e = entries[p_id]
+        return (-e["total_duration"], e["name"], p_id is None, p_id or 0)
+
+    return [entries[key] for key in sorted(entries.keys(), key=_sort_key)]
+
 def stats_json(db: Database) -> Dict[str, Any]:
     """Assemble a plain, machine-readable statistics payload.
 
-    Reuses the existing ``project_breakdown()`` calculation (including the
-    ``General / No Project`` -> ``Other`` mapping) instead of duplicating it, and
-    computes the top-level session/command/project totals plus the overall activity
-    time window directly from the database.
+    Uses the identity-keyed :func:`project_breakdown_json` variant (preserving the
+    ``General / No Project`` -> ``Other`` display mapping) instead of duplicating the
+    calculation, and computes the top-level session/command/project totals plus the
+    overall activity window directly from the database.
+
+    The activity window is built from every valid timestamp source via ``UNION ALL``
+    (session starts, non-NULL session ends, and command timestamps) so an unfinished
+    session (``end_time IS NULL``) still contributes its ``start_time`` to ``latest``.
+
+    Timestamps are serialized with :func:`_iso_from_ts`, which follows the existing
+    repository convention of skipping invalid/out-of-range values rather than
+    crashing.
 
     All return values are plain JSON-compatible primitives (ints, strings or None) so
     the result can be passed straight to ``json.dumps()`` with no custom serializer.
@@ -194,54 +309,63 @@ def stats_json(db: Database) -> Dict[str, Any]:
         cursor.execute("SELECT COUNT(*) FROM projects")
         total_projects = cursor.fetchone()[0]
 
-        # Overall activity window covering both sessions and commands.
-        cursor.execute(
-            "SELECT MIN(start_time), MAX(end_time) FROM sessions "
-            "WHERE start_time IS NOT NULL"
+        # Collect every timestamp source via UNION ALL. Doing MIN/MAX in SQL here
+        # would be wrong twice over: an unfinished session (end_time IS NULL) must
+        # still contribute its start_time to `latest`, and SQLite would happily
+        # return an out-of-range outlier that Python cannot convert -- masking all
+        # valid activity. So candidates are filtered/converted per the repository
+        # convention (skip OSError/ValueError/OverflowError) before min/max.
+        sql = (
+            "SELECT ts FROM ("
+            " SELECT start_time AS ts FROM sessions WHERE start_time IS NOT NULL"
+            " UNION ALL"
+            " SELECT end_time AS ts FROM sessions WHERE end_time IS NOT NULL"
+            " UNION ALL"
+            " SELECT timestamp AS ts FROM commands WHERE timestamp IS NOT NULL"
+            ") AS activity"
         )
-        s_min, s_max = cursor.fetchone()
-        cursor.execute(
-            "SELECT MIN(timestamp), MAX(timestamp) FROM commands "
-            "WHERE timestamp IS NOT NULL"
-        )
-        c_min, c_max = cursor.fetchone()
+        cursor.execute(sql)
+        candidate_rows = cursor.fetchall()
     finally:
         conn.close()
 
-    times = [t for t in (s_min, s_max, c_min, c_max) if t is not None]
-    if times:
-        earliest = datetime.fromtimestamp(min(times)).isoformat()
-        latest = datetime.fromtimestamp(max(times)).isoformat()
+    valid_datetimes = []
+    for (ts,) in candidate_rows:
+        dt = _safe_datetime_from_ts(ts)
+        if dt is not None:
+            valid_datetimes.append(dt)
+
+    if valid_datetimes:
+        earliest_dt = min(valid_datetimes)
+        latest_dt = max(valid_datetimes)
     else:
-        earliest = None
-        latest = None
+        earliest_dt = None
+        latest_dt = None
 
     projects = []
-    for name, stats in project_breakdown(db).items():
+    for stats in project_breakdown_json(db):
         projects.append({
-            "name": name,
+            "name": stats["name"],
             "id": stats["id"],
             "path": stats["path"],
             "commands_count": stats["commands_count"],
             "total_duration": stats["total_duration"],
             "sessions_count": stats["sessions_count"],
-            "first_seen": (
-                datetime.fromtimestamp(stats["first_seen"]).isoformat()
-                if stats["first_seen"] is not None else None
-            ),
-            "last_seen": (
-                datetime.fromtimestamp(stats["last_seen"]).isoformat()
-                if stats["last_seen"] is not None else None
-            ),
+            "first_seen": _iso_from_ts(stats["first_seen"]),
+            "last_seen": _iso_from_ts(stats["last_seen"]),
         })
 
     return {
         "total_sessions": total_sessions,
         "total_commands": total_commands,
         "total_projects": total_projects,
-        "time_range": {"earliest": earliest, "latest": latest},
+        "time_range": {
+            "earliest": earliest_dt.isoformat() if earliest_dt else None,
+            "latest": latest_dt.isoformat() if latest_dt else None,
+        },
         "projects": projects,
     }
+
 
 _LANG_CACHE = {}
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -837,6 +837,9 @@ def test_cli_stats_json_populated(tmp_path, monkeypatch):
     monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
     monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
     monkeypatch.setattr("termstory.cli.get_history_files", lambda: [])
+    # Ingestion warnings go to stderr; silence ingestion so the JSON-purity
+    # assertions hold even under CliRunner builds that mix stderr into stdout.
+    monkeypatch.setattr("termstory.cli.run_ingestion", lambda db: None)
 
     db = Database(str(db_file))
     db.init_db()
@@ -875,6 +878,9 @@ def test_cli_stats_json_empty(tmp_path, monkeypatch):
     monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
     monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
     monkeypatch.setattr("termstory.cli.get_history_files", lambda: [])
+    # Ingestion warnings go to stderr; silence ingestion so the JSON-purity
+    # assertions hold even under CliRunner builds that mix stderr into stdout.
+    monkeypatch.setattr("termstory.cli.run_ingestion", lambda db: None)
 
     db = Database(str(db_file))
     db.init_db()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -831,6 +831,67 @@ def test_cli_stats_command(tmp_path, monkeypatch):
     assert "HugeGraph" in result.stdout
 
 
+def test_cli_stats_json_populated(tmp_path, monkeypatch):
+    import json
+    db_file = tmp_path / "test_cli_stats_json.db"
+    monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.cli.get_history_files", lambda: [])
+
+    db = Database(str(db_file))
+    db.init_db()
+
+    from termstory.date_utils import get_current_time
+    now = int(get_current_time().timestamp())
+    p = Project(id=1, name="HugeGraph", path="~/projects/incubator-hugegraph", first_seen=now, last_seen=now, session_count=1, total_time=100)
+    cmd = Command(timestamp=now, command="docker run nginx", session_id=1, project_id=1)
+    s = Session(id=1, start_time=now, end_time=now + 100, duration_seconds=100, project_id=1, commands=[cmd])
+    db.save_data([p], [s], [cmd])
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["stats", "--json"])
+    assert result.exit_code == 0
+
+    data = json.loads(result.stdout)
+    assert data["total_sessions"] == 1
+    assert data["total_commands"] == 1
+    assert data["total_projects"] == 1
+    assert data["time_range"]["earliest"] is not None
+    assert data["time_range"]["latest"] is not None
+    assert isinstance(data["projects"], list)
+    assert len(data["projects"]) == 1
+    proj = data["projects"][0]
+    assert proj["name"] == "HugeGraph"
+    assert "commands_count" in proj
+    assert "total_duration" in proj
+    assert "sessions_count" in proj
+    assert "first_seen" in proj
+    assert "last_seen" in proj
+
+
+def test_cli_stats_json_empty(tmp_path, monkeypatch):
+    import json
+    db_file = tmp_path / "test_cli_stats_json_empty.db"
+    monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: str(db_file))
+    monkeypatch.setattr("termstory.cli.get_history_files", lambda: [])
+
+    db = Database(str(db_file))
+    db.init_db()
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["stats", "--json"])
+    assert result.exit_code == 0
+
+    data = json.loads(result.stdout)
+    assert data["total_sessions"] == 0
+    assert data["total_commands"] == 0
+    assert data["total_projects"] == 0
+    assert data["projects"] == []
+    assert data["time_range"]["earliest"] is None
+    assert data["time_range"]["latest"] is None
+
+
 def test_cli_project_context_command(tmp_path, monkeypatch):
     db_file = tmp_path / "test_cli_project_context.db"
     monkeypatch.setattr("termstory.cli.get_db_path", lambda: str(db_file))

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -188,6 +188,9 @@ def test_stats_json_populated(temp_db):
     other_entry = next(p for p in data["projects"] if p["name"] == "Other")
     assert other_entry["commands_count"] == 1
     assert other_entry["sessions_count"] == 1
+    # Identity-keyed JSON keeps the mapped project's own id/path.
+    assert other_entry["id"] == 1
+    assert other_entry["path"] is None
 
 
 def test_stats_json_empty(temp_db):
@@ -198,6 +201,87 @@ def test_stats_json_empty(temp_db):
     assert data["total_projects"] == 0
     assert data["projects"] == []
     assert data["time_range"] == {"earliest": None, "latest": None}
+
+def test_stats_json_unfinished_session_latest(temp_db):
+    base = int(time.time())
+    p = Project(id=1, name="Alpha", path="~/alpha", first_seen=base, last_seen=base + 300, session_count=2, total_time=100)
+    cmd = Command(timestamp=base + 150, command="git status", exit_code=0, session_id=1, project_id=1)
+    completed = Session(id=1, start_time=base + 100, end_time=base + 200, duration_seconds=100, project_id=1, commands=[cmd])
+    temp_db.save_data([p], [completed], [cmd])
+
+    # Later *unfinished* session: end_time/duration are NULL while still running.
+    conn = temp_db.get_connection()
+    try:
+        conn.execute(
+            "INSERT INTO sessions (start_time, end_time, duration_seconds, project_id) "
+            "VALUES (?, NULL, NULL, 1)",
+            (base + 300,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    data = stats_json(temp_db)
+
+    assert data["total_sessions"] == 2
+    assert data["total_commands"] == 1
+    # The unfinished session's start_time must bound `latest`.
+    assert data["time_range"]["latest"] == datetime.fromtimestamp(base + 300).isoformat()
+    assert data["time_range"]["earliest"] == datetime.fromtimestamp(base + 100).isoformat()
+
+
+def test_stats_json_duplicate_project_names(temp_db):
+    base = int(time.time())
+    pa = Project(id=1, name="demo", path="/repo/a", first_seen=base, last_seen=base + 10, session_count=1, total_time=10)
+    pb = Project(id=2, name="demo", path="/repo/b", first_seen=base + 20, last_seen=base + 40, session_count=1, total_time=20)
+    ca = Command(timestamp=base + 5, command="echo a", exit_code=0, session_id=1, project_id=1)
+    sa = Session(id=1, start_time=base, end_time=base + 10, duration_seconds=10, project_id=1, commands=[ca])
+    cb = Command(timestamp=base + 25, command="echo b", exit_code=0, session_id=2, project_id=2)
+    sb = Session(id=2, start_time=base + 20, end_time=base + 40, duration_seconds=20, project_id=2, commands=[cb])
+    temp_db.save_data([pa, pb], [sa, sb], [ca, cb])
+
+    data = stats_json(temp_db)
+
+    assert data["total_projects"] == 2
+    assert len(data["projects"]) == 2
+    demos = [entry for entry in data["projects"] if entry["name"] == "demo"]
+    assert len(demos) == 2
+    by_id = {entry["id"]: entry for entry in demos}
+    assert set(by_id) == {1, 2}
+    assert by_id[1]["path"] == "/repo/a"
+    assert by_id[2]["path"] == "/repo/b"
+    # Stats must stay attached to the correct project identity.
+    assert by_id[1]["commands_count"] == 1 and by_id[1]["sessions_count"] == 1
+    assert by_id[1]["total_duration"] == 10
+    assert by_id[2]["commands_count"] == 1 and by_id[2]["sessions_count"] == 1
+    assert by_id[2]["total_duration"] == 20
+
+
+def test_stats_json_skips_invalid_timestamps(temp_db):
+    base = int(time.time())
+    p = Project(id=1, name="Valid", path="~/valid", first_seen=base, last_seen=base + 50, session_count=2, total_time=50)
+    cmd = Command(timestamp=base + 10, command="ls", exit_code=0, session_id=1, project_id=1)
+    good = Session(id=1, start_time=base, end_time=base + 50, duration_seconds=50, project_id=1, commands=[cmd])
+    temp_db.save_data([p], [good], [cmd])
+
+    # Out-of-range timestamp (same shape insights.analyze_all already guards
+    # against) must not crash stats_json().
+    conn = temp_db.get_connection()
+    try:
+        conn.execute(
+            "INSERT INTO sessions (start_time, end_time, duration_seconds, project_id) "
+            "VALUES (?, NULL, NULL, 1)",
+            (-999999999999,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    data = stats_json(temp_db)  # Must not raise.
+
+    assert data["time_range"]["earliest"] == datetime.fromtimestamp(base).isoformat()
+    assert data["time_range"]["latest"] == datetime.fromtimestamp(base + 50).isoformat()
+
 
 @pytest.fixture(autouse=True)
 def clear_cache():

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from termstory.database import Database
 from termstory.models import Command, Session, Project
-from termstory.stats import daily_activity_heatmap, project_breakdown, language_detection, peak_hours, detect_project_language_from_files, _LANG_CACHE
+from termstory.stats import daily_activity_heatmap, project_breakdown, language_detection, peak_hours, detect_project_language_from_files, _LANG_CACHE, stats_json
 from termstory.formatter import format_stats_output
 
 @pytest.fixture
@@ -145,6 +145,59 @@ def test_format_stats_output(temp_db):
     assert "TermStory" in output
     assert "Python" in output
 
+def test_stats_json_populated(temp_db):
+    now_ts = int(time.time())
+    # Project 1: "General / No Project" -> should map to "Other"
+    p1 = Project(id=1, name="General / No Project", path=None, first_seen=now_ts, last_seen=now_ts + 60, session_count=1, total_time=60)
+    cmd1 = Command(timestamp=now_ts, command="ls", exit_code=0, session_id=1, project_id=1)
+    s1 = Session(id=1, start_time=now_ts, end_time=now_ts + 60, duration_seconds=60, project_id=1, commands=[cmd1])
+
+    # Project 2: "TermStory"
+    p2 = Project(id=2, name="TermStory", path="~/termstory", first_seen=now_ts + 100, last_seen=now_ts + 200, session_count=1, total_time=100)
+    cmd2 = Command(timestamp=now_ts + 100, command="git diff", exit_code=0, session_id=2, project_id=2)
+    s2 = Session(id=2, start_time=now_ts + 100, end_time=now_ts + 200, duration_seconds=100, project_id=2, commands=[cmd2])
+
+    temp_db.save_data([p1, p2], [s1, s2], [cmd1, cmd2])
+
+    data = stats_json(temp_db)
+
+    assert data["total_sessions"] == 2
+    assert data["total_commands"] == 2
+    assert data["total_projects"] == 2
+
+    # Time range spans earliest command and latest session end.
+    assert data["time_range"]["earliest"] == datetime.fromtimestamp(now_ts).isoformat()
+    assert data["time_range"]["latest"] == datetime.fromtimestamp(now_ts + 200).isoformat()
+
+    # Projects are a list (never keyed by name).
+    assert isinstance(data["projects"], list)
+    names = {p["name"] for p in data["projects"]}
+    assert "Other" in names
+    assert "TermStory" in names
+    assert "General / No Project" not in names
+
+    termstory_entry = next(p for p in data["projects"] if p["name"] == "TermStory")
+    assert termstory_entry["commands_count"] == 1
+    assert termstory_entry["sessions_count"] == 1
+    assert termstory_entry["total_duration"] == 100
+    assert termstory_entry["path"] == "~/termstory"
+    assert termstory_entry["id"] == 2
+    assert termstory_entry["first_seen"] == datetime.fromtimestamp(now_ts + 100).isoformat()
+    assert termstory_entry["last_seen"] == datetime.fromtimestamp(now_ts + 200).isoformat()
+
+    other_entry = next(p for p in data["projects"] if p["name"] == "Other")
+    assert other_entry["commands_count"] == 1
+    assert other_entry["sessions_count"] == 1
+
+
+def test_stats_json_empty(temp_db):
+    data = stats_json(temp_db)
+
+    assert data["total_sessions"] == 0
+    assert data["total_commands"] == 0
+    assert data["total_projects"] == 0
+    assert data["projects"] == []
+    assert data["time_range"] == {"earliest": None, "latest": None}
 
 @pytest.fixture(autouse=True)
 def clear_cache():


### PR DESCRIPTION
## Summary

- Add `termstory stats --json` for machine-readable session statistics.
- Add reusable raw statistics assembly in `termstory/stats.py`.
- Preserve the existing human-readable `termstory stats` output.
- Add populated and empty-database unit and CLI coverage.
- Document the new `--json` option.

## Validation

- `python -m pytest tests/test_stats.py` — 20 passed
- `python -m pytest tests/test_stats.py tests/test_database_queries.py tests/test_save_data_none_safety.py` — 26 passed
- `python -m pytest tests/test_exporter.py tests/test_insights.py` — 57 passed
- `python -m pytest tests/test_notebook.py tests/test_timeline.py` — 15 passed
- Ruff passed for the new stats implementation.
- `git diff --check` passed.
- CliRunner end-to-end validation passed for populated and empty databases.
- JSON stdout was verified to be parseable and free of ANSI/Rich output.
- Existing human-readable stats behavior was preserved.

There are pre-existing Windows-only test collection issues involving `os.geteuid()` and `test_bash_inspect.py`; these are unrelated to this change.

Closes #430