### PR TITLE
fix(git_integration): preserve hyphenated commit identifiers

### DIFF
--- a/termstory/git_integration.py
+++ b/termstory/git_integration.py
@@ -50,9 +50,11 @@ def clean_commit_message(message: str) -> str:
     msg = re.sub(r':[a-zA-Z0-9_\-+]+:', '', msg)
     msg = msg.strip()
     
-    # 3. Strip any JIRA/issue reference like [ABC-123] or ABC-123 at the start
+    # 3. Strip any JIRA/issue reference like [ABC-123] or ABC-123: at the start.
+    #    Requiring the colon keeps ordinary hyphenated identifiers such as
+    #    SHA-1, UTF-8, and CVE-2024 from being mistaken for an issue key.
     msg = re.sub(r'^\[[A-Za-z]+-\d+\]\s*', '', msg)
-    msg = re.sub(r'^[A-Za-z]+-\d+[:\s]\s*', '', msg)
+    msg = re.sub(r'^[A-Za-z]+-\d+:\s*', '', msg)
     
     # 4. Strip conventional commit prefixes (e.g. feat: fix: chore: etc. with case-insensitive flag at the start, supporting breaking changes and revert)
     msg = re.sub(r'(?i)^(feat|fix|chore|docs|refactor|test|style|ci|perf|build|revert)(?:\([a-zA-Z0-9_\-\/]+\))?!?:\s*', '', msg)

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -19,6 +19,11 @@ def test_clean_commit_message():
     assert clean_commit_message("[PROJ-123] Refactor CI pipeline") == "Refactor CI pipeline"
     assert clean_commit_message("ENG-456: hello world") == "Hello world"
     
+    # Test that ordinary hyphenated identifiers are not mistaken for issue keys
+    assert clean_commit_message("SHA-1 collision check added") == "SHA-1 collision check added"
+    assert clean_commit_message("UTF-8 decoding fix for logs") == "UTF-8 decoding fix for logs"
+    assert clean_commit_message("CVE-2024 mitigation applied") == "CVE-2024 mitigation applied"
+
     # Test emoji shorthand and unicode emoji stripping
     assert clean_commit_message("Refactor CI pipeline :rocket:") == "Refactor CI pipeline"
     assert clean_commit_message("🚧 fix: remove debug logs") == "Remove debug logs"


### PR DESCRIPTION
Closes #444 
## Summary

This PR fixes an issue in `clean_commit_message()` where valid hyphenated identifiers at the beginning of commit subjects were incorrectly interpreted as JIRA-style issue references and stripped from the message.

The existing regex:

`^[A-Za-z]+-\d+[:\s]\s*`

matched both a colon and whitespace after the issue key. As a result, commit subjects such as `SHA-1 collision check added` were incorrectly transformed into `Collision check added`. The same problem occurred with identifiers such as `UTF-8` and `CVE-2024`.

### Changes Made

- Updated the issue-key regex in `termstory/git_integration.py` to require a colon after the issue reference:
  `^[A-Za-z]+-\d+:\s*`
- This preserves legitimate commit subjects containing hyphenated identifiers while continuing to remove e
- xplicitly formatted issue references.
- Existing bracket-style issue references such as `[PROJ-123] Refactor CI pipeline` remain unchanged because they are handled separately.
- Existing colon-style issue references such as `ENG-456: hello world` continue to be normalized to `Hello world`.
- No unrelated logic in `clean_commit_message()` was modified.

### Regression Tests

Added test coverage for the affected cases:

- `SHA-1 collision check added` remains unchanged.
- `UTF-8 decoding fix for logs` remains unchanged.
- `CVE-2024 mitigation applied` remains unchanged.

Existing behavior was also preserved and verified for:

- `ENG-456: hello world`
- `[PROJ-123] Refactor CI pipeline`

### Validation

- `tests/test_git_integration.py`: **3 tests passed**
- `git diff --check`: **clean**
- Changes are limited to:
  - `termstory/git_integration.py`
  - `tests/test_git_integration.py`

The full test suite was also attempted. Collection/execution is currently affected by pre-existing environment/platform issues, including missing `textual`, POSIX-only `os.geteuid` usage on Windows, and Windows temporary-file permission errors. These failures are unrelated to the changes in this PR.

### Scope

The implementation is intentionally minimal and limited to the commit-message parsing behavior described in issue #444, with corresponding regression tests.