### PR TITLE
feat(tui): scope heatmap highlights to visible window

### DIFF
--- a/termstory/tui.py
+++ b/termstory/tui.py
@@ -133,7 +133,11 @@ def calculate_streak(sessions: List[Session]) -> int:
 EIGHT_HOURS_SECONDS = 8 * 3600
 
 
-def _compute_highlight_days(day_counts: dict, sessions: List[Session]) -> set:
+def _compute_highlight_days(
+    day_counts: dict,
+    sessions: List[Session],
+    days_limit: int = 30,
+) -> set:
     """Compute the set of dates that should be eligible for the magenta→pink
     pulse animation (issue #42).
 
@@ -144,22 +148,39 @@ def _compute_highlight_days(day_counts: dict, sessions: List[Session]) -> set:
       (b) at least one session that started on that day ran for 8+ continuous
           hours (``duration_seconds >= EIGHT_HOURS_SECONDS``).
 
-    Returns an empty set when there is no activity at all (so the pulse has
-    nothing to highlight — the scan-line effect still runs on its own).
+    The personal-best comparison is scoped to the **visible window**: the
+    ``days_limit`` most recent dates ending at today (``today - (days_limit -
+    1)`` .. ``today``), which is exactly the set of dates ``generate_heatmap``
+    renders. Days outside that window are ignored for the personal-best test,
+    so a single prolific day from long ago can no longer suppress
+    personal-best highlights on recent days inside the window.
 
-    TODO: When ``days_limit`` is ``None`` ("All History" mode), the
-    personal-best computation scans the ENTIRE session history rather than
-    a bounded window. This is correct but may produce surprising results
-    for long-time users (a single prolific day months ago suppresses all
-    other days). A follow-up PR could scope the personal-best to the
-    visible window only. Out of scope for this PR — requires threading
-    ``days_limit`` through the call chain.
+    When ``days_limit`` is ``None`` ("All History" mode), callers resolve it
+    to the rendered window they actually display (e.g. the dashboard's 90-day
+    fallback) before calling — it is never interpreted as an empty or zero-day
+    window here.
+
+    Returns an empty set when there is no visible activity at all (so the
+    pulse has nothing to highlight — the scan-line effect still runs on its
+    own).
     """
-    if not day_counts:
+    if not day_counts or days_limit is None or days_limit <= 0:
         return set()
 
-    max_count = max(day_counts.values())
-    highlight = {d for d, c in day_counts.items() if c > 0 and c == max_count}
+    now = get_current_time().date()
+    visible_days = {now - timedelta(days=i) for i in range(days_limit)}
+
+    visible_day_counts = {
+        d: c for d, c in day_counts.items() if d in visible_days
+    }
+
+    if not visible_day_counts:
+        return set()
+
+    max_count = max(visible_day_counts.values())
+    highlight = {
+        d for d, c in visible_day_counts.items() if c > 0 and c == max_count
+    }
 
     for s in sessions:
         if getattr(s, "duration_seconds", 0) >= EIGHT_HOURS_SECONDS:
@@ -202,6 +223,9 @@ def generate_heatmap(
     highlight = highlight_days or set()
 
     heatmap_blocks = []
+    # These ``days_limit`` dates are THE visible window. _compute_highlight_days()
+    # scopes the personal-best to this exact same date set, derived from the same
+    # resolved ``days_limit`` int — keep the two in sync (issue #446).
     for i in range(days_limit - 1, -1, -1):
         target_date = now - timedelta(days=i)
         cmd_count = day_counts[target_date]
@@ -289,7 +313,8 @@ def calculate_dashboard_stats(
         day_counts = defaultdict(int)
         for s in real_sessions:
             day_counts[datetime.fromtimestamp(s.start_time).date()] += len(s.commands)
-        highlight_days = _compute_highlight_days(day_counts, real_sessions)
+        # Scope the personal-best to the same visible window the heatmap uses.
+        highlight_days = _compute_highlight_days(day_counts, real_sessions, days_limit)
 
     streak = calculate_streak(real_sessions)
     total_seconds = sum(s.duration_seconds for s in sessions)
@@ -3130,7 +3155,14 @@ class TermStoryWorkspace(App):
             day_counts = defaultdict(int)
             for s in real_sessions:
                 day_counts[datetime.fromtimestamp(s.start_time).date()] += len(s.commands)
-            self._cached_highlight_days = _compute_highlight_days(day_counts, real_sessions)
+            # The resolved rendered window (same value passed to
+            # calculate_dashboard_stats/generate_heatmap below) is used so the
+            # personal-best is scoped to the days actually visible in the
+            # heatmap, even in "All History" mode (days_limit is None → 90).
+            resolved_window = self.days_limit or 90
+            self._cached_highlight_days = _compute_highlight_days(
+                day_counts, real_sessions, resolved_window
+            )
             self._cached_highlight_session_count = session_count
 
         stats = calculate_dashboard_stats(

--- a/termstory/tui.py
+++ b/termstory/tui.py
@@ -3146,11 +3146,20 @@ class TermStoryWorkspace(App):
         # This avoids re-iterating all sessions every 0.5s — important for not
         # perturbing the timing of background worker threads (e.g. the exec
         # review worker) on slower Python versions (3.9/3.10).
+        #
+        # Issue #446: highlights are now scoped to the VISIBLE heatmap window,
+        # so the cache is also keyed on the current date (midnight rolls the
+        # rendered window forward even with no new sessions) and on the
+        # resolved window (--days/--all-history flips it).
+        current_date = get_current_time().date()
+        resolved_window = self.days_limit or 90
         real_sessions = [s for s in self.sessions if not getattr(s, "is_legacy", False)]
         session_count = len(real_sessions)
         if (
             not hasattr(self, "_cached_highlight_days")
             or getattr(self, "_cached_highlight_session_count", -1) != session_count
+            or getattr(self, "_cached_highlight_date", None) != current_date
+            or getattr(self, "_cached_highlight_window", None) != resolved_window
         ):
             day_counts = defaultdict(int)
             for s in real_sessions:
@@ -3159,15 +3168,16 @@ class TermStoryWorkspace(App):
             # calculate_dashboard_stats/generate_heatmap below) is used so the
             # personal-best is scoped to the days actually visible in the
             # heatmap, even in "All History" mode (days_limit is None → 90).
-            resolved_window = self.days_limit or 90
             self._cached_highlight_days = _compute_highlight_days(
                 day_counts, real_sessions, resolved_window
             )
             self._cached_highlight_session_count = session_count
+            self._cached_highlight_date = current_date
+            self._cached_highlight_window = resolved_window
 
         stats = calculate_dashboard_stats(
             self.sessions, self.projects,
-            days_limit=self.days_limit or 90,
+            days_limit=resolved_window,
             pulse_phase=pulse,
             highlight_days=self._cached_highlight_days,
         )

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -256,6 +256,78 @@ async def test_tui_all_history_scopes_highlight_cache_to_rendered_window(monkeyp
             assert "Activity (All History):" in str(stats_panel.render())
 
 
+@pytest.mark.asyncio
+async def test_tui_highlight_cache_invalidates_across_midnight(monkeypatch):
+    """Issue #446 review fix: the highlight cache must be keyed on the current
+    date too, not just session_count.
+
+    With ``days_limit=1`` and one session on day A, day A's tick caches
+    ``{A}``. After midnight (day B) the rendered window is ``{B}`` only and no
+    new session appeared — the stale cache must NOT keep serving ``{A}``.
+    """
+    clock = {"now": datetime(2026, 6, 2, 12, 0)}
+    monkeypatch.setattr("termstory.tui.get_current_time", lambda: clock["now"])
+
+    day_a = clock["now"].date()
+    start_a = int(clock["now"].timestamp())
+    project = Project(
+        id=1,
+        name="Project Alpha",
+        path="~/alpha",
+        first_seen=start_a,
+        last_seen=start_a,
+        session_count=1,
+        total_time=600,
+    )
+    cmds = [
+        Command(timestamp=start_a + i, command=f"cmd_{i}", session_id=1, project_id=1)
+        for i in range(10)
+    ]
+    session_a = Session(
+        id=1,
+        start_time=start_a,
+        end_time=start_a + 600,
+        duration_seconds=600,
+        project_id=1,
+        commands=cmds,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        db_path = os.path.join(tmp_dir, "test.db")
+        db = Database(db_path)
+        db.init_db()
+        db.save_data([project], [session_a], cmds)
+
+        app = TermStoryWorkspace(
+            db,
+            days_limit=1,
+            config_override={
+                "has_seen_onboarding": True,
+                "ai_enabled": False,
+                "active_provider": "disabled",
+            },
+        )
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            # Day A: today's session is the personal best inside {A}.
+            assert app._cached_highlight_days == {day_a}
+            assert app._cached_highlight_date == day_a
+
+            # Midnight rolls over; NO new session is created.
+            clock["now"] = clock["now"] + timedelta(days=1)
+            day_b = clock["now"].date()
+            assert len(app.sessions) == 1  # session_count unchanged...
+
+            app.update_stats_header()
+
+            # ...yet the cache was recomputed for day B's rendered window:
+            # the session's day A is now outside it and nothing is highlightable.
+            assert app._cached_highlight_date == day_b
+            assert app._cached_highlight_days == set()
+            assert app._cached_highlight_session_count == 1
+
+
 def test_get_session_memory_str():
     # 1. Commit priority
     s1 = Session(

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -14,6 +14,7 @@ from termstory.tui import (
     MatrixDefragCanvas,
     OnboardingScreen,
     TermStoryWorkspace,
+    _compute_highlight_days,
     calculate_dashboard_stats,
     calculate_streak,
     clean_command_to_memory,
@@ -86,6 +87,173 @@ def test_generate_heatmap():
     heatmap = generate_heatmap(sessions, days_limit=30)
     assert "█" in heatmap or "■" in heatmap or "▄" in heatmap
     assert "░" in heatmap
+
+
+def test_highlight_days_visible_window_scopes_personal_best(monkeypatch):
+    """Regression for issue #446: a prolific day OUTSIDE the visible window must
+    not suppress personal-best highlights on days INSIDE the window.
+
+    The old behaviour computed the personal-best across the entire session
+    history, so a single historically-prolific day set ``max_count`` and recent
+    (lower-count) visible days never got highlighted. The visible window here
+    is ``days_limit=4`` (the 4 most recent days ending today)."""
+    now = datetime(2026, 6, 2, 12, 0)
+    monkeypatch.setattr("termstory.tui.get_current_time", lambda: now)
+    today = now.date()
+
+    historical_day = today - timedelta(days=10)   # outside the 4-day window
+    day_a = today                                  # inside
+    day_b = today - timedelta(days=1)              # inside
+    day_c = today - timedelta(days=2)              # inside
+
+    # A single prolific day long before the visible window used to set the bar.
+    day_counts = {
+        historical_day: 1000,
+        day_a: 100,
+        day_b: 100,
+        day_c: 100,
+    }
+
+    highlight = _compute_highlight_days(day_counts, [], days_limit=4)
+
+    assert historical_day not in highlight
+    assert highlight == {day_a, day_b, day_c}
+
+
+def test_calculate_dashboard_stats_scopes_personal_best_to_all_history_window(monkeypatch):
+    """Regression for issue #446 via the dashboard path.
+
+    Contract: ``calculate_dashboard_stats()`` requires an already-resolved
+    concrete window — ``days_limit=None`` is resolved upstream by
+    ``update_stats_header()`` (``self.days_limit or 90``) because
+    ``generate_heatmap()`` can only render a concrete day count. This test
+    therefore exercises All History semantics via the exact resolved rendered
+    window (90 days) that the app passes in that mode; see
+    ``test_tui_all_history_scopes_highlight_cache_to_rendered_window`` for the
+    end-to-end ``days_limit=None`` resolution itself.
+    """
+    now = datetime(2026, 6, 2, 12, 0)
+    monkeypatch.setattr("termstory.tui.get_current_time", lambda: now)
+
+    today = now.date()
+    recent_a = int((now - timedelta(days=0)).timestamp())
+    recent_b = int((now - timedelta(days=1)).timestamp())
+    recent_c = int((now - timedelta(days=2)).timestamp())
+    old_z = int((now - timedelta(days=100)).timestamp())  # outside 90-day window
+
+    def session(sid, ts, count):
+        return Session(
+            id=sid,
+            start_time=ts,
+            end_time=ts + 600,
+            duration_seconds=600,
+            project_id=1,
+            commands=[Command(timestamp=ts, command=f"cmd_{count}") for _ in range(count)],
+        )
+
+    sessions = [
+        session(1, old_z, 1000),   # prolific day, outside the visible window
+        session(2, recent_a, 100),  # visible, personal best (tie)
+        session(3, recent_b, 100),  # visible, personal best (tie)
+        session(4, recent_c, 100),  # visible, personal best (tie)
+    ]
+
+    # 90 = the window update_stats_header() resolves from days_limit=None.
+    stats = calculate_dashboard_stats(sessions, [], days_limit=90, pulse_phase=0)
+
+    highlight = stats["highlight_days"]
+    # The prolific day 100 days ago is outside the 90-day window and must not
+    # suppress the visible recent days from being personal-best highlights.
+    assert (today - timedelta(days=100)) not in highlight
+    assert today in highlight
+    assert today - timedelta(days=1) in highlight
+    assert today - timedelta(days=2) in highlight
+
+
+@pytest.mark.asyncio
+async def test_tui_all_history_scopes_highlight_cache_to_rendered_window(monkeypatch):
+    """End-to-end issue #446 coverage of ``days_limit=None`` ("All History").
+
+    cli.py wires ``--all-history`` to ``TermStoryWorkspace(db, days_limit=None)``.
+    All sessions are still loaded from the DB, but update_stats_header() must
+    resolve the actually rendered heatmap window (``self.days_limit or 90``)
+    before computing the personal-best highlight cache — so a prolific day
+    outside that window can neither be highlighted itself nor suppress the
+    tied personal-best days that ARE rendered.
+    """
+    now = datetime(2026, 6, 2, 12, 0)
+    monkeypatch.setattr("termstory.tui.get_current_time", lambda: now)
+
+    def ts(days_ago):
+        return int((now - timedelta(days=days_ago)).timestamp())
+
+    project = Project(
+        id=1,
+        name="Project Alpha",
+        path="~/alpha",
+        first_seen=ts(100),
+        last_seen=ts(0),
+        session_count=4,
+        total_time=2400,
+    )
+
+    sessions = []
+    commands = []
+    # (session_id, days_ago, command_count): one prolific historical day plus
+    # three visible days tied at a lower count.
+    for sid, days_ago, count in [(1, 100, 1000), (2, 0, 100), (3, 1, 100), (4, 2, 100)]:
+        start = ts(days_ago)
+        cmds = [
+            Command(timestamp=start + i, command=f"cmd_{i}", session_id=sid, project_id=1)
+            for i in range(count)
+        ]
+        commands.extend(cmds)
+        sessions.append(
+            Session(
+                id=sid,
+                start_time=start,
+                end_time=start + 600,
+                duration_seconds=600,
+                project_id=1,
+                commands=cmds,
+            )
+        )
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        db_path = os.path.join(tmp_dir, "test.db")
+        db = Database(db_path)
+        db.init_db()
+        db.save_data([project], sessions, commands)
+
+        app = TermStoryWorkspace(
+            db,
+            days_limit=None,  # All History mode
+            config_override={
+                "has_seen_onboarding": True,
+                "ai_enabled": False,
+                "active_provider": "disabled",
+            },
+        )
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            # All History still LOADS every session — the fix must scope only
+            # the personal-best comparison, never drop historical data.
+            assert len(app.sessions) == len(sessions)
+
+            today = now.date()
+            highlight = getattr(app, "_cached_highlight_days")
+            assert today in highlight
+            assert today - timedelta(days=1) in highlight
+            assert today - timedelta(days=2) in highlight
+            # Outside the rendered 90-day window: neither highlighted nor
+            # allowed to suppress the ties above.
+            assert today - timedelta(days=100) not in highlight
+
+            # The raw None still flows to the label; only rendering/highlights
+            # use the resolved 90-day window.
+            stats_panel = app.query_one("#stats-panel")
+            assert "Activity (All History):" in str(stats_panel.render())
 
 
 def test_get_session_memory_str():

--- a/tests/test_tui_cyberpunk_animations.py
+++ b/tests/test_tui_cyberpunk_animations.py
@@ -80,7 +80,7 @@ def _make_session(
 
 def test_highlight_days_empty_when_no_sessions():
     """No sessions → no highlight days."""
-    assert _compute_highlight_days({}, []) == set()
+    assert _compute_highlight_days({}, [], days_limit=30) == set()
 
 
 def test_highlight_days_personal_best_command_count():
@@ -91,7 +91,7 @@ def test_highlight_days_personal_best_command_count():
 
     day_counts = {today: 50, yesterday: 10}
     # The sessions list is only used for the 8-hour check, so pass empty.
-    highlight = _compute_highlight_days(day_counts, [])
+    highlight = _compute_highlight_days(day_counts, [], days_limit=30)
     assert highlight == {today}
 
 
@@ -103,7 +103,7 @@ def test_highlight_days_ties_for_personal_best_all_highlighted():
     two_days_ago = today - timedelta(days=2)
 
     day_counts = {today: 30, yesterday: 30, two_days_ago: 10}
-    highlight = _compute_highlight_days(day_counts, [])
+    highlight = _compute_highlight_days(day_counts, [], days_limit=30)
     assert highlight == {today, yesterday}
 
 
@@ -111,7 +111,7 @@ def test_highlight_days_zero_count_days_not_highlighted():
     """A day with 0 commands must never be highlighted even if it's the 'max'."""
     today = datetime.now().date()
     day_counts = {today: 0}
-    assert _compute_highlight_days(day_counts, []) == set()
+    assert _compute_highlight_days(day_counts, [], days_limit=30) == set()
 
 
 # ────────────────────────────────────────────────────────────────────────────
@@ -127,7 +127,7 @@ def test_highlight_days_eight_hour_session_highlighted():
     # 8-hour session today, 0 commands so it won't trigger via personal-best.
     s = _make_session(1, now, EIGHT_HOURS_SECONDS, command_count=0)
     day_counts = {today: 0}
-    highlight = _compute_highlight_days(day_counts, [s])
+    highlight = _compute_highlight_days(day_counts, [s], days_limit=1)
     assert today in highlight
 
 
@@ -138,7 +138,7 @@ def test_highlight_days_just_under_eight_hours_not_highlighted():
 
     s = _make_session(1, now, EIGHT_HOURS_SECONDS - 1, command_count=0)
     day_counts = {today: 0}
-    highlight = _compute_highlight_days(day_counts, [s])
+    highlight = _compute_highlight_days(day_counts, [s], days_limit=1)
     assert today not in highlight
 
 
@@ -149,7 +149,7 @@ def test_highlight_days_eight_hour_exactly_is_highlighted():
 
     s = _make_session(1, now, EIGHT_HOURS_SECONDS, command_count=0)
     day_counts = {today: 0}
-    highlight = _compute_highlight_days(day_counts, [s])
+    highlight = _compute_highlight_days(day_counts, [s], days_limit=1)
     assert today in highlight
 
 
@@ -170,7 +170,7 @@ def test_highlight_days_union_of_personal_best_and_eight_hour():
     )
 
     day_counts = {today: 50, yesterday: 10}
-    highlight = _compute_highlight_days(day_counts, [s_today, s_yesterday])
+    highlight = _compute_highlight_days(day_counts, [s_today, s_yesterday], days_limit=30)
     assert today in highlight      # via personal best
     assert yesterday in highlight  # via 8h session
 


### PR DESCRIPTION
Closes #446

## Summary

This PR fixes the heatmap personal-best highlighting behavior so that the personal-best command count is calculated only from the days currently visible in the rendered heatmap window.

Previously, `_compute_highlight_days()` calculated the personal-best using all available `day_counts`. In All History mode, all historical sessions are loaded, so a single highly active day from months earlier could set the personal-best threshold and prevent recent visible days from being highlighted.

The fix scopes the personal-best calculation to the same resolved window used by the heatmap renderer.

## Changes

- Updated `_compute_highlight_days()` to accept the resolved visible `days_limit`.
- Constructed the visible date window using the same current-date source and day-range semantics as `generate_heatmap()`.
- Filtered `day_counts` to visible dates before calculating `max_count`.
- Preserved the existing session data; historical sessions are not removed or filtered globally.
- Updated both production call paths:
  - `calculate_dashboard_stats()`
  - `TermStoryWorkspace.update_stats_header()` highlight caching
- Updated existing `_compute_highlight_days()` test calls for the new internal signature.
- Added regression coverage for a prolific historical day being outside the visible window.
- Added end-to-end coverage for the actual `days_limit=None` / All History workspace path.
- Removed the obsolete TODO describing the previous limitation.
- Added a comment documenting that the highlight calculation must remain synchronized with the rendered heatmap window.

## All History behavior

`days_limit=None` represents All History for the data scope, so all historical sessions are loaded.

The existing dashboard rendering path resolves this to the existing 90-day rendered window before generating the heatmap. The highlight calculation now uses that same resolved window, ensuring that personal-best highlights correspond to the days actually displayed.

Therefore:

- Historical data remains available to the application.
- The heatmap continues to render its existing 90-day strip.
- A prolific day outside that rendered strip cannot determine the personal-best threshold.
- Recent visible days can correctly receive personal-best highlights.

## 8+ Hour Session Rule

The existing `EIGHT_HOURS_SECONDS` highlighting rule is unchanged.

Sessions lasting at least 8 hours continue to be highlighted independently of the personal-best command-count calculation.

## Tests

### Focused tests

`tests/test_tui_cyberpunk_animations.py`

- 30 passed

Relevant `tests/test_tui.py` tests:

- 5 passed

Coverage includes:

- Personal-best highlighting within a visible window
- Tied personal-best days
- Historical prolific days outside the visible window
- All History workspace behavior
- Highlight cache behavior
- 8-hour session highlighting
- Existing heatmap behavior

`git diff --check` also passes with no whitespace errors.

## Scope

Changes are limited to:

- `termstory/tui.py`
- `tests/test_tui.py`
- `tests/test_tui_cyberpunk_animations.py`

No unrelated modules or systems were modified.