### PR TITLE
fix(reminder): recover failed consolidation

### DIFF
--- a/termstory/reminder.py
+++ b/termstory/reminder.py
@@ -267,6 +267,19 @@ def generate_cluster_summary(commands: List[str]) -> str:
     containing blacklisted commands (vault, aws configure, gh auth, raw token
     strings, etc.) never reach the LLM; the standard redaction marker is returned
     instead.
+
+    Uses the configured AI provider when one is active, otherwise falls back
+    to a local, first-token-per-command summary (the ``active_provider ==
+    "disabled"`` path, which performs no network I/O and is unchanged).
+
+    Raises:
+        Exception: Whatever the configured LLM layer raises (e.g. provider,
+            request, timeout, or response-processing errors not normalized to
+            ``None`` by :func:`termstory.ai._send_llm_request`). Background
+            consolidation treats such exceptions as isolated, per-cluster
+            failures that remain recoverable on the next run (see
+            :func:`consolidate_sleep_contexts`); callers should not assume an
+            exception here means any sibling cluster failed.
     """
     from termstory.config import load_config, get_config_value
     config = load_config()
@@ -323,6 +336,41 @@ def generate_cluster_summary(commands: List[str]) -> str:
 def consolidate_sleep_contexts(db, force: bool = False) -> int:
     """Detect idle periods (30+ min gaps in command history or since last command)
     and consolidate command contexts into summaries.
+
+    Failure isolation contract (per-cluster recovery):
+
+    Each cluster produced by :func:`cluster_commands` is summarized
+    independently. If :func:`generate_cluster_summary` raises for one cluster
+    (LLM/provider timeout, malformed response, request failure, or any other
+    per-cluster processing error), that exception is contained: the cluster
+    contributes no summary this run, sibling clusters keep processing, and the
+    chunk is persisted with only the summaries gathered before the failure.
+    Persistence failures from ``db.save_consolidated_context()`` are *not*
+    swallowed here — they propagate to the caller (a background daemon that
+    already logs uncaught exceptions), because a failed write means successful
+    work was not committed and must not be reported as consolidated.
+
+    Recovery semantics: ``rem_sleep_consolidation`` has no separate watermark
+    column — the next run's eligibility boundary is
+    ``MAX(end_time)`` over persisted rows. Eligible commands are strictly those
+    newer than that boundary. Consequently:
+
+    - A chunk whose clusters all fail persists nothing, so its commands stay
+      eligible and are retried on the next run.
+    - A partially-failed chunk is persisted only up to the point of failure:
+      summaries for clusters whose commands are all strictly older than every
+      command of the earliest failed cluster form a leading chronological
+      prefix, which is saved with an ``end_time`` below the earliest failed
+      timestamp. The surviving work (the failed cluster's commands onward)
+      therefore remains eligible and is retried — overlapping-free, so a
+      retry cannot produce duplicate rows for already-persisted windows.
+    - Retry idempotency: a run starts after the existing watermark and only
+      writes rows ending below it; previously persisted work is never rewritten,
+      so no duplicates can be created despite the absence of a uniqueness
+      constraint on ``(start_time, end_time)``.
+
+    Returns:
+        Number of chunks successfully persisted this run (unchanged meaning).
     """
     # 1. Get the last consolidated end_time
     conn = db.get_connection()
@@ -397,21 +445,94 @@ def consolidate_sleep_contexts(db, force: bool = False) -> int:
         cmd_strs = [c["command"] for c in chunk]
         
         clusters = cluster_commands(cmd_strs, threshold=clustering_threshold)
+
+        # Attach each cluster's earliest command timestamp (set intersection,
+        # as dedup leaves multiple timestamps per command string) so the
+        # checkpoint can be kept below any failed cluster's commands. Without
+        # a per-cluster marker in rem_sleep_consolidation, this chronological
+        # bookkeeping is what keeps failed work discoverable on the next run.
+        cmd_min_ts = {}
+        for c in chunk:
+            if c["command"] not in cmd_min_ts or c["timestamp"] < cmd_min_ts[c["command"]]:
+                cmd_min_ts[c["command"]] = c["timestamp"]
+
         cluster_summaries = []
+        succeeded_with_ts = []  # (summary, latest command timestamp of its cluster)
+        failed_clusters = []
+        failed_earliest_ts = None
         for cluster in clusters:
-            summ = generate_cluster_summary(cluster)
+            # Per-cluster failure isolation: a summarize failure (e.g. LLM
+            # timeout, malformed response, provider error) affects only that
+            # cluster. Sibling clusters still run; a failed cluster contributes
+            # no summary and is never reported as consolidated — its commands
+            # stay recoverable because the checkpoint is not advanced past
+            # them (see persistence below).
+            try:
+                summ = generate_cluster_summary(cluster)
+            except Exception:
+                logger.exception(
+                    "Sleep consolidation: failed to summarize a cluster "
+                    "(commands=%d); its commands remain eligible for retry",
+                    len(cluster),
+                )
+                failed_clusters.append(cluster)
+                fail_floor = min(cmd_min_ts.get(c, start_time) for c in cluster)
+                if failed_earliest_ts is None or fail_floor < failed_earliest_ts:
+                    failed_earliest_ts = fail_floor
+                continue
             if summ:
                 cluster_summaries.append(summ)
+                # Defaulting unknown strings to end_time keeps such a cluster
+                # out of the safe prefix (withheld -> retried), never the
+                # reverse, so success is never claimed prematurely.
+                succeeded_with_ts.append(
+                    (summ, max(cmd_min_ts.get(c, end_time) for c in cluster))
+                )
                 
+        # If no cluster produced a summary, persist nothing and leave the
+        # whole chunk untouched: it stays fully eligible for the next run.
+        # (Preserves normal empty-result behavior as before.)
         if not cluster_summaries:
             continue
-            
-        if len(cluster_summaries) == 1:
-            final_summary = cluster_summaries[0]
+
+        # Persist following the existing checkpoint model. The next run
+        # discovers commands strictly newer than MAX(end_time), so a saved row
+        # must never end at/after a failed cluster's commands — otherwise that
+        # failed work would become permanently undiscoverable while looking
+        # consolidated. With failures present, successful summaries split into:
+        #   - a leading chronological prefix covering only commands strictly
+        #     older than every failure (safe to persist now; a retry starts
+        #     after it, so it cannot be duplicated), and
+        #   - trailing work at/after the failure (withheld, retried later,
+        #     including any successful clusters overlapping that region).
+        # Chunks with no failed cluster keep the original single-write path.
+        if failed_clusters:
+            prefix_summaries = [
+                s for s, cluster_last_ts in succeeded_with_ts
+                if cluster_last_ts < failed_earliest_ts
+            ]
+            if not prefix_summaries:
+                # Nothing fully precedes the failure: withhold everything,
+                # including successful clusters, so the whole chunk retries
+                # intact on the next run (no partial-window rewrites).
+                continue
+            # Anchor the saved row to the actual work being persisted, never
+            # past the earliest failed command (guaranteed by the filter above).
+            save_start = start_time
+            save_end = max(ts for s, ts in succeeded_with_ts if ts < failed_earliest_ts)
+            save_commands = [
+                c["command"] for c in chunk if save_start <= c["timestamp"] <= save_end
+            ]
         else:
-            final_summary = " | ".join(cluster_summaries)
+            prefix_summaries = cluster_summaries
+            save_start, save_end, save_commands = start_time, end_time, cmd_strs
             
-        db.save_consolidated_context(start_time, end_time, final_summary, cmd_strs)
+        if len(prefix_summaries) == 1:
+            final_summary = prefix_summaries[0]
+        else:
+            final_summary = " | ".join(prefix_summaries)
+            
+        db.save_consolidated_context(save_start, save_end, final_summary, save_commands)
         consolidated_count += 1
 
     return consolidated_count

--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -634,3 +634,372 @@ def test_generate_cluster_summary_disabled_provider_stays_local(monkeypatch):
 
     assert result == "Worked on commands: git, docker"
     assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #468: recover failed background consolidation
+# without losing work.
+#
+# Persistence/checkpoint model being tested (from termstory/database.py and
+# termstory/reminder.py):
+#   - rem_sleep_consolidation has NO uniqueness constraint on
+#     (start_time, end_time); save_consolidated_context() is a plain INSERT,
+#     so writing the same window twice would duplicate rows.
+#   - There is no separate watermark column: the next consolidation run's
+#     eligibility boundary is MAX(end_time) over persisted rows, and eligible
+#     commands are strictly those newer than it. The tests below therefore
+#     verify retryability through that exact boundary.
+# ---------------------------------------------------------------------------
+
+def _sleep_checkpoint(db):
+    """Return the consolidation checkpoint (MAX(end_time)) for assertions."""
+    conn = db.get_connection()
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT MAX(end_time) FROM rem_sleep_consolidation")
+        row = cursor.fetchone()
+        return row[0] if row and row[0] is not None else 0
+    finally:
+        conn.close()
+
+
+def _seed_three_clusters(tmp_path):
+    """Create a Database containing one idle chunk with three orthogonally
+    embeddable two-command clusters (git -> docker -> npm) in chronological
+    order. Returns (db, now, command-timestamp dict per tool family)."""
+    db_file = tmp_path / "test_468.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    now = int(time.time())
+    t_git_a, t_git_b = now - 5900, now - 5890
+    t_docker_a, t_docker_b = now - 5800, now - 5790
+    t_npm_a, t_npm_b = now - 5700, now - 5690
+
+    commands = [
+        Command(timestamp=t_git_a, command="git alpha-one", session_id=1, project_id=1),
+        Command(timestamp=t_git_b, command="git alpha-two", session_id=1, project_id=1),
+        Command(timestamp=t_docker_a, command="docker beta-one", session_id=1, project_id=1),
+        Command(timestamp=t_docker_b, command="docker beta-two", session_id=1, project_id=1),
+        Command(timestamp=t_npm_a, command="npm gamma-one", session_id=1, project_id=1),
+        Command(timestamp=t_npm_b, command="npm gamma-two", session_id=1, project_id=1),
+    ]
+    p = Project(id=1, name="termstory", path="~/projects/termstory",
+                first_seen=now - 6000, last_seen=now, session_count=1, total_time=310)
+    s = Session(id=1, start_time=t_git_a, end_time=t_npm_b, duration_seconds=210,
+                project_id=1, commands=commands)
+    db.save_data([p], [s], commands)
+    return db, now, {
+        "git": (t_git_a, t_git_b),
+        "docker": (t_docker_a, t_docker_b),
+        "npm": (t_npm_a, t_npm_b),
+    }
+
+
+def _fake_three_cluster_embeddings(monkeypatch):
+    """Force the embeddings clustering path with three orthogonal groups so
+    cluster_commands() deterministically yields one cluster per tool family."""
+    import termstory.rag as rag
+
+    mapping = {
+        "git alpha-one": [1.0, 0.0, 0.0],
+        "git alpha-two": [1.0, 0.0, 0.0],
+        "docker beta-one": [0.0, 1.0, 0.0],
+        "docker beta-two": [0.0, 1.0, 0.0],
+        "npm gamma-one": [0.0, 0.0, 1.0],
+        "npm gamma-two": [0.0, 0.0, 1.0],
+    }
+
+    def fake_get_embeddings(texts, model_name="all-MiniLM-L6-v2"):
+        return [list(mapping[t]) for t in texts]
+
+    monkeypatch.setattr(rag, "get_embeddings", fake_get_embeddings)
+    monkeypatch.setattr(rag, "SENTENCE_TRANSFORMERS_AVAILABLE", True)
+
+
+def _summary_stub(failing_prefixes):
+    """Build a generate_cluster_summary stand-in raising for clusters whose
+    first command starts with any prefix in failing_prefixes."""
+    def fake_generate_cluster_summary(cluster):
+        if any(cluster[0].startswith(prefix) for prefix in failing_prefixes):
+            raise TimeoutError("simulated LLM request timeout")
+        return "SUMMARY-" + cluster[0].split()[0]
+    return fake_generate_cluster_summary
+
+
+def test_consolidate_preserves_successful_clusters_when_one_fails(tmp_path, monkeypatch):
+    """A+B (issue #468): with clusters A(ok) -> B(raises) -> C(ok) in one
+    chunk, A's summary survives, B is not marked consolidated, processing
+    continues past B, and the checkpoint stays below B's commands."""
+    db, now, ts = _seed_three_clusters(tmp_path)
+    _fake_three_cluster_embeddings(monkeypatch)
+    # git succeeds, docker raises, npm must still be processed afterwards.
+    seen_after_failure = []
+    base_stub = _summary_stub(["docker"])
+
+    def stub_and_track(cluster):
+        result = base_stub(cluster)
+        seen_after_failure.append(cluster[0].split()[0])
+        return result
+
+    monkeypatch.setattr(
+        "termstory.reminder.generate_cluster_summary", stub_and_track
+    )
+
+    count = consolidate_sleep_contexts(db, force=True)
+
+    # C was processed after B's failure (processing did not abort at B).
+    assert "npm" in seen_after_failure
+
+    # Only the safe prefix (git cluster) was persisted; docker/npm withheld.
+    assert count == 1
+    contexts = db.get_consolidated_contexts()
+    assert len(contexts) == 1
+    ctx = contexts[0]
+    assert ctx["start_time"] == ts["git"][0]
+    assert ctx["end_time"] == ts["git"][1]  # row anchored below the failure
+    assert ctx["commands"] == ["git alpha-one", "git alpha-two"]
+    assert "SUMMARY-git" in ctx["summary"]
+
+    # B is not falsely marked consolidated: its own and C's summary strings
+    # are absent from persisted rows, and their commands are excluded too.
+    assert "SUMMARY-docker" not in ctx["summary"]
+    assert "SUMMARY-npm" not in ctx["summary"]
+    assert "docker beta-one" not in ctx["commands"]
+
+    # Checkpoint did NOT advance past the failed cluster's commands.
+    assert _sleep_checkpoint(db) == ts["git"][1]
+
+
+def test_consolidate_failure_before_all_successes_persists_nothing(tmp_path, monkeypatch):
+    """B (issue #468): when the failing cluster precedes every successful one
+    chronologically, nothing can be safely persisted without advancing the
+    checkpoint over the failed work — so the whole chunk stays retryable."""
+    db, now, ts = _seed_three_clusters(tmp_path)
+    _fake_three_cluster_embeddings(monkeypatch)
+    monkeypatch.setattr(
+        "termstory.reminder.generate_cluster_summary", _summary_stub(["git"])
+    )
+
+    count = consolidate_sleep_contexts(db, force=True)
+
+    # Successful sibling summaries were computed but withheld rather than
+    # persisted ahead of the failure; they will be retried together with it.
+    assert count == 0
+    assert len(db.get_consolidated_contexts()) == 0
+
+    # Nothing was persisted => checkpoint untouched => ALL work (including
+    # the successful clusters' commands) remains eligible next run.
+    assert _sleep_checkpoint(db) == 0
+
+
+def test_failed_cluster_remains_retryable_on_next_run(tmp_path, monkeypatch):
+    """B (issue #468): after a partial failure, the NEXT consolidation run
+    must actually discover and persist the previously failed work through the
+    MAX(end_time)-based eligibility boundary."""
+    db, now, ts = _seed_three_clusters(tmp_path)
+    _fake_three_cluster_embeddings(monkeypatch)
+
+    monkeypatch.setattr(
+        "termstory.reminder.generate_cluster_summary", _summary_stub(["docker"])
+    )
+    first_count = consolidate_sleep_contexts(db, force=True)
+    assert first_count == 1
+    assert _sleep_checkpoint(db) == ts["git"][1]
+
+    # Failed cluster's commands sit strictly above the checkpoint: they were
+    # not consumed by the failed/partial first run.
+    checkpoint = _sleep_checkpoint(db)
+    assert ts["docker"][0] > checkpoint
+    assert ts["npm"][1] > checkpoint
+
+    # Retry with all clusters succeeding.
+    monkeypatch.setattr(
+        "termstory.reminder.generate_cluster_summary", _summary_stub([])
+    )
+    second_count = consolidate_sleep_contexts(db, force=True)
+    assert second_count == 1
+
+    contexts = db.get_consolidated_contexts()
+    assert len(contexts) == 2
+    retried = [c for c in contexts if c["start_time"] == ts["docker"][0]]
+    assert len(retried) == 1
+    retried_ctx = retried[0]
+    assert retried_ctx["start_time"] == ts["docker"][0]
+    assert retried_ctx["end_time"] == ts["npm"][1]
+    assert set(retried_ctx["commands"]) == {
+        "docker beta-one", "docker beta-two", "npm gamma-one", "npm gamma-two",
+    }
+    assert "SUMMARY-docker" in retried_ctx["summary"]
+    assert "SUMMARY-npm" in retried_ctx["summary"]
+
+    # Every command is covered by exactly two ordered, non-overlapping
+    # windows: run 1's safe prefix plus run 2's recovery window.
+    windows = sorted((c["start_time"], c["end_time"]) for c in contexts)
+    assert windows == [
+        (ts["git"][0], ts["git"][1]),
+        (ts["docker"][0], ts["npm"][1]),
+    ]
+
+
+def test_retry_is_idempotent_and_never_duplicates_context(tmp_path, monkeypatch):
+    """C (issue #468): a retry after recovery must not duplicate already-
+    persisted context, despite rem_sleep_consolidation having no uniqueness
+    constraint on (start_time, end_time)."""
+    db, now, ts = _seed_three_clusters(tmp_path)
+    _fake_three_cluster_embeddings(monkeypatch)
+
+    # Run 1: docker fails; only git's window persists.
+    monkeypatch.setattr(
+        "termstory.reminder.generate_cluster_summary", _summary_stub(["docker"])
+    )
+    consolidate_sleep_contexts(db, force=True)
+
+    # Run 2: recovery — previously failed work is consolidated.
+    monkeypatch.setattr(
+        "termstory.reminder.generate_cluster_summary", _summary_stub([])
+    )
+    consolidate_sleep_contexts(db, force=True)
+    contexts_after_recovery = db.get_consolidated_contexts()
+    rows_after_recovery = len(contexts_after_recovery)
+    checkpoint_after_recovery = _sleep_checkpoint(db)
+
+    # Run 3: a further forced consolidation finds nothing new and must not
+    # rewrite or re-insert anything.
+    third_count = consolidate_sleep_contexts(db, force=True)
+    assert third_count == 0
+
+    contexts_final = db.get_consolidated_contexts()
+    assert len(contexts_final) == rows_after_recovery
+    assert sorted((c["start_time"], c["end_time"]) for c in contexts_final) == \
+        sorted((c["start_time"], c["end_time"]) for c in contexts_after_recovery)
+    assert _sleep_checkpoint(db) == checkpoint_after_recovery == ts["npm"][1]
+
+    conn = db.get_connection()
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM rem_sleep_consolidation")
+        assert cursor.fetchone()[0] == rows_after_recovery
+    finally:
+        conn.close()
+
+
+def test_llm_provider_timeout_is_isolated_to_one_cluster(tmp_path, monkeypatch):
+    """D (issue #468): through the real config->provider->_send_llm_request
+    path, a realistic timeout exception raised for one cluster's request is
+    isolated: sibling clusters' requests still go out, their LLM responses
+    persist, and the timed-out cluster's commands stay retryable."""
+    db, now, ts = _seed_three_clusters(tmp_path)
+    _fake_three_cluster_embeddings(monkeypatch)
+
+    # Provider enabled; requests flow through termstory.ai._send_llm_request.
+    monkeypatch.setattr(
+        "termstory.config.load_config",
+        lambda: {
+            "active_provider": "groq",
+            "providers": {
+                "groq": {
+                    "api_key": "test-key",
+                    "api_base_url": "http://localhost:9/v1",
+                    "model_name": "test-model",
+                }
+            },
+        },
+    )
+
+    llm_calls = []
+
+    def fake_send_llm_request(prompt, *args, **kwargs):
+        llm_calls.append(prompt)
+        if "docker beta-one" in prompt:
+            # Realistic provider-side hard failure (what urllib surfaces when
+            # a socket read aborts mid-request).
+            raise TimeoutError("The read operation timed out")
+        return "llm-summary-" + prompt.split("- ")[1].split()[0]
+
+    monkeypatch.setattr(
+        "termstory.ai._send_llm_request", fake_send_llm_request
+    )
+
+    count = consolidate_sleep_contexts(db, force=True)
+
+    # All three clusters were attempted despite the middle one timing out.
+    assert len(llm_calls) == 3
+    assert sum(1 for p in llm_calls if "docker beta-one" in p) == 1
+
+    # The leading successful cluster persisted; the failed one did not.
+    assert count == 1
+    contexts = db.get_consolidated_contexts()
+    assert len(contexts) == 1
+    ctx = contexts[0]
+    assert ctx["end_time"] == ts["git"][1]
+    assert ctx["commands"] == ["git alpha-one", "git alpha-two"]
+    assert "llm-summary-git" in ctx["summary"]
+    assert _sleep_checkpoint(db) == ts["git"][1]
+
+
+def test_consolidate_all_success_persists_exactly_once(tmp_path, monkeypatch):
+    """F (issue #468): with every cluster succeeding, the chunk is persisted
+    exactly once through the original single-write path: one row spanning the
+    full window, all summaries joined, checkpoint at the true end, and a
+    further forced run adds nothing (no duplicate persistence)."""
+    db, now, ts = _seed_three_clusters(tmp_path)
+    _fake_three_cluster_embeddings(monkeypatch)
+    # Exercise the real config -> provider -> LLM path for every cluster.
+    monkeypatch.setattr(
+        "termstory.config.load_config",
+        lambda: {
+            "active_provider": "groq",
+            "providers": {
+                "groq": {
+                    "api_key": "test-key",
+                    "api_base_url": "http://localhost:9/v1",
+                    "model_name": "test-model",
+                }
+            },
+        },
+    )
+    llm_calls = []
+
+    def fake_send_llm_request(prompt, *args, **kwargs):
+        llm_calls.append(prompt)
+        return "llm-summary-" + prompt.split("- ")[1].split()[0]
+
+    monkeypatch.setattr(
+        "termstory.ai._send_llm_request", fake_send_llm_request
+    )
+
+    count = consolidate_sleep_contexts(db, force=True)
+
+    assert count == 1  # single persisted chunk, unchanged meaning
+    assert len(llm_calls) == 3
+    contexts = db.get_consolidated_contexts()
+    assert len(contexts) == 1
+    ctx = contexts[0]
+    assert ctx["start_time"] == ts["git"][0]
+    assert ctx["end_time"] == ts["npm"][1]
+    assert ctx["commands"] == [
+        "git alpha-one", "git alpha-two",
+        "docker beta-one", "docker beta-two",
+        "npm gamma-one", "npm gamma-two",
+    ]
+    assert (
+        "llm-summary-git" in ctx["summary"]
+        and "llm-summary-docker" in ctx["summary"]
+        and "llm-summary-npm" in ctx["summary"]
+    )
+    assert _sleep_checkpoint(db) == ts["npm"][1]
+
+    # An additional forced run must not re-insert or rewrite anything.
+    assert consolidate_sleep_contexts(db, force=True) == 0
+    assert len(db.get_consolidated_contexts()) == 1
+
+
+def test_generate_cluster_summary_disabled_provider_empty_cluster(monkeypatch):
+    """G (issue #468): an empty cluster under the disabled provider keeps the
+    existing 'Idle session' fallback instead of turning into a failure."""
+    monkeypatch.setattr(
+        "termstory.config.load_config",
+        lambda: {"active_provider": "disabled"},
+    )
+    assert generate_cluster_summary([]) == "Idle session"


### PR DESCRIPTION
## Summary

Fix background sleep consolidation so a failure while generating one cluster summary does not cause successfully processed work to be lost or advance the consolidation checkpoint past failed work.

### What changed

- Isolate failures to the individual `generate_cluster_summary()` call.
- Preserve successfully processed clusters when safe to persist them.
- Prevent `MAX(end_time)` from advancing past the earliest failed cluster.
- Keep failed and post-failure commands eligible for the next consolidation run.
- Preserve idempotency across retries without introducing a database schema change.
- Keep database persistence failures outside the cluster-generation exception boundary.
- Preserve the existing disabled-provider behavior.
- Add regression coverage for partial failure, failure-first ordering, retryability, idempotency, provider timeouts, all-success behavior, and disabled-provider behavior.

### Validation

- `pytest tests/test_reminder.py --timeout=600 -q --durations=8` — 28 passed
- `pytest tests/test_sleep.py --timeout=600 -q` — 4 passed
- `git diff --check` — clean

No frontend, CLI, schema, migration, search, or unrelated changes were made.

Closes #468