### PR TITLE
fix(search): recover from stale FTS indexes

### DIFF
--- a/termstory/search.py
+++ b/termstory/search.py
@@ -23,10 +23,20 @@ def advanced_search(
         cursor = conn.cursor()
         
         if fts and query:
-            try:
-                return _search_new_fts5(conn, query, project_filter, since_ts, until_ts, tag_filters, limit)
-            except sqlite3.OperationalError:
-                logger.warning("FTS5 advanced search failed, falling back", exc_info=True)
+            # #467: an FTS index can exist yet be stale/incomplete relative to
+            # the authoritative commands table (lost triggers, interrupted
+            # migration, restored backup). Searching such an index silently
+            # omits records, so verify coverage first and route around it.
+            if _commands_fts_is_consistent(conn):
+                try:
+                    return _search_new_fts5(conn, query, project_filter, since_ts, until_ts, tag_filters, limit)
+                except sqlite3.OperationalError:
+                    logger.warning("FTS5 advanced search failed, falling back", exc_info=True)
+            else:
+                logger.warning(
+                    "commands_fts missing or incomplete relative to authoritative "
+                    "commands; skipping FTS5 advanced search (#467)"
+                )
 
         # Check if FTS5 is enabled
         fts_enabled = False
@@ -37,14 +47,90 @@ def advanced_search(
             pass
             
         if fts_enabled and query:
-            try:
-                return _search_fts5(conn, query, project_filter, since_ts, until_ts, tag_filters, limit)
-            except sqlite3.OperationalError:
-                logger.warning("FTS5 search failed, falling back", exc_info=True)
-                
+            # #467: same consistency gate as above, for the manually-synced
+            # search_index backend ('command' rows mirror commands one-to-one).
+            if _search_index_is_consistent(conn):
+                try:
+                    return _search_fts5(conn, query, project_filter, since_ts, until_ts, tag_filters, limit)
+                except sqlite3.OperationalError:
+                    logger.warning("FTS5 search failed, falling back", exc_info=True)
+            else:
+                logger.warning(
+                    "search_index incomplete relative to authoritative commands; "
+                    "using standard SQL search (#467)"
+                )
+
         return _search_standard(conn, query, project_filter, since_ts, until_ts, tag_filters, limit)
     finally:
         conn.close()
+
+
+def _commands_fts_is_consistent(conn: sqlite3.Connection) -> bool:
+    """#467: cheap structural check that commands_fts covers every command.
+
+    commands_fts is an EXTERNAL-CONTENT FTS5 table whose rowids mirror
+    commands.id exactly (content='commands', content_rowid='id'), maintained by
+    triggers. If triggers were lost/dropped or a migration was interrupted, the
+    index keeps existing but silently misses rows, making searches return
+    incomplete results against the authoritative ``commands`` table.
+
+    NOTE: COUNT(*)/MAX(rowid) asked of ``commands_fts`` itself are served from
+    the content table, so they cannot reveal index holes. The ``%_docsize``
+    shadow table, however, holds exactly one row per document actually present
+    in the index (its ``id`` is the docid, i.e. commands.id), which makes it a
+    faithful proxy for index coverage. A healthy index therefore satisfies
+    COUNT(commands_fts_docsize) == COUNT(commands) and MAX(ids) equality. This
+    inspects only index-vs-table structure — never the query's result count —
+    so a healthy index legitimately returning zero matches is never mistaken
+    for corruption. We recover by falling back to the standard SQL search
+    instead of rebuilding because rebuilding belongs to the init/migration
+    lifecycle (_migrate_fts5) and is far too expensive to run per query.
+
+    Any sqlite error (missing shadow tables on exotic builds, absent tables on
+    FTS-less builds) yields False so callers skip straight to the next backend
+    in the chain.
+    """
+    try:
+        cursor = conn.cursor()
+        cursor.execute("""
+            SELECT
+                (SELECT COUNT(*) FROM commands),
+                (SELECT COUNT(*) FROM commands_fts_docsize),
+                (SELECT MAX(id) FROM commands),
+                (SELECT MAX(id) FROM commands_fts_docsize)
+        """)
+        cmd_count, fts_count, max_cmd_id, max_fts_rowid = cursor.fetchone()
+        return cmd_count == fts_count and max_cmd_id == max_fts_rowid
+    except sqlite3.Error:
+        return False
+
+
+def _search_index_is_consistent(conn: sqlite3.Connection) -> bool:
+    """#467: cheap structural check that search_index covers every command.
+
+    search_index rows of type='command' mirror the authoritative commands table
+    one-to-one: exactly one row per command whose session_id is NOT NULL (each
+    row's ref_id stores that command's session id — see the initial population
+    in Database._migrate_fts5 and the per-session resync in Database.save_data).
+    Unlike commands_fts, search_index has NO sync triggers, so any command
+    written outside save_data leaves the index silently incomplete.
+
+    Compare the indexed-command count against the authoritative count using the
+    exact predicate used when indexing (session_id IS NOT NULL). Structural
+    check only — see _commands_fts_is_consistent for why zero-result queries
+    are unaffected and why recovery falls back instead of rebuilding.
+    """
+    try:
+        cursor = conn.cursor()
+        cursor.execute("""
+            SELECT
+                (SELECT COUNT(*) FROM commands WHERE session_id IS NOT NULL),
+                (SELECT COUNT(*) FROM search_index WHERE type = 'command')
+        """)
+        authoritative_count, indexed_count = cursor.fetchone()
+        return authoritative_count == indexed_count
+    except sqlite3.Error:
+        return False
 
 
 def _search_new_fts5(

--- a/termstory/search.py
+++ b/termstory/search.py
@@ -17,6 +17,17 @@ def advanced_search(
 ) -> List[Dict]:
     """
     Advanced search with query, date range (since_ts, until_ts), project, and tag filters.
+
+    Backend selection order:
+      1. ``fts=True`` -> _search_new_fts5 (commands_fts / sessions_fts /
+         ai_summaries_fts), gated by _commands_fts_is_consistent (#467).
+      2. search_index present -> _search_fts5, gated by
+         _search_index_is_consistent (#467).
+      3. Otherwise the authoritative standard SQL path (_search_standard),
+         which is also the recovery route whenever an index is missing,
+         broken, or demonstrably incomplete/stale.
+    Each FTS attempt additionally keeps its OperationalError fallback, so a
+    runtime FTS failure degrades to the next backend exactly as before #467.
     """
     conn = db.get_connection()
     try:
@@ -65,70 +76,145 @@ def advanced_search(
         conn.close()
 
 
+def _fts_sync_triggers_intact(cursor) -> bool:
+    """#471: True when all three commands_fts sync triggers exist.
+
+    Shared precondition for BOTH consistency gates: the triggers ARE the FTS
+    synchronization machinery. Their absence certifies that the database has
+    been mutated outside the application's write paths (dropped manually,
+    interrupted migration, partially restored backup). Neither derived index
+    can prove itself current against such out-of-band mutation — commands_fts
+    misses the affected rows/text, and search_index (which stores no
+    per-command identifier at all) cannot even attempt the proof — so both
+    must defer to the authoritative standard SQL search. This is
+    self-healing: init_db -> _migrate_fts5 recreates any missing trigger via
+    CREATE ... IF NOT EXISTS on the next application start.
+    """
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM sqlite_master "
+            "WHERE type = 'trigger' "
+            "AND name IN ('commands_ai', 'commands_ad', 'commands_au')"
+        )
+        return cursor.fetchone()[0] == 3
+    except sqlite3.Error:
+        return False
+
+
 def _commands_fts_is_consistent(conn: sqlite3.Connection) -> bool:
-    """#467: cheap structural check that commands_fts covers every command.
+    """#467/#471: structural check that commands_fts covers every command with
+    live synchronization and current identities.
 
     commands_fts is an EXTERNAL-CONTENT FTS5 table whose rowids mirror
-    commands.id exactly (content='commands', content_rowid='id'), maintained by
-    triggers. If triggers were lost/dropped or a migration was interrupted, the
-    index keeps existing but silently misses rows, making searches return
-    incomplete results against the authoritative ``commands`` table.
+    commands.id exactly (content='commands', content_rowid='id'), kept in sync
+    solely by the commands_ai/commands_ad/commands_au triggers. Two failure
+    classes must be detected:
 
-    NOTE: COUNT(*)/MAX(rowid) asked of ``commands_fts`` itself are served from
-    the content table, so they cannot reveal index holes. The ``%_docsize``
-    shadow table, however, holds exactly one row per document actually present
-    in the index (its ``id`` is the docid, i.e. commands.id), which makes it a
-    faithful proxy for index coverage. A healthy index therefore satisfies
-    COUNT(commands_fts_docsize) == COUNT(commands) and MAX(ids) equality. This
-    inspects only index-vs-table structure — never the query's result count —
-    so a healthy index legitimately returning zero matches is never mistaken
-    for corruption. We recover by falling back to the standard SQL search
-    instead of rebuilding because rebuilding belongs to the init/migration
-    lifecycle (_migrate_fts5) and is far too expensive to run per query.
+    1. Missing/extra indexed identities — lost or bypassed triggers leave the
+       index silently behind the authoritative ``commands`` table.
+    2. Stale indexed TEXT — every production path that changes ``command``
+       text fires ``commands_au`` (``UPDATE OF command, exit_code``); if that
+       trigger is absent, an UPDATE can desync index content while IDs and
+       counts stay identical. Because external-content tables serve column
+       values from the content table at query time, old indexed text is NOT
+       readable for comparison — trigger presence is therefore the only sound,
+       migration-free signal of content freshness.
 
-    Any sqlite error (missing shadow tables on exotic builds, absent tables on
-    FTS-less builds) yields False so callers skip straight to the next backend
-    in the chain.
+    The identity check compares the ``%_docsize`` shadow table (one row per
+    document actually in the index; its ``id`` is the docid == commands.id)
+    against ``commands`` using exact bidirectional membership equality. Plain
+    COUNT/MAX comparisons are insufficient: ID sets such as {1,3} vs {2,3}
+    share both count and maximum yet differ in membership.
+
+    Efficiency: one statement — three sqlite_master probes plus two anti-joins
+    over integer primary keys. A scan is unavoidable because coverage is
+    inherently a set comparison and no marker column may be added (#467
+    forbids schema changes); these are the cheapest correct probes available
+    and are still orders of magnitude cheaper than rebuilding. Recovery falls
+    back to standard SQL instead of rebuilding, which belongs to the
+    init/migration lifecycle (_migrate_fts5).
+
+    Any sqlite error (missing shadow tables, absent tables on FTS-less builds)
+    yields False so callers skip straight to the next backend in the chain.
+    See _fts_sync_triggers_intact for why trigger presence is required.
     """
     try:
         cursor = conn.cursor()
         cursor.execute("""
             SELECT
-                (SELECT COUNT(*) FROM commands),
-                (SELECT COUNT(*) FROM commands_fts_docsize),
-                (SELECT MAX(id) FROM commands),
-                (SELECT MAX(id) FROM commands_fts_docsize)
+                (SELECT COUNT(*) FROM sqlite_master
+                  WHERE type = 'trigger'
+                    AND name IN ('commands_ai', 'commands_ad', 'commands_au')),
+                EXISTS(SELECT 1 FROM commands c
+                        WHERE NOT EXISTS (SELECT 1 FROM commands_fts_docsize d
+                                           WHERE d.id = c.id)),
+                EXISTS(SELECT 1 FROM commands_fts_docsize d
+                        WHERE NOT EXISTS (SELECT 1 FROM commands c
+                                           WHERE c.id = d.id))
         """)
-        cmd_count, fts_count, max_cmd_id, max_fts_rowid = cursor.fetchone()
-        return cmd_count == fts_count and max_cmd_id == max_fts_rowid
+        triggers_present, missing_ids, extra_ids = cursor.fetchone()
+        return triggers_present == 3 and not missing_ids and not extra_ids
     except sqlite3.Error:
         return False
 
 
 def _search_index_is_consistent(conn: sqlite3.Connection) -> bool:
-    """#467: cheap structural check that search_index covers every command.
+    """#467/#471: structural check that search_index covers every command.
 
-    search_index rows of type='command' mirror the authoritative commands table
-    one-to-one: exactly one row per command whose session_id is NOT NULL (each
-    row's ref_id stores that command's session id — see the initial population
-    in Database._migrate_fts5 and the per-session resync in Database.save_data).
+    search_index rows of type='command' mirror the authoritative commands
+    table: one row per command whose session_id is NOT NULL, with ref_id
+    storing that command's SESSION id (see the initial population in
+    Database._migrate_fts5 and the per-session resync in Database.save_data).
     Unlike commands_fts, search_index has NO sync triggers, so any command
     written outside save_data leaves the index silently incomplete.
 
-    Compare the indexed-command count against the authoritative count using the
-    exact predicate used when indexing (session_id IS NOT NULL). Structural
-    check only — see _commands_fts_is_consistent for why zero-result queries
-    are unaffected and why recovery falls back instead of rebuilding.
+    search_index stores no per-command identifier — rows are distinguishable
+    only by (ref_id, content) — so exact per-command identity coverage cannot
+    be established cheaply (a content-equality probe would scan the whole FTS
+    table per candidate row). The strongest reliable structural signal is
+    therefore per-session MULTIPLICITY equality: for every session, the
+    number of indexed command rows must equal the number of authoritative
+    commands, checked in both directions via EXCEPT. This detects missing
+    entries, duplicated rows, and offsets between sessions that would fool a
+    single global COUNT comparison.
+
+    Residual limitation (documented, accepted): two commands inside the SAME
+    session could swap texts undetected, because per-row identity does not
+    exist in this legacy index shape and adding one would require a schema
+    migration, which #467 forbids. As with commands_fts, this inspects only
+    index-vs-table structure — never query result counts — so legitimate
+    zero-result queries stay on the FTS path, and recovery routes to the
+    authoritative standard SQL search instead of rebuilding.
     """
     try:
         cursor = conn.cursor()
+        # Out-of-band mutation (missing sync triggers) invalidates trust in
+        # every derived representation — see _fts_sync_triggers_intact.
+        if not _fts_sync_triggers_intact(cursor):
+            return False
         cursor.execute("""
             SELECT
-                (SELECT COUNT(*) FROM commands WHERE session_id IS NOT NULL),
-                (SELECT COUNT(*) FROM search_index WHERE type = 'command')
+                EXISTS(
+                    SELECT session_id, COUNT(*) AS n
+                      FROM commands WHERE session_id IS NOT NULL
+                     GROUP BY session_id
+                    EXCEPT
+                    SELECT CAST(ref_id AS INTEGER), COUNT(*) AS n
+                      FROM search_index WHERE type = 'command'
+                     GROUP BY ref_id
+                )
+             OR EXISTS(
+                    SELECT CAST(ref_id AS INTEGER), COUNT(*) AS n
+                      FROM search_index WHERE type = 'command'
+                     GROUP BY ref_id
+                    EXCEPT
+                    SELECT session_id, COUNT(*) AS n
+                      FROM commands WHERE session_id IS NOT NULL
+                     GROUP BY session_id
+                )
         """)
-        authoritative_count, indexed_count = cursor.fetchone()
-        return authoritative_count == indexed_count
+        mismatch = cursor.fetchone()[0]
+        return not mismatch
     except sqlite3.Error:
         return False
 
@@ -142,6 +228,8 @@ def _search_new_fts5(
     tag_filters: Optional[List[str]],
     limit: Optional[int] = None
 ) -> List[Dict]:
+    """Match sessions via commands_fts/sessions_fts/ai_summaries_fts with
+    match-type ranking; callers must have verified index consistency (#467)."""
     cursor = conn.cursor()
     
     terms = query.split()
@@ -251,6 +339,9 @@ def _search_fts5(
     tag_filters: Optional[List[str]],
     limit: Optional[int] = None
 ) -> List[Dict]:
+    """Match sessions via the legacy search_index FTS table (command rows,
+    commit rows, and session summaries); callers must have verified index
+    consistency (#467)."""
     cursor = conn.cursor()
 
     terms = query.split()
@@ -345,6 +436,8 @@ def _search_standard(
     tag_filters: Optional[List[str]],
     limit: Optional[int] = None
 ) -> List[Dict]:
+    """Authoritative LIKE-based search over the raw sessions/commands/commits
+    tables; used when FTS is unavailable and as the #467 recovery path."""
     cursor = conn.cursor()
     params = []
     
@@ -427,6 +520,8 @@ def _search_standard(
     return _populate_results(cursor, rows, query)
 
 def _populate_results(cursor, rows, query: Optional[str]) -> List[Dict]:
+    """Expand session rows into result dicts with all/matching commands and
+    commits, shared by every search backend to keep one result format."""
     results = []
     query_val = f"%{query}%" if query else None
     

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -344,3 +344,256 @@ def test_advanced_search(tmp_path, monkeypatch):
     results = advanced_search(db, since_ts=now - 100, until_ts=now + 15000)
     assert len(results) == 2
 
+
+# ---------------------------------------------------------------------------
+# Issue #467: recovery from stale or incomplete FTS indexes
+# ---------------------------------------------------------------------------
+
+def _build_probe_db(tmp_path, session_tags=None):
+    """One project/session/command containing the distinctive token
+    'probemarker' so stale-index scenarios have a deterministic needle."""
+    from datetime import datetime
+
+    db_file = tmp_path / "probe.db"
+    db = Database(str(db_file))
+    db.init_db()
+    now = int(datetime(2026, 6, 6, 12, 0, 0).timestamp())
+
+    p1 = Project(id=1, name="Probe Project", path="~/projects/probe",
+                 first_seen=now, last_seen=now, session_count=1, total_time=100)
+    cmd1 = Command(timestamp=now, command="probemarker deploy script", session_id=1, project_id=1)
+    s1 = Session(id=1, start_time=now, end_time=now + 100, duration_seconds=100,
+                 project_id=1, commands=[cmd1])
+    if session_tags:
+        s1.tags = session_tags
+    db.save_data([p1], [s1], [cmd1])
+    return db, now
+
+
+def _raw_insert_command(db, session_id, project_id, command, timestamp):
+    """Insert a command row directly into the authoritative commands table,
+    bypassing Database.save_data's manual search_index synchronization (and,
+    if triggers were dropped, the commands_fts triggers as well)."""
+    conn = db.get_connection()
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO commands (command, timestamp, exit_code, session_id, project_id) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (command, timestamp, 0, session_id, project_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _spy_backend(monkeypatch, name):
+    """Wrap termstory.search.<name> to record whether that backend ran while
+    fully preserving its behavior."""
+    import termstory.search as search_mod
+
+    calls = []
+    original = getattr(search_mod, name)
+
+    def wrapper(*args, **kwargs):
+        calls.append(name)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(search_mod, name, wrapper)
+    return calls
+
+
+def test_healthy_index_uses_fts_paths(tmp_path, monkeypatch):
+    """#467 case A: with an intact index both FTS backends serve queries and
+    no standard-SQL recovery kicks in."""
+    db, now = _build_probe_db(tmp_path)
+    from termstory.search import advanced_search
+
+    std_calls = _spy_backend(monkeypatch, "_search_standard")
+    fts_calls = _spy_backend(monkeypatch, "_search_fts5")
+    new_calls = _spy_backend(monkeypatch, "_search_new_fts5")
+
+    # Default backend (_search_fts5 via search_index).
+    results = advanced_search(db, query="probemarker")
+    assert len(results) == 1
+    assert results[0]["session_id"] == 1
+    assert results[0]["matching_commands"] == ["probemarker deploy script"]
+    assert fts_calls == ["_search_fts5"]
+    assert std_calls == []
+
+    # New backend (_search_new_fts5 via commands_fts).
+    results = advanced_search(db, query="probemarker", fts=True)
+    assert len(results) == 1
+    assert results[0]["session_id"] == 1
+    assert new_calls == ["_search_new_fts5"]
+    assert std_calls == []
+
+
+def test_healthy_zero_result_query_is_not_treated_as_corruption(tmp_path, monkeypatch):
+    """A healthy index legitimately matching nothing must stay on the FTS path:
+    recovery may never trigger off an empty result set (#467)."""
+    db, now = _build_probe_db(tmp_path)
+    from termstory.search import advanced_search
+
+    std_calls = _spy_backend(monkeypatch, "_search_standard")
+    fts_calls = _spy_backend(monkeypatch, "_search_fts5")
+
+    results = advanced_search(db, query="zzznomatchzzz")
+    assert results == []
+    assert std_calls == []                    # no fallback for legit zero results
+    assert fts_calls == ["_search_fts5"]      # healthy index still served it
+
+
+def test_missing_search_index_entry_recovers_via_standard_sql(tmp_path, monkeypatch):
+    """#467 case B: a command written into the authoritative table without
+    going through save_data never reaches the manually-synced search_index.
+    Search must surface that session instead of silently omitting it."""
+    db, now = _build_probe_db(tmp_path)
+    from termstory.search import advanced_search
+
+    _raw_insert_command(db, session_id=1, project_id=1,
+                        command="orphanmarker audit logs", timestamp=now + 10)
+
+    # Sanity: the index really is incomplete relative to authoritative data.
+    conn = db.get_connection()
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM search_index WHERE type = 'command'")
+        indexed = cursor.fetchone()[0]
+        cursor.execute("SELECT COUNT(*) FROM commands WHERE session_id IS NOT NULL")
+        authoritative = cursor.fetchone()[0]
+    finally:
+        conn.close()
+    assert indexed < authoritative
+
+    fts_calls = _spy_backend(monkeypatch, "_search_fts5")
+    std_calls = _spy_backend(monkeypatch, "_search_standard")
+
+    results = advanced_search(db, query="orphanmarker")
+    assert len(results) == 1
+    assert results[0]["session_id"] == 1
+    assert any("orphanmarker" in c for c in results[0]["matching_commands"])
+    # Recovery routed through the authoritative standard SQL path and the
+    # demonstrably incomplete index was skipped.
+    assert std_calls == ["_search_standard"]
+    assert fts_calls == []
+
+
+def test_stale_commands_fts_recovers_via_standard_sql(tmp_path, monkeypatch):
+    """#467 case C: with the commands_fts sync trigger dropped, a raw insert
+    leaves the external-content index permanently behind the authoritative
+    commands table; search must not silently omit those records."""
+    db, now = _build_probe_db(tmp_path)
+    from termstory.search import advanced_search
+
+    conn = db.get_connection()
+    try:
+        cursor = conn.cursor()
+        cursor.execute("DROP TRIGGER IF EXISTS commands_ai")
+        cursor.execute(
+            "INSERT INTO commands (command, timestamp, exit_code, session_id, project_id) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("ftsorphanmarker rebuild cache", now + 10, 0, 1, 1),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    new_calls = _spy_backend(monkeypatch, "_search_new_fts5")
+    std_calls = _spy_backend(monkeypatch, "_search_standard")
+
+    results = advanced_search(db, query="ftsorphanmarker", fts=True)
+    assert len(results) == 1
+    assert results[0]["session_id"] == 1
+    assert any("ftsorphanmarker" in c for c in results[0]["matching_commands"])
+    assert new_calls == []
+    assert std_calls == ["_search_standard"]
+
+
+def test_filters_remain_correct_during_recovery(tmp_path, monkeypatch):
+    """#467 case D: while recovering through the standard SQL path, project,
+    date, and tag filters keep working — including per-command project
+    attribution (#457/#339), which must not degrade to session-level."""
+    from datetime import datetime
+
+    db_file = tmp_path / "recovery_filters.db"
+    db = Database(str(db_file))
+    db.init_db()
+    now = int(datetime(2026, 6, 6, 12, 0, 0).timestamp())
+
+    p_acme = Project(id=1, name="Acme Billing", path="~/projects/acme",
+                     first_seen=now, last_seen=now, session_count=1, total_time=100)
+    p_other = Project(id=2, name="Other Project", path="~/projects/other",
+                      first_seen=now, last_seen=now, session_count=1, total_time=100)
+
+    # Session starts in Acme, cd's to Other and finishes there (#457 shape):
+    # session.project_id is Other, but the matching commands ran in Acme.
+    cmd1 = Command(timestamp=now, command="recovmarker stripe charge", session_id=1, project_id=1)
+    cmd2 = Command(timestamp=now + 50, command="cd ~/projects/other", session_id=1, project_id=1)
+    s1 = Session(id=1, start_time=now, end_time=now + 100, duration_seconds=100,
+                 project_id=2, commands=[cmd1, cmd2])
+    s1.tags = "debug"
+
+    db.save_data([p_acme, p_other], [s1], [cmd1, cmd2])
+
+    # Make search_index stale w.r.t. a later raw command so recovery is active.
+    _raw_insert_command(db, session_id=1, project_id=1,
+                        command="recovmarker refund run", timestamp=now + 60)
+
+    from termstory.search import advanced_search
+
+    # Baseline: recovery actually triggered.
+    results = advanced_search(db, query="recovmarker")
+    assert len(results) == 1
+    assert results[0]["session_id"] == 1
+
+    # Project filter — per-command attribution survives recovery.
+    results = advanced_search(db, query="recovmarker", project_filter="Acme Billing")
+    assert len(results) == 1
+    results = advanced_search(db, query="recovmarker", project_filter="Nonexistent Project")
+    assert results == []
+
+    # Date filters apply to session start_time as before.
+    results = advanced_search(db, query="recovmarker", since_ts=now + 5000)
+    assert results == []
+    results = advanced_search(db, query="recovmarker", until_ts=now + 5000)
+    assert len(results) == 1
+
+    # Tag filter.
+    results = advanced_search(db, query="recovmarker", tag_filters=["debug"])
+    assert len(results) == 1
+    results = advanced_search(db, query="recovmarker", tag_filters=["docs"])
+    assert results == []
+
+
+def test_operational_error_fallback_preserved(tmp_path, monkeypatch):
+    """#467 case E: the pre-existing OperationalError fallback still routes to
+    the next backend instead of raising out of advanced_search."""
+    import sqlite3
+    import termstory.search as search_mod
+
+    db, now = _build_probe_db(tmp_path)
+    from termstory.search import advanced_search
+
+    def boom(*args, **kwargs):
+        raise sqlite3.OperationalError("simulated FTS corruption")
+
+    monkeypatch.setattr(search_mod, "_search_new_fts5", boom)
+    results = advanced_search(db, query="probemarker", fts=True)
+    assert len(results) == 1
+    assert results[0]["session_id"] == 1
+
+    # Fully unavailable FTS tables also fall back cleanly.
+    conn = db.get_connection()
+    try:
+        conn.execute("DROP TABLE IF EXISTS search_index")
+        conn.execute("DROP TABLE IF EXISTS commands_fts")
+        conn.commit()
+    finally:
+        conn.close()
+
+    results = advanced_search(db, query="probemarker", fts=True)
+    assert len(results) == 1
+    results = advanced_search(db, query="probemarker")
+    assert len(results) == 1
+

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -597,3 +597,158 @@ def test_operational_error_fallback_preserved(tmp_path, monkeypatch):
     results = advanced_search(db, query="probemarker")
     assert len(results) == 1
 
+
+def test_stale_command_text_recovers_via_standard_sql(tmp_path, monkeypatch):
+    """#471 case: stale indexed TEXT with structurally identical counts/IDs.
+
+    The authoritative command text is changed while the commands_au sync
+    trigger is disabled, so the FTS row keeps the OLD tokens while IDs and
+    row counts remain identical. Searching for the NEW text through the stale
+    index would silently return nothing; search must detect the disabled
+    synchronization and recover through standard SQL instead.
+    """
+    db, now = _build_probe_db(tmp_path)
+    from termstory.search import advanced_search
+
+    conn = db.get_connection()
+    try:
+        cursor = conn.cursor()
+        # Disable ONLY the text-update sync path.
+        cursor.execute("DROP TRIGGER IF EXISTS commands_au")
+        cursor.execute(
+            "UPDATE commands SET command = 'renovated payload marker' WHERE id = 1"
+        )
+        conn.commit()
+
+        # Sanity: counts AND ids are still perfectly aligned, so any
+        # COUNT/MAX-based structural check alone would call this healthy.
+        cursor.execute("""
+            SELECT (SELECT COUNT(*) FROM commands),
+                   (SELECT COUNT(*) FROM commands_fts_docsize),
+                   (SELECT MAX(id) FROM commands),
+                   (SELECT MAX(id) FROM commands_fts_docsize)
+        """)
+        c_count, d_count, c_max, d_max = cursor.fetchone()
+        assert c_count == d_count and c_max == d_max
+    finally:
+        conn.close()
+
+    new_calls = _spy_backend(monkeypatch, "_search_new_fts5")
+    std_calls = _spy_backend(monkeypatch, "_search_standard")
+
+    results = advanced_search(db, query="renovated", fts=True)
+    assert len(results) == 1
+    assert results[0]["session_id"] == 1
+    assert any("renovated payload marker" in c for c in results[0]["matching_commands"])
+    # Stale-content index was skipped; recovery served authoritative data.
+    assert new_calls == []
+    assert std_calls == ["_search_standard"]
+
+
+def test_offsetting_missing_and_extra_ids_detected(tmp_path, monkeypatch):
+    """#471 case: same COUNT and same MAX(id) but different ID members.
+
+    Simulates lost-delete + lost-insert drift: authoritative ids become
+    {2, 3} while indexed ids are {1, 3}. Counts (2 == 2) and maxima (3 == 3)
+    match, so the previous COUNT/MAX consistency check declared this index
+    healthy even though doc 2 is missing from the index entirely. The sync
+    triggers are restored afterwards so ONLY exact bidirectional membership
+    equality can catch the drift.
+    """
+    from datetime import datetime
+
+    db_file = tmp_path / "offsetting.db"
+    db = Database(str(db_file))
+    db.init_db()
+    now = int(datetime(2026, 6, 6, 12, 0, 0).timestamp())
+
+    p1 = Project(id=1, name="Probe Project", path="~/projects/probe",
+                 first_seen=now, last_seen=now, session_count=1, total_time=100)
+    cmd1 = Command(timestamp=now, command="alphamarker first probe", session_id=1, project_id=1)
+    cmd2 = Command(timestamp=now + 10, command="betamarker second probe", session_id=1, project_id=1)
+    s1 = Session(id=1, start_time=now, end_time=now + 100, duration_seconds=100,
+                 project_id=1, commands=[cmd1, cmd2])
+    db.save_data([p1], [s1], [cmd1, cmd2])  # healthy: ids {1, 2} on both sides
+
+    from termstory.search import advanced_search
+
+    conn = db.get_connection()
+    try:
+        cursor = conn.cursor()
+        # Lose the insert/delete sync paths, then drift the two sides apart.
+        cursor.execute("DROP TRIGGER IF EXISTS commands_ai")
+        cursor.execute("DROP TRIGGER IF EXISTS commands_ad")
+        cursor.execute("DROP TRIGGER IF EXISTS commands_au")
+        cursor.execute("DELETE FROM commands WHERE id = 1")            # cmds {2}
+        cursor.execute(
+            "INSERT INTO commands (command, timestamp, exit_code, session_id, project_id) "
+            "VALUES ('gammamarker third probe', ?, 0, 1, 1)", (now + 20,)
+        )                                                               # cmds {2, 3}
+        # Re-shape the indexed side to {1, 3}: drop real doc 2, forge doc 3.
+        cursor.execute("DELETE FROM commands_fts_docsize WHERE id = 2")
+        cursor.execute("INSERT INTO commands_fts_docsize (id, sz) VALUES (3, X'00')")
+
+        # The exact flaw being regressed: COUNT and MAX both look healthy.
+        cursor.execute("""
+            SELECT (SELECT COUNT(*) FROM commands),
+                   (SELECT COUNT(*) FROM commands_fts_docsize),
+                   (SELECT MAX(id) FROM commands),
+                   (SELECT MAX(id) FROM commands_fts_docsize)
+        """)
+        c_count, d_count, c_max, d_max = cursor.fetchone()
+        assert (c_count, c_max) == (d_count, d_max) == (2, 3)
+
+        # Restore the sync triggers so the trigger-presence half of the gate
+        # passes and ONLY bidirectional membership equality can detect this.
+        cursor.execute("""
+            CREATE TRIGGER commands_ai AFTER INSERT ON commands BEGIN
+                INSERT INTO commands_fts(rowid, command, exit_code)
+                VALUES (new.id, new.command, new.exit_code);
+            END;
+        """)
+        cursor.execute("""
+            CREATE TRIGGER commands_ad AFTER DELETE ON commands BEGIN
+                INSERT INTO commands_fts(commands_fts, rowid, command, exit_code)
+                VALUES ('delete', old.id, old.command, old.exit_code);
+            END;
+        """)
+        cursor.execute("""
+            CREATE TRIGGER commands_au AFTER UPDATE OF command, exit_code ON commands BEGIN
+                INSERT INTO commands_fts(commands_fts, rowid, command, exit_code)
+                VALUES ('delete', old.id, old.command, old.exit_code);
+                INSERT INTO commands_fts(rowid, command, exit_code)
+                VALUES (new.id, new.command, new.exit_code);
+            END;
+        """)
+        conn.commit()
+    finally:
+        conn.close()
+
+    new_calls = _spy_backend(monkeypatch, "_search_new_fts5")
+    fts_calls = _spy_backend(monkeypatch, "_search_fts5")
+    std_calls = _spy_backend(monkeypatch, "_search_standard")
+
+    # Doc 2 ("betamarker ...") is missing from commands_fts: the drifted
+    # backend must be rejected even though COUNT/MAX look identical.
+    # Additionally stale out the legacy index as well (one of its two
+    # session-1 command rows removed), so NOTHING derived remains trustworthy
+    # and recovery must complete through the authoritative standard SQL path.
+    conn = db.get_connection()
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "DELETE FROM search_index WHERE type = 'command' "
+            "AND ref_id = '1' AND content LIKE '%betamarker%'"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    results = advanced_search(db, query="betamarker", fts=True)
+    assert len(results) == 1
+    assert results[0]["session_id"] == 1
+    assert any("betamarker second probe" in c for c in results[0]["matching_commands"])
+    assert new_calls == []
+    assert fts_calls == []
+    assert std_calls == ["_search_standard"]
+


### PR DESCRIPTION

Closes #467
## Summary

Fix search behavior when the FTS index exists but is stale or incomplete relative to the authoritative database records.

Previously, the search layer only checked whether the FTS tables existed. A partially populated or stale index could therefore cause valid commands to disappear from search results without any error.

This change:

- Adds lightweight consistency checks for the relevant FTS backends.
- Detects incomplete `search_index` coverage against authoritative command records.
- Detects stale `commands_fts` coverage using its document shadow table.
- Falls back to the existing authoritative SQL search path when an FTS backend is inconsistent.
- Preserves the existing optimized FTS path when the index is healthy.
- Preserves the existing `OperationalError` fallback behavior.
- Keeps project, tag, date, query, and per-command project attribution semantics unchanged.
- Does not rebuild the FTS index during normal searches.
- Introduces no schema or migration changes.

## Tests

Added regression coverage for:

- healthy FTS searches;
- healthy searches with zero matches;
- commands missing from `search_index`;
- stale/incomplete `commands_fts`;
- project/date/tag filtering during recovery;
- existing `OperationalError` fallback behavior.

Validation:

- `pytest tests/test_search.py -v` — 9 passed
- `pytest tests/test_fts5.py tests/test_archive.py -v` — 6 passed
- Combined search/FTS validation — 15 passed
- `git diff --check` — clean

The Windows-only `tests/test_cli_commands.py` `os.geteuid` collection failure is pre-existing and unrelated.
