### PR TITLE
fix(git_integration): validate git worktree status

### DIFF
--- a/termstory/git_integration.py
+++ b/termstory/git_integration.py
@@ -19,7 +19,10 @@ def is_git_repo(path: str) -> bool:
             check=False,
             timeout=10
         )
-        return res.returncode == 0
+        # Returning True only when both the process succeeded and git reports
+        # that we are inside a work tree. `rev-parse --is-inside-work-tree`
+        # exits 0 and prints "false" for a .git directory or a bare repo.
+        return res.returncode == 0 and res.stdout.strip() == "true"
     except Exception:
         return False
 

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -64,6 +64,22 @@ def test_git_operations_on_temp_repo(tmp_path):
     assert len(commits[0]["hash"]) == 40
     assert commits[0]["timestamp"] > 0
 
+def test_is_git_repo_worktree_vs_git_dir(tmp_path):
+    # Initialize a temporary git repository
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    try:
+        subprocess.run(["git", "init"], cwd=str(repo_path), check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except Exception:
+        # If git is not installed or init fails, skip the rest of the test
+        return
+
+    # The repository root is a valid worktree
+    assert is_git_repo(str(repo_path)) is True
+
+    # The .git directory is NOT a worktree (rev-parse exits 0 but prints "false")
+    assert is_git_repo(str(repo_path / ".git")) is False
+
 from unittest.mock import patch
 def test_git_missing_or_failing(tmp_path):
     # Test subprocess.run raising an exception (e.g. git not found)
@@ -80,6 +96,22 @@ def test_git_missing_or_failing(tmp_path):
         mock_run.return_value = MockResult()
         assert not is_git_repo(str(tmp_path))
         
+    # Test subprocess.run reporting success with git printing "true" (inside a worktree)
+    with patch("termstory.git_integration.subprocess.run") as mock_run:
+        class MockResult:
+            returncode = 0
+            stdout = "true\n"
+        mock_run.return_value = MockResult()
+        assert is_git_repo(str(tmp_path)) is True
+
+    # Test subprocess.run reporting success but git printing "false" (e.g. .git dir or bare repo)
+    with patch("termstory.git_integration.subprocess.run") as mock_run:
+        class MockResult:
+            returncode = 0
+            stdout = "false\n"
+        mock_run.return_value = MockResult()
+        assert is_git_repo(str(tmp_path)) is False
+
     # Test get_project_commits returning non-zero return code
     with patch("termstory.git_integration.is_git_repo", return_value=True):
         with patch("termstory.git_integration.subprocess.run") as mock_run:

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -65,14 +65,12 @@ def test_git_operations_on_temp_repo(tmp_path):
     assert commits[0]["timestamp"] > 0
 
 def test_is_git_repo_worktree_vs_git_dir(tmp_path):
-    # Initialize a temporary git repository
+    # Initialize a temporary git repository. Failure here must fail the test
+    # (no try/except): the regression assertions below are meaningless unless
+    # the temporary repository was successfully initialized.
     repo_path = tmp_path / "repo"
     repo_path.mkdir()
-    try:
-        subprocess.run(["git", "init"], cwd=str(repo_path), check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    except Exception:
-        # If git is not installed or init fails, skip the rest of the test
-        return
+    subprocess.run(["git", "init"], cwd=str(repo_path), check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     # The repository root is a valid worktree
     assert is_git_repo(str(repo_path)) is True


### PR DESCRIPTION
Closes #445
## Summary

Fixes #445 by making `is_git_repo()` verify the actual result reported by Git instead of relying only on the subprocess exit code.

Previously, `git rev-parse --is-inside-work-tree` could exit successfully with return code `0` while printing `false` when the supplied path was a `.git` directory or a bare repository. Since `is_git_repo()` only checked the return code, these paths were incorrectly treated as valid Git worktrees.

### Changes

- Updated `is_git_repo()` to require both:
  - `res.returncode == 0`
  - `res.stdout.strip() == "true"`
- Added a regression test verifying that a normal repository root returns `True`.
- Added a regression test verifying that the repository's `.git` directory returns `False`.
- Added mocked positive and negative stdout cases to verify both sides of the new condition.
- Kept the change limited to `termstory/git_integration.py` and `tests/test_git_integration.py`.
- Did not modify the analogous logic in `mcp_snapshot.py`, as it is outside the scope of this issue.

### Testing

Targeted Git integration tests:

    4 passed in 1.75s

`git diff --check`:

    clean

The full test suite was also attempted. Collection is currently affected by pre-existing environment/platform issues, including a missing `textual` dependency, use of POSIX-only `os.geteuid` on Windows, and Windows file-lock errors. These failures are unrelated to this change.

### Scope

This is a focused bugfix with no API changes, migrations, or unrelated refactoring.

