### PR TITLE
fix(tags): prevent network utilities from matching debug

### DIFF
--- a/termstory/tags.py
+++ b/termstory/tags.py
@@ -17,7 +17,7 @@ TAG_RULES = {
         "cmd_patterns": [
             r"\bdebug(ger)?\b", r"\bpdb\b", r"\bipdb\b", r"\blldb\b", r"\bgdb\b",
             r"\btrace\b", r"\bvalgrind\b", r"\bstrace\b", r"\bprofile(r)?\b",
-            r"\bpyinstrument\b", r"\bcurl\b", r"\bping\b", r"\bdig\b", r"\bnslookup\b",
+            r"\bpyinstrument\b",
             r"\btcpdump\b", r"\bdoctor\b", r"\bdiagnose\b", r"\bdiagnostic\b",
             r"\bjournalctl\b", r"\bdmesg\b", r"\bdocker logs\b"
         ],

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -32,6 +32,33 @@ def test_compute_tags_from_text():
     # Ordering should be: deploy, debug, setup, test, docs
     assert tags == ["deploy", "setup", "test"]
 
+def test_network_utilities_not_tagged_debug():
+    """Regression test for issue #452: ordinary network utilities must not
+    receive the debug tag. Assertions check 'debug' specifically so another
+    tag cannot mask the result."""
+    for cmd in [
+        "curl https://example.com",
+        "ping 8.8.8.8",
+        "dig example.com",
+        "nslookup example.com",
+    ]:
+        assert "debug" not in compute_tags_from_text([cmd], []), (
+            f"{cmd!r} must not be tagged debug"
+        )
+
+def test_debug_tools_still_tagged_debug():
+    """Regression test for issue #452: removing the bare network-utility
+    patterns must not affect legitimate debugger/profiler commands."""
+    for cmd in [
+        "python3 -m pdb script.py",
+        "gdb ./program",
+        "lldb ./program",
+        "strace ./program",
+    ]:
+        assert "debug" in compute_tags_from_text([cmd], []), (
+            f"{cmd!r} must be tagged debug"
+        )
+
 def test_auto_tag_all_sessions():
     fd, temp_db_path = tempfile.mkstemp()
     os.close(fd)


### PR DESCRIPTION
Closes #452
## Summary

The `debug` tag was incorrectly matching common network utilities such as `curl`, `ping`, `dig`, and `nslookup`.

## Changes

- Removed the four overly broad network-utility patterns from the `debug` command rules.
- Preserved the existing debugger/profiler patterns including `pdb`, `gdb`, `lldb`, `strace`, `valgrind`, and related tools.
- Added regression coverage ensuring:
  - `curl`, `ping`, `dig`, and `nslookup` do not produce the `debug` tag.
  - `pdb`, `gdb`, `lldb`, and `strace` continue to produce the `debug` tag.
- No changes to project detection, database schema, CLI/TUI behavior, or unrelated tag rules.

## Validation

- `pytest tests/test_tags.py -v` — 4 passed
- `git diff --check` — clean
- Final diff limited to:
  - `termstory/tags.py`
  - `tests/test_tags.py`