### PR TITLE
fix(reminder): sanitize cluster commands before LLM prompts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ branch on the flag before touching the list.
 secret (`AKIAIO...MPLE`) is not in the captured payload.
 
 Existing reference implementations: `generate_ai_summary()` and `generate_rpg_bio()`
-in `termstory/ai.py`.
+in `termstory/ai.py`, plus `generate_cluster_summary()` in `termstory/reminder.py`.
 
 ## Submitting PRs
 

--- a/termstory/reminder.py
+++ b/termstory/reminder.py
@@ -7,6 +7,7 @@ import sqlite3
 import time
 from typing import List, Dict, Optional, Tuple
 from termstory.config import get_app_dir, load_config
+from termstory.sanitizer import sanitize_session_commands
 
 logger = logging.getLogger(__name__)
 
@@ -259,7 +260,14 @@ def cluster_commands(commands: List[str], threshold: Optional[float] = None) -> 
 
 
 def generate_cluster_summary(commands: List[str]) -> str:
-    """Generate a single-line, high-density summary of a command cluster."""
+    """Generate a single-line, high-density summary of a command cluster.
+
+    Security: commands are sanitized via sanitize_session_commands() before being
+    embedded in the LLM prompt (same contract as generate_ai_summary()). Clusters
+    containing blacklisted commands (vault, aws configure, gh auth, raw token
+    strings, etc.) never reach the LLM; the standard redaction marker is returned
+    instead.
+    """
     from termstory.config import load_config, get_config_value
     config = load_config()
     provider = config.get("active_provider", "disabled")
@@ -274,12 +282,19 @@ def generate_cluster_summary(commands: List[str]) -> str:
             return "Idle session"
         return f"Worked on commands: {', '.join(unique[:3])}"
 
+    # Sanitize before anything reaches the LLM prompt. A blacklisted cluster
+    # (any vault/aws configure/gh auth-style command) never leaves the machine.
+    sanitized_cmds, is_blacklisted = sanitize_session_commands(commands)
+    if is_blacklisted:
+        # sanitized_cmds is None here — never iterate it.
+        return "[REDACTED: Security/Authentication Operations]"
+
     # Query LLM
     from termstory.ai import _send_llm_request
     prompt = (
         "You are a developer memory engine. Summarize the following cluster of raw terminal commands "
         "into a single-line, high-density, tech-dense summary of what the developer was doing (e.g. 'Set up Docker container and verified logs').\n\n"
-        "Commands:\n" + "\n".join(f"- {c}" for c in commands) + "\n\n"
+        "Commands:\n" + "\n".join(f"- {c}" for c in sanitized_cmds) + "\n\n"
         "Return ONLY the single line summary. No markdown formatting, no conversational filler, and no surrounding quotes."
     )
     
@@ -295,9 +310,10 @@ def generate_cluster_summary(commands: List[str]) -> str:
         from rich.markup import escape
         return escape(summary.strip())
     
-    # Fallback if request failed
+    # Fallback if request failed (local string only — still derived from the
+    # sanitized list so raw command text is never reused downstream).
     unique = []
-    for c in commands:
+    for c in sanitized_cmds:
         base = c.split()[0] if c.strip() else ""
         if base and base not in unique:
             unique.append(base)

--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -16,6 +16,7 @@ from termstory.reminder import (
     save_reminders,
     get_reminders_file_path,
     cluster_commands,
+    generate_cluster_summary,
     _DEFAULT_CLUSTERING_THRESHOLD,
     consolidate_sleep_contexts
 )
@@ -534,3 +535,102 @@ def test_consolidate_sleep_contexts_reads_config_once_not_per_chunk(tmp_path, mo
         f"load_config() was called {call_count[0]} times for 3 chunks — "
         "expected exactly 1 (resolved once per run, not once per chunk)"
     )
+
+
+def _patch_cluster_llm(monkeypatch, provider="groq"):
+    """Point generate_cluster_summary at a fake provider and capture the outbound
+    LLM prompt via _send_llm_request — the request boundary it actually uses."""
+    config = {
+        "active_provider": provider,
+        "providers": {
+            provider: {
+                "api_key": "test-key",
+                "api_base_url": "https://api.example.test/v1",
+                "model_name": "test-model",
+            }
+        },
+    }
+    monkeypatch.setattr("termstory.config.load_config", lambda: config)
+
+    calls = []
+
+    def fake_send_llm_request(prompt, *args, **kwargs):
+        calls.append({"prompt": prompt})
+        return "Shipped the feature"
+
+    monkeypatch.setattr("termstory.ai._send_llm_request", fake_send_llm_request)
+    return calls
+
+
+def test_generate_cluster_summary_redacts_secrets_from_llm_prompt(monkeypatch):
+    """Regression test for issue #449: secrets must be scrubbed by
+    sanitize_session_commands() before the cluster prompt reaches the LLM."""
+    calls = _patch_cluster_llm(monkeypatch)
+
+    result = generate_cluster_summary(
+        [
+            "git status",
+            # Not blacklisted (no 'aws configure'), but carries a fake AWS key
+            # that redact_command() must turn into [REDACTED_AWS_KEY].
+            "aws s3 ls --access-key AKIAIOSFODNN7EXAMPLE",
+        ]
+    )
+
+    assert len(calls) == 1
+    sent_prompt = calls[0]["prompt"]
+    assert "AKIAIOSFODNN7EXAMPLE" not in sent_prompt
+    assert "[REDACTED_AWS_KEY]" in sent_prompt
+    assert "git status" in sent_prompt
+    assert result == "Shipped the feature"
+
+
+def test_generate_cluster_summary_blacklisted_commands_never_reach_llm(monkeypatch):
+    """A cluster containing a blacklisted command (e.g. vault) must return the
+    standard redaction marker and must not trigger any LLM request."""
+    calls = _patch_cluster_llm(monkeypatch)
+
+    result = generate_cluster_summary(
+        [
+            "cd project",
+            "vault read secret/data/prod",
+        ]
+    )
+
+    assert result == "[REDACTED: Security/Authentication Operations]"
+    assert calls == []
+
+
+def test_generate_cluster_summary_keeps_normal_commands_in_prompt(monkeypatch):
+    """Ordinary (non-blacklisted) commands must still be summarized by the LLM
+    path with their sanitized text present in the prompt."""
+    calls = _patch_cluster_llm(monkeypatch)
+
+    result = generate_cluster_summary(
+        [
+            "docker compose up -d",
+            "pytest tests/ -q",
+        ]
+    )
+
+    assert len(calls) == 1
+    sent_prompt = calls[0]["prompt"]
+    assert "- docker compose up -d" in sent_prompt
+    assert "- pytest tests/ -q" in sent_prompt
+    assert result == "Shipped the feature"
+
+
+def test_generate_cluster_summary_disabled_provider_stays_local(monkeypatch):
+    """provider == "disabled" keeps the original local fallback behavior: no
+    sanitization/request logic and definitely no LLM call."""
+    config = {"active_provider": "disabled"}
+    monkeypatch.setattr("termstory.config.load_config", lambda: config)
+    calls = []
+    monkeypatch.setattr(
+        "termstory.ai._send_llm_request",
+        lambda *args, **kwargs: calls.append(args),
+    )
+
+    result = generate_cluster_summary(["git status", "docker ps"])
+
+    assert result == "Worked on commands: git, docker"
+    assert calls == []


### PR DESCRIPTION
Closes #449
## Summary

Fixes the reminder LLM path so `generate_cluster_summary()` never embeds raw session commands into an LLM prompt.

### Changes

- Sanitize cluster commands with the existing `sanitize_session_commands()` helper before prompt construction.
- Handle blacklisted commands before iterating over the sanitized command list.
- Return the standard security/authentication redaction marker for blacklisted sessions.
- Ensure the LLM prompt and request-failure fallback use sanitized commands only.
- Preserve the existing disabled-provider behavior.
- Add regression tests covering:
  - secret redaction in the outbound LLM prompt;
  - blacklisted commands being blocked from the LLM;
  - normal commands remaining available for summarization;
  - the disabled-provider path making no LLM request.
- Document `generate_cluster_summary()` as an LLM-facing sanitization path.

### Validation

- `tests/test_reminder.py -k generate_cluster_summary`: 4 passed
- `tests/test_reminder.py` + `tests/test_sanitizer.py`: 61 passed
- `tests/test_ask.py` + `tests/test_ai.py`: 78 passed
- `tests/test_sleep.py`: 4 passed
- `git diff --check`: clean

