### PR TITLE
fix(mcp): redact local cwd from snapshots

### DIFF
--- a/termstory/mcp_snapshot.py
+++ b/termstory/mcp_snapshot.py
@@ -5,7 +5,7 @@ import re
 import sqlite3
 import subprocess
 import time
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 
 from termstory.sanitizer import redact_command
 
@@ -148,6 +148,87 @@ def _scrub_git_path(line: str) -> str:
     return redact_command(scrubbed)
 
 
+def _scrub_cwd(cwd: Optional[str]) -> Optional[str]:
+    """Sanitize a working-directory value before persisting it in an MCP snapshot.
+
+    The persisted snapshot must not leak the current user's home directory or
+    username (e.g. ``/home/alice/projects/Termstory`` or
+    ``C:\\Users\\alice\\Documents\\PrivateProject``). This mirrors the privacy
+    boundary already applied to git-status paths by ``_scrub_git_path``, but is
+    tailored to a single directory path rather than a shell command line.
+
+    Behavior:
+    * ``None`` is preserved unchanged (the cwd is ``None`` when the working
+      directory has been deleted and ``os.getcwd()`` raises ``OSError``).
+    * Known home directories (``HOME`` / ``USERPROFILE`` / ``expanduser``) are
+      redacted on path-component boundaries, preserving the trailing project
+      context and the path's own separators.
+    * Username path components are redacted case-insensitively so a Windows
+      ``C:\\Users\\Alice`` is caught even when the host advertises the user as
+      ``alice`` (and even when the scrubbing host is a different OS and the path
+      uses different separators).
+    * Matching is component/whole-word bounded, so unrelated path components are
+      not corrupted (e.g. ``alicebackup`` is left intact).
+
+    Unlike ``_scrub_git_path``, this does *not* run the value through
+    ``redact_command``: a working directory is a location string, not a shell
+    command, and the command-redaction pipeline can mangle legitimate
+    project/repository names that merely look host-shaped. Only the
+    home/username privacy boundary is sanitized here.
+
+    IMPORTANT: this must ONLY be applied to the value stored in (and later
+    displayed from) the snapshot. The real, unredacted cwd is still passed to
+    ``capture_git_status`` for Git repository detection and subprocess execution.
+    """
+    if cwd is None:
+        return None
+
+    scrubbed = cwd
+
+    # 1. Redact known home directories as a path-component prefix. The
+    #    separator class ``[\\/]`` makes matching work for Windows-style paths
+    #    even when the scrubbing host is POSIX (and vice-versa). ``re.IGNORECASE``
+    #    handles drive-letter / casing differences. Matching is anchored to the
+    #    start and bounded by a trailing separator or end of string, so a home
+    #    that is only a substring-prefix of a longer segment (e.g.
+    #    ``/home/alice`` vs ``/home/alicee``) is left intact rather than
+    #    corrupting it into ``<REDACTED_HOME>e``.
+    for home in _home_dirs():
+        if not home:
+            continue
+        parts = [p for p in re.split(r"[\\/]", home) if p != ""]
+        if not parts:
+            continue
+        core = r"(?:[\\/])".join(re.escape(p) for p in parts)
+        pattern = re.compile(
+            r"^(?:[\\/]{1,2})?" + core + r"(?=$|[\\/])",
+            re.IGNORECASE,
+        )
+        # count=1: only the leading (prefix) home component is replaced, which is
+        # where the cwd lives; trailing context is preserved as-is.
+        scrubbed = pattern.sub("<REDACTED_HOME>", scrubbed, count=1)
+
+    # 2. Redact username path components. Whole-component matching (bounded by
+    #    separators / string edges / non-word characters) ensures a username is
+    #    not redacted merely because it is a substring of a longer component
+    #    (e.g. ``alicebackup`` is preserved). Case-insensitive so casing
+    #    differences between the env-reported username and an observed path
+    #    cannot bypass redaction (e.g. ``C:\\Users\\Alice`` vs username
+    #    ``alice``). Skip trivial single-character names to avoid needlessly
+    #    corrupting ordinary single-letter path segments.
+    for name in _user_names():
+        if not name or len(name) < 2:
+            continue
+        scrubbed = re.sub(
+            r"(?<![A-Za-z0-9_])" + re.escape(name) + r"(?![A-Za-z0-9_])",
+            "<REDACTED_USER>",
+            scrubbed,
+            flags=re.IGNORECASE,
+        )
+
+    return scrubbed
+
+
 def capture_git_status(cwd: str) -> Dict[str, Any]:
     """Capture Git status (branch, uncommitted files) for the given directory"""
     result = {
@@ -246,9 +327,12 @@ def capture_mcp_snapshot() -> Dict[str, Any]:
         )
         cwd = None
     ide_info = capture_ide_state()
+    # Git repository detection and any `git -C <cwd>` subprocess execution must
+    # use the REAL, unredacted filesystem path. Only the value persisted in (and
+    # later displayed from) the snapshot is sanitized via `_scrub_cwd`.
     git_info = capture_git_status(cwd)
     return {
-        "cwd": cwd,
+        "cwd": _scrub_cwd(cwd),
         "ide": ide_info,
         "git": git_info
     }

--- a/tests/test_mcp_snapshot.py
+++ b/tests/test_mcp_snapshot.py
@@ -12,7 +12,8 @@ from termstory.mcp_snapshot import (
     capture_ide_state,
     capture_git_status,
     capture_mcp_snapshot,
-    capture_and_store_mcp_snapshot
+    capture_and_store_mcp_snapshot,
+    _scrub_cwd
 )
 from termstory.formatter import format_mcp_snapshots
 
@@ -324,6 +325,86 @@ def test_capture_mcp_snapshot_deleted_cwd():
         assert not snapshot["git"]["is_repo"]
 
 
+# ---------------------------------------------------------------------------
+# Issue #477 regressions: the persisted snapshot "cwd" must be scrubbed of
+# locally-identifying home/username path components. All identity inputs
+# (HOME / USERPROFILE / USERNAME / expanduser / getpass.getuser) are pinned in
+# every test so results never depend on the developer machine's real values.
+# ---------------------------------------------------------------------------
+
+_ALICE_UNIX_ENV = {
+    "HOME": "/home/alice",
+    "USERPROFILE": "/home/alice",
+    "USERNAME": "alice",
+    "USER": "alice",
+}
+
+_ALICE_WIN_ENV = {
+    "HOME": "C:\\Users\\alice",
+    "USERPROFILE": "C:\\Users\\alice",
+    "USERNAME": "alice",
+    "USER": "alice",
+}
+
+
+def test_scrub_cwd_none_preserved():
+    # A deleted cwd (os.getcwd() raising OSError) yields cwd=None upstream;
+    # the sanitizer must preserve None rather than crash or coerce it.
+    assert _scrub_cwd(None) is None
+
+
+def test_scrub_cwd_unix_home_and_username_components():
+    with patch.dict(os.environ, _ALICE_UNIX_ENV, clear=True), \
+         patch("termstory.mcp_snapshot.os.path.expanduser", return_value="/home/alice"), \
+         patch("termstory.mcp_snapshot.getpass.getuser", return_value="alice"):
+        # Home is redacted on component boundaries; trailing project context
+        # is preserved.
+        assert _scrub_cwd("/home/alice/projects/Termstory") == "<REDACTED_HOME>/projects/Termstory"
+        # The exact home path itself collapses to the placeholder.
+        assert _scrub_cwd("/home/alice") == "<REDACTED_HOME>"
+        # A username appearing as a nested (non-home-prefix) path component is
+        # still redacted...
+        assert _scrub_cwd("/srv/workspaces/alice/notes") == "/srv/workspaces/<REDACTED_USER>/notes"
+        # ...as is a macOS-style home not advertised via HOME.
+        assert _scrub_cwd("/Users/alice/termstory") == "/Users/<REDACTED_USER>/termstory"
+        # A component merely containing the username as a substring must NOT
+        # be corrupted.
+        assert _scrub_cwd("/srv/alicebackup/build") == "/srv/alicebackup/build"
+        # A path sharing a prefix with the home but forming a different
+        # component must be left intact.
+        assert _scrub_cwd("/home/alicee/data") == "/home/alicee/data"
+
+
+def test_scrub_cwd_windows_home_and_case_insensitive_username():
+    # Windows-style paths must be scrubbed regardless of the host OS the tests
+    # run on, and casing differences must not bypass redaction.
+    with patch.dict(os.environ, _ALICE_WIN_ENV, clear=True), \
+         patch("termstory.mcp_snapshot.os.path.expanduser", return_value="C:\\Users\\alice"), \
+         patch("termstory.mcp_snapshot.getpass.getuser", return_value="alice"):
+        # Windows home prefix is redacted; project context survives.
+        assert _scrub_cwd("C:\\Users\\alice\\Documents\\Termstory") == "<REDACTED_HOME>\\Documents\\Termstory"
+        # C:\\Users\\Alice (different case) must also be caught.
+        assert _scrub_cwd("C:\\Users\\Alice\\Documents\\Termstory") == "<REDACTED_HOME>\\Documents\\Termstory"
+        # A POSIX path is still scrubbed even when the advertised home is a
+        # Windows path (username component match is OS-independent).
+        assert _scrub_cwd("/home/alice/projects/Termstory") == "/home/<REDACTED_USER>/projects/Termstory"
+        # Username as a nested Windows path component.
+        assert _scrub_cwd("D:\\data\\alice\\repo") == "D:\\data\\<REDACTED_USER>\\repo"
+        # Longer components that merely contain the username stay intact.
+        assert _scrub_cwd("C:\\Users\\alicebackup\\Termstory") == "C:\\Users\\alicebackup\\Termstory"
+
+
+def test_scrub_cwd_preserves_paths_without_sensitive_components():
+    with patch.dict(os.environ, _ALICE_UNIX_ENV, clear=True), \
+         patch("termstory.mcp_snapshot.os.path.expanduser", return_value="/home/alice"), \
+         patch("termstory.mcp_snapshot.getpass.getuser", return_value="alice"):
+        # Paths with no home/username components must pass through untouched.
+        assert _scrub_cwd("/opt/apps/Termstory") == "/opt/apps/Termstory"
+        assert _scrub_cwd("C:\\dev\\tools\\Termstory") == "C:\\dev\\tools\\Termstory"
+        assert _scrub_cwd("relative/nested/path") == "relative/nested/path"
+        assert _scrub_cwd("") == ""
+
+
 def test_capture_git_status_subprocess_timeout():
     mock_run = MagicMock(side_effect=subprocess.TimeoutExpired(cmd="git", timeout=5))
     with patch("termstory.mcp_snapshot.os.path.exists", return_value=True), \
@@ -402,6 +483,79 @@ def test_capture_and_store_mcp_snapshot_db_error_does_not_raise(mock_git, mock_i
     # Must swallow the db failure and return normally. A snapshot
     # failure must never disrupt the core ingestion process.
     capture_and_store_mcp_snapshot(db)
+
+
+# ---------------------------------------------------------------------------
+# Issue #477: capture-level regressions. The REAL, unredacted cwd must still
+# reach capture_git_status() for repository detection, while only the value
+# persisted in (and displayed from) the snapshot is sanitized.
+# ---------------------------------------------------------------------------
+
+_GIT_INFO = {"is_repo": True, "branch": "main", "uncommitted_files": []}
+
+
+def test_capture_mcp_snapshot_scrubs_cwd_but_git_receives_real_cwd():
+    with patch.dict(os.environ, _ALICE_UNIX_ENV, clear=True), \
+         patch("termstory.mcp_snapshot.os.path.expanduser", return_value="/home/alice"), \
+         patch("termstory.mcp_snapshot.getpass.getuser", return_value="alice"), \
+         patch("termstory.mcp_snapshot.os.getcwd", return_value="/home/alice/projects/Termstory"), \
+         patch("termstory.mcp_snapshot.capture_git_status", return_value=dict(_GIT_INFO)) as mock_git:
+        snapshot = capture_mcp_snapshot()
+
+    cwd = snapshot["cwd"]
+    assert cwd is not None
+    assert "/home/alice" not in cwd
+    assert "alice" not in cwd
+    assert "Termstory" in cwd
+    # Git repository detection received the REAL, unredacted cwd.
+    mock_git.assert_called_once_with("/home/alice/projects/Termstory")
+    assert snapshot["git"] == _GIT_INFO
+
+
+def test_capture_mcp_snapshot_scrubs_windows_cwd_but_git_receives_real_cwd():
+    real_cwd = "C:\\Users\\Alice\\Documents\\Termstory"
+    with patch.dict(os.environ, _ALICE_WIN_ENV, clear=True), \
+         patch("termstory.mcp_snapshot.os.path.expanduser", return_value="C:\\Users\\alice"), \
+         patch("termstory.mcp_snapshot.getpass.getuser", return_value="alice"), \
+         patch("termstory.mcp_snapshot.os.getcwd", return_value=real_cwd), \
+         patch("termstory.mcp_snapshot.capture_git_status", return_value=dict(_GIT_INFO)) as mock_git:
+        snapshot = capture_mcp_snapshot()
+
+    cwd = snapshot["cwd"]
+    assert cwd is not None
+    assert "C:\\Users\\alice" not in cwd
+    assert "C:\\Users\\Alice" not in cwd
+    assert "alice" not in cwd.lower()
+    assert "Termstory" in cwd
+    # The REAL, unredacted path (with its original casing) reaches Git.
+    mock_git.assert_called_once_with(real_cwd)
+
+
+def test_capture_and_store_mcp_snapshot_persists_scrubbed_cwd():
+    db = MagicMock()
+    db.get_latest_session_id.return_value = 1
+    db.get_mcp_snapshots.return_value = []
+
+    with patch.dict(os.environ, _ALICE_UNIX_ENV, clear=True), \
+         patch("termstory.mcp_snapshot.os.path.expanduser", return_value="/home/alice"), \
+         patch("termstory.mcp_snapshot.getpass.getuser", return_value="alice"), \
+         patch("termstory.mcp_snapshot.os.getcwd", return_value="/home/alice/projects/Termstory"), \
+         patch("termstory.mcp_snapshot.capture_ide_state", return_value={"ide_name": "Unknown", "env_vars": {}}), \
+         patch("termstory.mcp_snapshot.capture_git_status", return_value=dict(_GIT_INFO)) as mock_git:
+        capture_and_store_mcp_snapshot(db)
+
+    assert db.save_mcp_snapshot.called
+    payload = db.save_mcp_snapshot.call_args.kwargs.get("payload")
+    if payload is None:
+        payload = db.save_mcp_snapshot.call_args.args[2]
+    # The persisted cwd is sanitized but keeps the project context.
+    assert payload["cwd"] == "<REDACTED_HOME>/projects/Termstory"
+    # Neither the home path nor the username may leak anywhere in the payload.
+    payload_text = json.dumps(payload)
+    assert "/home/alice" not in payload_text
+    assert "alice" not in payload_text
+    # Git detection still ran against the real directory.
+    mock_git.assert_called_once_with("/home/alice/projects/Termstory")
 
 
 @patch("termstory.mcp_snapshot.os.getcwd", return_value="/Users/developer/termstory")


### PR DESCRIPTION
Closes #477
## Summary

Redact machine-specific working-directory information before persisting MCP snapshots.

## What changed

- Added `_scrub_cwd()` for persisted MCP snapshot working-directory values.
- Redacts known home-directory and username path components.
- Handles Unix and Windows-style paths, including Windows case variations.
- Preserves `cwd=None` behavior.
- Keeps the original unredacted cwd for Git/repository detection.
- Leaves existing Git-status sanitization unchanged.
- Added regression coverage for Unix, Windows, persistence, deleted cwd, and the real-cwd/Git boundary.
- No database schema or migration changes.

## Validation

- `pytest tests/test_mcp_snapshot.py -q` — 21 passed
- `pytest tests/test_replay.py -q` — 9 passed
- Relevant database/sanitizer/formatter/query tests — 71 passed
- `git diff --check` — clean

Known unrelated Windows/platform failures were reproduced against pristine `upstream/main`.

