### PR TITLE
feat(models): format multi-day durations with days

### DIFF
--- a/termstory/models.py
+++ b/termstory/models.py
@@ -3,16 +3,25 @@ from datetime import datetime
 from typing import Optional, List, Dict
 
 def format_duration(seconds: int) -> str:
-    """Format duration in seconds to human readable form like 2h 15m, 15m, or 45s"""
+    """Format duration in seconds to human readable form like 1d 2h 15m, 2h 15m, 15m, or 45s.
+
+    Durations of a day or more include a day component and always show the
+    hour part (e.g. "1d 0h"); shorter durations keep their existing format.
+    """
     if seconds <= 0:
         return "0s"
     if seconds < 60:
         return f"{seconds}s"
-    hours = seconds // 3600
+    days = seconds // 86400
+    hours = (seconds % 86400) // 3600
     minutes = (seconds % 3600) // 60
     
     parts = []
-    if hours > 0:
+    if days > 0:
+        parts.append(f"{days}d")
+    # Hours are always shown once days are present ("1d 0h"), but stay
+    # omitted below an hour so sub-day output remains unchanged.
+    if days > 0 or hours > 0:
         parts.append(f"{hours}h")
     if minutes > 0 or not parts:
         parts.append(f"{minutes}m")

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,4 +1,4 @@
-from termstory.models import Command, Session
+from termstory.models import Command, Session, format_duration
 from termstory.session import create_sessions
 
 def test_create_sessions_empty():
@@ -77,3 +77,23 @@ def test_create_sessions_no_cwd_fragmentation():
     
     assert sessions[0].id == 1
     assert len(sessions[0].commands) == 6
+
+def test_format_duration_sub_day_output_unchanged():
+    """Pre-existing sub-24-hour output must remain byte-for-byte unchanged."""
+    assert format_duration(0) == "0s"
+    assert format_duration(-1) == "0s"
+    assert format_duration(45) == "45s"
+    assert format_duration(59) == "59s"
+    assert format_duration(60) == "1m"
+    assert format_duration(3599) == "59m"
+    assert format_duration(3600) == "1h"
+    assert format_duration(3660) == "1h 1m"
+    assert format_duration(86399) == "23h 59m"
+
+def test_format_duration_multi_day():
+    """Issue #447: durations >= 24h render a day component, with hours always shown."""
+    assert format_duration(86400) == "1d 0h"
+    assert format_duration(86401) == "1d 0h"
+    assert format_duration(90061) == "1d 1h 1m"
+    assert format_duration(259200) == "3d 0h"
+    assert format_duration(7 * 86400 + 2 * 3600) == "7d 2h"


### PR DESCRIPTION
Closes #447

## Summary

Updates `format_duration()` to represent durations of 24 hours or more using an explicit day component instead of accumulating all elapsed time into hours.

Previously:

- `86400` → `24h`
- `259200` → `72h`
- `90061` → `25h 1m`

Now:

- `86400` → `1d 0h`
- `259200` → `3d 0h`
- `90061` → `1d 1h 1m`

## Changes

- Added day calculation using 86400-second units.
- Calculate remaining hours from the post-day remainder.
- Preserve the existing minute formatting behavior.
- Ensure hours are explicitly shown when a day component exists, including `0h`.
- Preserved the existing `seconds <= 0` behavior.
- Preserved the existing seconds-only behavior for durations below one minute.
- Updated the `format_duration()` docstring with the new multi-day behavior.
- Added regression coverage for the 24-hour boundary and multi-day durations.
- Added tests confirming existing sub-24-hour output remains unchanged.

## Regression coverage

The tests cover:

- `0` → `0s`
- negative values → `0s`
- `45` → `45s`
- `59` → `59s`
- `60` → `1m`
- `3599` → `59m`
- `3600` → `1h`
- `3660` → `1h 1m`
- `86399` → `23h 59m`
- `86400` → `1d 0h`
- `86401` → `1d 0h`
- `90061` → `1d 1h 1m`
- multiple full days → `Nd 0h`

## Validation

- `pytest tests/test_session.py -v` — 6 passed
- Consumer suites — 110 passed
- `git diff --check` — clean
- No changes made to `termstory/web.py`
- No call-site changes required
- No unrelated production files modified

This is a pure formatting change; the underlying duration values and session calculations are unchanged.