### PR TITLE
fix(backup): validate restored databases before replacement

### DIFF
--- a/termstory/backup.py
+++ b/termstory/backup.py
@@ -158,27 +158,39 @@ def _validate_backup(path: str) -> None:
 
 
 def _sidecar_glob(base: str) -> list:
-    """Return existing SQLite sidecar files (``-wal``, ``-shm``, ``-journal``)
-    associated with *base* (without following into other databases)."""
+    """Return the SQLite sidecar file paths (``-wal``, ``-shm``, ``-journal``)
+    that would be associated with the exact database at *base*.  No filesystem
+    glob is performed — the three paths are derived deterministically so that
+    only sidecars belonging to this exact database path are ever considered."""
     return [f"{base}{suffix}" for suffix in ("-wal", "-shm", "-journal")]
 
 
-def _remove_sidecars(base: str) -> None:
-    """Remove SQLite sidecar files (``-wal`` / ``-shm`` / ``-journal``) for
-    the database at *base* path.  Missing files are silently skipped; removal
-    failures are logged but never raised."""
+def _remove_orphaned_sidecars(base: str) -> None:
+    """Remove SQLite sidecar files for the database at *base* path.
+
+    This is only safe to call AFTER the replacement at *base* has succeeded,
+    at which point any ``-wal``/``-shm``/``-journal`` file still present belongs
+    to the *old* (now replaced) database and would otherwise be replayed against
+    the new main file, corrupting it.  The new database is a clean single file,
+    so it has no sidecars of its own to preserve.
+
+    Raises:
+        OSError: if a stale sidecar exists but cannot be removed.  A leftover
+            stale sidecar is a correctness hazard (it can corrupt the new DB on
+            the next open), so removal failure is surfaced rather than logged
+            and silently ignored.
+    """
     for sidecar in _sidecar_glob(base):
         if os.path.exists(sidecar):
-            try:
-                os.remove(sidecar)
-            except OSError:
-                logger.warning("Could not remove stale SQLite sidecar %s", sidecar)
+            os.remove(sidecar)
 
 
 def _cleanup_temp_db(temp_db_path: str) -> None:
     """Remove a temporary database file and any of its sidecar files.
 
-    Safe to call even if the files do not exist.  Never raises.
+    Safe to call even if the files do not exist.  Best-effort by design: a
+    temporary artifact that cannot be removed is logged, never raised, so that
+    the original restore error is preserved.  Never raises.
     """
     if not temp_db_path:
         return
@@ -190,11 +202,59 @@ def _cleanup_temp_db(temp_db_path: str) -> None:
                 logger.warning("Could not remove temporary file %s", path)
 
 
+class _RestoreLock:
+    """A cross-process advisory lock that serializes restore operations.
+
+    Uses the same atomic ``O_CREAT | O_EXCL`` claim as the sleep daemon PID
+    file, so concurrent restores (in the same process or across processes)
+    cannot run the filesystem replacement at the same time.  It does not gate
+    normal Termstory database operations — it only prevents two restores from
+    racing each other while swapping the active database pathname.
+    """
+
+    def __init__(self, db_path: str):
+        self._lock_path = f"{db_path}.restore.lock"
+        self._fd = None
+
+    def acquire(self) -> None:
+        if self._fd is not None:
+            return  # already held
+        try:
+            self._fd = os.open(
+                self._lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o666
+            )
+        except FileExistsError as exc:
+            raise BackupError(
+                "Another database restore is already in progress."
+            ) from exc
+
+    def release(self) -> None:
+        if self._fd is not None:
+            try:
+                os.close(self._fd)
+            finally:
+                self._fd = None
+        try:
+            if os.path.exists(self._lock_path):
+                os.remove(self._lock_path)
+        except OSError:
+            logger.warning("Could not remove restore lock file %s", self._lock_path)
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, *exc_info):
+        self.release()
+        return False
+
+
 def restore_db(backup_path: str) -> None:
     """Restore the TermStory database from a backup file.
 
     The restore is safe by construction.  The active database is **never**
-    touched until the backup has passed every validation step:
+    touched until the backup has passed every validation step, and it is only
+    replaced once the replacement is known to have succeeded:
 
     1. **Source validation** — *backup_path* is opened and verified to be a
        readable SQLite database.
@@ -203,24 +263,33 @@ def restore_db(backup_path: str) -> None:
     3. **Integrity check** — ``PRAGMA integrity_check`` succeeds.
     4. **Temporary restore** — the validated backup is copied into a
        temporary file in the same directory (and filesystem) as the active
-       database, so the final swap can use ``os.replace``.
-    5. **Validate the restored copy** — the temporary database is
-       re-checked (readability, schema, integrity) before it is allowed to
-       replace the active database.
-    6. **Atomic replace** — stale WAL/SHM/journal sidecars of the old active
-       database are removed and ``os.replace`` atomically swaps in the
-       validated copy.
+       database, then checkpointed so the copy is a self-contained single
+       file, so the final swap can use ``os.replace``.
+    5. **Validate the restored copy** — the temporary database is re-checked
+       (readability, schema, integrity) before it is allowed to replace the
+       active database.
+    6. **Coordination** — a cross-process advisory lock prevents concurrent
+       restores from racing, and any in-flight writer on the active database
+       is quiesced before the swap.
+    7. **Atomic replace** — ``os.replace`` atomically swaps the validated
+       temporary copy in for the active database.
+    8. **Post-replace cleanup** — only after the swap has succeeded are the
+       *old* database's now-orphaned ``-wal``/``-shm``/``-journal`` sidecars
+       removed, so the restored database cannot accidentally consume stale
+       state belonging to the previous database.
 
-    If *any* step fails, the active database is left completely untouched and
-    all temporary artifacts are cleaned up.
+    If *any* step before a successful ``os.replace`` fails, the active
+    database and its WAL/SHM state are left completely untouched and all
+    temporary artifacts are cleaned up.  A failed ``os.replace`` likewise
+    leaves the original database and its sidecars fully intact.
 
     Args:
         backup_path: Absolute path to the backup .db file.
 
     Raises:
         FileNotFoundError: If ``backup_path`` does not exist.
-        BackupError: If the backup fails any validation step or the restore
-            into the temporary database fails.
+        BackupError: If the backup fails any validation step, if coordination
+            cannot be obtained, or if any restore operation fails.
     """
     if not os.path.isfile(backup_path):
         raise FileNotFoundError(f"Backup file not found at {backup_path}")
@@ -233,31 +302,87 @@ def restore_db(backup_path: str) -> None:
     _validate_backup(backup_path)
 
     # --- Step 4: Restore into a temporary file in the same directory ---
-    fd, temp_db_path = tempfile.mkstemp(
-        prefix=".termstory_restore_", suffix=".db", dir=db_dir
-    )
+    try:
+        fd, temp_db_path = tempfile.mkstemp(
+            prefix=".termstory_restore_", suffix=".db", dir=db_dir
+        )
+    except OSError as exc:
+        raise BackupError(
+            f"Could not create a temporary restore file in {db_dir}: {exc}"
+        ) from exc
     os.close(fd)  # close the raw fd so SQLite can open the file by path
 
+    replaced = False
     try:
-        src_conn = sqlite3.connect(backup_path)
-        dst_conn = sqlite3.connect(temp_db_path)
         try:
-            src_conn.backup(dst_conn)
-        finally:
-            dst_conn.close()
-            src_conn.close()
+            src_conn = sqlite3.connect(backup_path)
+            dst_conn = sqlite3.connect(temp_db_path)
+            try:
+                src_conn.backup(dst_conn)
+            finally:
+                dst_conn.close()
+                src_conn.close()
+        except sqlite3.Error as exc:
+            raise BackupError(
+                f"Could not copy the backup into the temporary database: {exc}"
+            ) from exc
+
+        # Checkpoint the temporary copy so it is a self-contained single file
+        # (no WAL/SHM of its own) before it can become the active database.
+        try:
+            tmp_conn = sqlite3.connect(temp_db_path)
+            try:
+                tmp_conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                tmp_conn.commit()
+            finally:
+                tmp_conn.close()
+        except sqlite3.Error as exc:
+            raise BackupError(
+                f"Could not finalize the temporary restore copy: {exc}"
+            ) from exc
 
         # --- Step 5: Validate the restored temporary database ---
         _validate_backup(temp_db_path)
 
-        # --- Step 6: Atomically replace the active database ---
-        # Remove stale WAL/SHM/journal sidecars from the old active DB so they
-        # cannot be replayed against the new database after the swap.
-        _remove_sidecars(db_path)
-        os.replace(temp_db_path, db_path)
+        # --- Step 6: Coordinate the replacement ---
+        with _RestoreLock(db_path):
+            # Quiesce any in-flight writer on the active database: briefly take
+            # and release a write lock so every concurrent writer commits before
+            # we swap the pathname.  The connection is closed before the
+            # replacement, so no transaction is held across the swap.
+            if os.path.exists(db_path):
+                try:
+                    quiesce_conn = sqlite3.connect(db_path, timeout=5.0)
+                    try:
+                        quiesce_conn.execute("BEGIN IMMEDIATE")
+                        quiesce_conn.commit()
+                    finally:
+                        quiesce_conn.close()
+                except sqlite3.OperationalError as exc:
+                    raise BackupError(
+                        "The database is in active use and could not be "
+                        "quiesced for restore."
+                    ) from exc
+
+            # --- Step 7: Atomically replace the active database ---
+            try:
+                os.replace(temp_db_path, db_path)
+            except OSError as exc:
+                raise BackupError(
+                    f"Could not replace the active database at {db_path}: {exc}"
+                ) from exc
+            replaced = True
+
+            # --- Step 8: Post-replace cleanup of the old database's sidecars ---
+            # Only after a successful swap may the old sidecars be removed;
+            # before this point they still described the live database and
+            # must be preserved so a failed replace leaves it intact.
+            _remove_orphaned_sidecars(db_path)
         # temp_db_path no longer exists — it is now db_path.
     except BaseException:
-        # On any failure: clean up temporary artifacts and re-raise.
-        # The active DB was never opened or modified, so it is untouched.
-        _cleanup_temp_db(temp_db_path)
+        # On any failure before the swap completed, clean up temporary
+        # artifacts.  The active DB and its sidecars were never deleted, so
+        # they are untouched.  If replacement succeeded, temp_db_path is gone.
+        if not replaced:
+            _cleanup_temp_db(temp_db_path)
         raise

--- a/termstory/backup.py
+++ b/termstory/backup.py
@@ -3,10 +3,28 @@ import os
 import shutil
 import sqlite3
 import glob
+import tempfile
 from datetime import datetime
 from termstory.config import get_db_path
 
 logger = logging.getLogger(__name__)
+
+# Core TermStory tables whose presence identifies a valid backup.
+# Derived from the schema created by ``Database.init_db`` (see also
+# ``docs/database-schema.md``).  Only the four fundamental data tables are
+# required — supplementary/cache tables such as ``macro_summaries`` may be
+# added or removed in future schema revisions without invalidating restores.
+REQUIRED_TABLES = ("projects", "sessions", "commands", "commits")
+
+
+class BackupError(Exception):
+    """Raised when a backup file fails validation or cannot be safely restored.
+
+    Unlike ``FileNotFoundError`` (raised when the backup *path* does not exist),
+    ``BackupError`` signals that the file exists but is not a usable TermStory
+    backup — e.g. it is not a SQLite database, is missing required tables, or
+    failed ``PRAGMA integrity_check``.
+    """
 
 
 def _get_backup_dir() -> str:
@@ -84,23 +102,162 @@ def backup_db() -> str:
     return backup_path
 
 
+def _validate_backup(path: str) -> None:
+    """Validate that *path* is a readable, structurally sound TermStory backup.
+
+    Three checks are performed in order:
+
+    1. **Readability** — the file can be queried as a SQLite database (the
+       first read of ``sqlite_master`` forces header parsing, so non-database
+       files are detected even though ``sqlite3.connect`` is lazy).
+    2. **Schema** — the core TermStory tables listed in ``REQUIRED_TABLES`` are
+       present.
+    3. **Integrity** — ``PRAGMA integrity_check`` returns ``"ok"``.
+
+    Raises:
+        BackupError: if any check fails.
+    """
+    conn = sqlite3.connect(path)
+    try:
+        cursor = conn.cursor()
+        # Force real parsing of the SQLite file header.  ``sqlite3.connect``
+        # is lazy and will happily open an arbitrary file; the error only
+        # surfaces when a query actually touches the database.
+        try:
+            cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+            existing_tables = {row[0] for row in cursor.fetchall()}
+        except sqlite3.DatabaseError as exc:
+            raise BackupError(
+                f"Backup file is not a readable SQLite database: {exc}"
+            ) from exc
+
+        missing = [t for t in REQUIRED_TABLES if t not in existing_tables]
+        if missing:
+            raise BackupError(
+                f"Backup file is missing required TermStory tables: "
+                f"{', '.join(missing)}"
+            )
+
+        # ``integrity_check`` can itself raise DatabaseError on a structurally
+        # corrupt file, so it must be wrapped separately.
+        try:
+            integrity = cursor.execute("PRAGMA integrity_check").fetchone()
+        except sqlite3.DatabaseError as exc:
+            raise BackupError(
+                f"Backup file failed integrity check: {exc}"
+            ) from exc
+        if not integrity or integrity[0] != "ok":
+            detail = integrity[0] if integrity else "no result"
+            raise BackupError(
+                f"Backup file failed integrity check: {detail}"
+            )
+    finally:
+        conn.close()
+
+
+def _sidecar_glob(base: str) -> list:
+    """Return existing SQLite sidecar files (``-wal``, ``-shm``, ``-journal``)
+    associated with *base* (without following into other databases)."""
+    return [f"{base}{suffix}" for suffix in ("-wal", "-shm", "-journal")]
+
+
+def _remove_sidecars(base: str) -> None:
+    """Remove SQLite sidecar files (``-wal`` / ``-shm`` / ``-journal``) for
+    the database at *base* path.  Missing files are silently skipped; removal
+    failures are logged but never raised."""
+    for sidecar in _sidecar_glob(base):
+        if os.path.exists(sidecar):
+            try:
+                os.remove(sidecar)
+            except OSError:
+                logger.warning("Could not remove stale SQLite sidecar %s", sidecar)
+
+
+def _cleanup_temp_db(temp_db_path: str) -> None:
+    """Remove a temporary database file and any of its sidecar files.
+
+    Safe to call even if the files do not exist.  Never raises.
+    """
+    if not temp_db_path:
+        return
+    for path in [temp_db_path] + _sidecar_glob(temp_db_path):
+        if os.path.exists(path):
+            try:
+                os.remove(path)
+            except OSError:
+                logger.warning("Could not remove temporary file %s", path)
+
+
 def restore_db(backup_path: str) -> None:
     """Restore the TermStory database from a backup file.
 
+    The restore is safe by construction.  The active database is **never**
+    touched until the backup has passed every validation step:
+
+    1. **Source validation** — *backup_path* is opened and verified to be a
+       readable SQLite database.
+    2. **Schema validation** — the backup is checked for the core TermStory
+       tables (``projects``, ``sessions``, ``commands``, ``commits``).
+    3. **Integrity check** — ``PRAGMA integrity_check`` succeeds.
+    4. **Temporary restore** — the validated backup is copied into a
+       temporary file in the same directory (and filesystem) as the active
+       database, so the final swap can use ``os.replace``.
+    5. **Validate the restored copy** — the temporary database is
+       re-checked (readability, schema, integrity) before it is allowed to
+       replace the active database.
+    6. **Atomic replace** — stale WAL/SHM/journal sidecars of the old active
+       database are removed and ``os.replace`` atomically swaps in the
+       validated copy.
+
+    If *any* step fails, the active database is left completely untouched and
+    all temporary artifacts are cleaned up.
+
     Args:
         backup_path: Absolute path to the backup .db file.
+
+    Raises:
+        FileNotFoundError: If ``backup_path`` does not exist.
+        BackupError: If the backup fails any validation step or the restore
+            into the temporary database fails.
     """
     if not os.path.isfile(backup_path):
         raise FileNotFoundError(f"Backup file not found at {backup_path}")
-    db_path = get_db_path()
-    # Ensure the destination directory exists
-    os.makedirs(os.path.dirname(db_path), exist_ok=True)
 
-    # Replace the current database with the backup using backup API
-    src = sqlite3.connect(backup_path)
-    dst = sqlite3.connect(db_path)
+    db_path = get_db_path()
+    db_dir = os.path.dirname(db_path) or "."
+    os.makedirs(db_dir, exist_ok=True)
+
+    # --- Steps 1-3: Validate the source backup before touching the active DB ---
+    _validate_backup(backup_path)
+
+    # --- Step 4: Restore into a temporary file in the same directory ---
+    fd, temp_db_path = tempfile.mkstemp(
+        prefix=".termstory_restore_", suffix=".db", dir=db_dir
+    )
+    os.close(fd)  # close the raw fd so SQLite can open the file by path
+
     try:
-        src.backup(dst)
-    finally:
-        src.close()
-        dst.close()
+        src_conn = sqlite3.connect(backup_path)
+        dst_conn = sqlite3.connect(temp_db_path)
+        try:
+            src_conn.backup(dst_conn)
+        finally:
+            dst_conn.close()
+            src_conn.close()
+
+        # --- Step 5: Validate the restored temporary database ---
+        _validate_backup(temp_db_path)
+
+        # --- Step 6: Atomically replace the active database ---
+        # Remove stale WAL/SHM/journal sidecars from the old active DB so they
+        # cannot be replayed against the new database after the swap.
+        _remove_sidecars(db_path)
+        os.replace(temp_db_path, db_path)
+        # temp_db_path no longer exists — it is now db_path.
+    except BaseException:
+        # On any failure: clean up temporary artifacts and re-raise.
+        # The active DB was never opened or modified, so it is untouched.
+        _cleanup_temp_db(temp_db_path)
+        raise

--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -1376,7 +1376,7 @@ def restore_cmd(
 
     Use `--yes` (or `-y`) to skip the prompt in automation.
     """
-    from termstory.backup import restore_db
+    from termstory.backup import restore_db, BackupError
     from rich.markup import escape
     import os as _os
 
@@ -1426,6 +1426,12 @@ def restore_cmd(
         # restore_db re-checks file existence; preserve the existing
         # error-handling contract in case the file disappeared between
         # our preflight check and the actual restore call.
+        console.print(f"[bold red]Error: {escape(str(e))}[/]")
+        raise typer.Exit(code=1)
+    except BackupError as e:
+        # The backup file exists but failed validation (corrupt, wrong
+        # schema, failed integrity_check).  The active database has not
+        # been touched.  Surface a clean error rather than a traceback.
         console.print(f"[bold red]Error: {escape(str(e))}[/]")
         raise typer.Exit(code=1)
 

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -454,3 +454,222 @@ def test_restore_failed_preserves_all_active_data(tmp_path, monkeypatch):
     assert _count_rows(db_path, "projects") == 1
     assert _count_rows(db_path, "sessions") == 1
     assert _count_rows(db_path, "commands") == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #479 follow-up — WAL safety, concurrency, and error normalization
+# ---------------------------------------------------------------------------
+
+def _db_state(db_path):
+    """Capture a representative snapshot of active DB state for before/after
+    comparison: the first project name and row counts across all four core
+    tables."""
+    return {
+        "first_project": _read_first_project_name(db_path),
+        "projects": _count_rows(db_path, "projects"),
+        "sessions": _count_rows(db_path, "sessions"),
+        "commands": _count_rows(db_path, "commands"),
+        "commits": _count_rows(db_path, "commits"),
+    }
+
+
+def test_restore_replace_failure_preserves_wal_active_db(tmp_path, monkeypatch):
+    """If os.replace() fails while the active database has WAL sidecars, the
+    restore must raise, the active DB + sidecars must be untouched, temp
+    artifacts must be cleaned up, and no unrelated files touched."""
+    db_path = str(tmp_path / "live.db")
+    _patch_db_path(monkeypatch, db_path)
+
+    _seed_db(db_path, "Survive Me")
+    _seed_db(db_path, "Survive Me 2")  # extra project for richer state
+
+    # Plant sidecar files for the active DB (simulating an unclean WAL state
+    # that must never be deleted on the fallible replacement path).
+    sidecar_wal = db_path + "-wal"
+    sidecar_shm = db_path + "-shm"
+    with open(sidecar_wal, "wb") as f:
+        f.write(b"\x96\x35\x7f\x00" + b"fake-wal-data")
+    with open(sidecar_shm, "wb") as f:
+        f.write(b"fake-shm-data")
+
+    before = _db_state(db_path)
+    sidecars_before = {
+        "wal": os.path.exists(sidecar_wal),
+        "shm": os.path.exists(sidecar_shm),
+    }
+
+    backup_path = str(tmp_path / "backup.db")
+    _seed_db(backup_path, "Restored Project")
+
+    dir_before = set(os.listdir(str(tmp_path)))
+
+    def boom_replace(src, dst):
+        raise OSError("simulated disk failure on replace")
+
+    monkeypatch.setattr("termstory.backup.os.replace", boom_replace)
+
+    with pytest.raises(BackupError):
+        restore_db(backup_path)
+
+    # 1. Active DB contents unchanged.
+    assert _db_state(db_path) == before
+    # 2. Existing sidecars remain present (never deleted on the fallible path).
+    assert os.path.exists(sidecar_wal) == sidecars_before["wal"]
+    assert os.path.exists(sidecar_shm) == sidecars_before["shm"]
+    # 3. Temporary restore artifacts cleaned up.
+    leftover = glob.glob(os.path.join(str(tmp_path), ".termstory_restore_*"))
+    assert leftover == [], "Leftover temp files: {}".format(leftover)
+    # 4. No unrelated files touched.
+    dir_after = set(os.listdir(str(tmp_path)))
+    assert dir_after == dir_before, (
+        "Unrelated files changed: {} vs {}".format(dir_before, dir_after)
+    )
+
+
+def test_restore_replace_failure_leaves_original_db_usable(tmp_path, monkeypatch):
+    """A failed replacement must leave the original DB exactly usable: every
+    table intact and the DB valid."""
+    db_path = str(tmp_path / "live.db")
+    _patch_db_path(monkeypatch, db_path)
+    _seed_db(db_path, "Usable Project")
+
+    backup_path = str(tmp_path / "backup.db")
+    _seed_db(backup_path, "Restored Project")
+
+    before = _db_state(db_path)
+
+    def boom_replace(src, dst):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr("termstory.backup.os.replace", boom_replace)
+
+    with pytest.raises(BackupError):
+        restore_db(backup_path)
+
+    # State is unchanged and the DB is still openable/valid.
+    assert _db_state(db_path) == before
+    conn = sqlite3.connect(db_path)
+    try:
+        assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+    finally:
+        conn.close()
+
+
+def test_restore_concurrent_same_lock_fails_cleanly(tmp_path, monkeypatch):
+    """A second restore attempt while a restore lock is held must fail cleanly
+    with BackupError and not touch the active DB."""
+    db_path = str(tmp_path / "live.db")
+    _patch_db_path(monkeypatch, db_path)
+    _seed_db(db_path, "Keep Me")
+
+    backup_path = str(tmp_path / "backup.db")
+    _seed_db(backup_path, "Other Project")
+
+    # Take the restore lock first, simulating a concurrent restore in progress.
+    with open(db_path + ".restore.lock", "w") as f:
+        f.write("another-restore")
+
+    with pytest.raises(BackupError):
+        restore_db(backup_path)
+
+    assert _read_first_project_name(db_path) == "Keep Me"
+    leftover = glob.glob(os.path.join(str(tmp_path), ".termstory_restore_*"))
+    assert leftover == []
+
+
+def test_restore_copy_failure_is_normalized(tmp_path, monkeypatch):
+    """A failure while copying the backup raises a normalized BackupError, the
+    active DB is untouched, and temp artifacts are cleaned up."""
+    db_path = str(tmp_path / "live.db")
+    _patch_db_path(monkeypatch, db_path)
+    _seed_db(db_path, "Sentinel Project")
+
+    backup_path = str(tmp_path / "backup.db")
+    _seed_db(backup_path, "Restored Project")
+
+    before = _db_state(db_path)
+
+    # Simulate the SQLite backup-copy step failing.  We cannot set a method on
+    # the immutable sqlite3.Connection C type, so we wrap sqlite3.connect to
+    # return a thin proxy whose .backup() raises, while still delegating
+    # everything else (validation opens, close, execute) to the real file.
+    real_connect = sqlite3.connect
+
+    class FakeBackupConn:
+        def __init__(self, real):
+            self._real = real
+        def backup(self, dst):
+            raise sqlite3.OperationalError("disk I/O error during backup")
+        def close(self):
+            self._real.close()
+        def cursor(self):
+            return self._real.cursor()
+        def execute(self, *a, **k):
+            return self._real.execute(*a, **k)
+        def commit(self):
+            return self._real.commit()
+
+    def fake_connect(*args, **kwargs):
+        return FakeBackupConn(real_connect(*args, **kwargs))
+
+    monkeypatch.setattr("termstory.backup.sqlite3.connect", fake_connect)
+
+    with pytest.raises(BackupError):
+        restore_db(backup_path)
+
+    assert _db_state(db_path) == before
+    leftover = glob.glob(os.path.join(str(tmp_path), ".termstory_restore_*"))
+    assert leftover == []
+
+
+
+def test_restore_temp_creation_failure_is_normalized(tmp_path, monkeypatch):
+    """A failure creating the temporary restore file raises a normalized
+    BackupError and the active DB is untouched."""
+    db_path = str(tmp_path / "live.db")
+    _patch_db_path(monkeypatch, db_path)
+    _seed_db(db_path, "Sentinel Project")
+
+    backup_path = str(tmp_path / "backup.db")
+    _seed_db(backup_path, "Restored Project")
+
+    before = _db_state(db_path)
+
+    def boom_mkstemp(*args, **kwargs):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr("termstory.backup.tempfile.mkstemp", boom_mkstemp)
+
+    with pytest.raises(BackupError):
+        restore_db(backup_path)
+
+    assert _db_state(db_path) == before
+
+
+def test_restore_success_cleans_stale_sidecars(tmp_path, monkeypatch):
+    """After a successful swap, stale orphaned sidecars from the OLD database
+    must be removed so the restored database cannot consume them."""
+    db_path = str(tmp_path / "live.db")
+    _patch_db_path(monkeypatch, db_path)
+    _seed_db(db_path, "Old Project")
+
+    # Plant stale sidecars for the OLD active DB that would otherwise be
+    # replayed against the newly-restored database.
+    sidecar_wal = db_path + "-wal"
+    sidecar_shm = db_path + "-shm"
+    with open(sidecar_wal, "wb") as f:
+        f.write(b"stale-old-wal")
+    with open(sidecar_shm, "wb") as f:
+        f.write(b"stale-old-shm")
+
+    backup_path = str(tmp_path / "backup.db")
+    _seed_db(backup_path, "New Project")
+
+    restore_db(backup_path)
+
+    assert _read_first_project_name(db_path) == "New Project"
+    # The old (orphaned) sidecars must be gone.
+    assert not os.path.exists(sidecar_wal)
+    assert not os.path.exists(sidecar_shm)
+    # The restore lock file is cleaned up too.
+    assert not os.path.exists(db_path + ".restore.lock")

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,8 +1,9 @@
 import logging
 import os
+import glob
 import sqlite3
 import pytest
-from termstory.backup import backup_db, restore_db
+from termstory.backup import backup_db, restore_db, BackupError
 from termstory.database import Database
 from termstory.models import Project, Session, Command
 
@@ -226,7 +227,7 @@ def test_backup_consecutive_calls_unique(tmp_path, monkeypatch):
     assert os.path.isfile(backup_one), "first backup file was not created"
     assert os.path.isfile(backup_two), "second backup file was not created"
 
-    # Both backups must contain valid SQLite data.
+        # Both backups must contain valid SQLite data.
     for backup_path in (backup_one, backup_two):
         conn = sqlite3.connect(backup_path)
         try:
@@ -234,3 +235,222 @@ def test_backup_consecutive_calls_unique(tmp_path, monkeypatch):
             assert integrity[0] == "ok"
         finally:
             conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers for Issue #479 restore-validation regression tests
+# ---------------------------------------------------------------------------
+
+def _patch_db_path(monkeypatch, db_path):
+    """Patch get_db_path in both config and backup modules to *db_path*."""
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.setattr("termstory.config.get_db_path", lambda: db_path)
+    monkeypatch.setattr("termstory.backup.get_db_path", lambda: db_path)
+
+
+def _seed_db(db_path, project_name="Test Project"):
+    """Initialize a TermStory DB and seed one project/session/command."""
+    db = Database(db_path)
+    db.init_db()
+    now = 1730000000
+    project = Project(
+        id=1, name=project_name, path="~/demo",
+        first_seen=now, last_seen=now,
+        session_count=1, total_time=100,
+    )
+    command = Command(timestamp=now, command="echo hello",
+                      session_id=1, project_id=1)
+    session = Session(
+        id=1, start_time=now, end_time=now + 100,
+        duration_seconds=100, project_id=1, commands=[command],
+    )
+    db.save_data([project], [session], [command])
+
+
+def _read_first_project_name(db_path):
+    """Return the name of the first project row, or None if no projects."""
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM projects ORDER BY id LIMIT 1")
+        row = cursor.fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+def _count_rows(db_path, table):
+    """Return the row count of *table* in the database at *db_path*."""
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM {}".format(table))
+        return cursor.fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _make_corrupt_termstory_db(path):
+    """Create a valid TermStory DB (schema + bulk data) then corrupt a data
+    page so that PRAGMA integrity_check fails while the schema on page 1
+    remains readable."""
+    db = Database(path)
+    db.init_db()
+    now = 1730000000
+    conn = sqlite3.connect(path)
+    conn.executemany(
+        "INSERT INTO commands (timestamp, command, session_id, project_id) "
+        "VALUES (?, ?, ?, ?)",
+        [(now + i, "cmd{}".format(i), 1, 1) for i in range(5000)],
+    )
+    conn.commit()
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    conn.commit()
+    conn.close()
+    page_size = 4096
+    with open(path, "r+b") as f:
+        f.seek(0, 2)
+        size = f.tell()
+        assert size > page_size * 3, "DB too small to corrupt: {} bytes".format(size)
+        f.seek(page_size * 2)
+        f.write(b"\xFF" * page_size)
+
+
+# ---------------------------------------------------------------------------
+# Issue #479 — restore validation and atomic replacement tests
+# ---------------------------------------------------------------------------
+
+def test_restore_valid_backup_succeeds(tmp_path, monkeypatch):
+    """A valid backup restores all data correctly."""
+    db_path = str(tmp_path / "live.db")
+    _patch_db_path(monkeypatch, db_path)
+
+    _seed_db(db_path, "Live Project")
+    backup_path = backup_db()
+    assert os.path.isfile(backup_path)
+
+    restore_db(backup_path)
+
+    assert os.path.isfile(db_path)
+    assert _read_first_project_name(db_path) == "Live Project"
+    assert _count_rows(db_path, "projects") == 1
+    assert _count_rows(db_path, "sessions") == 1
+    assert _count_rows(db_path, "commands") == 1
+
+
+def test_restore_rejects_non_sqlite_file(tmp_path, monkeypatch):
+    """A file that is not a SQLite database must be rejected and the
+    active DB must remain untouched."""
+    db_path = str(tmp_path / "live.db")
+    _patch_db_path(monkeypatch, db_path)
+    _seed_db(db_path, "Sentinel Project")
+
+    fake_backup = str(tmp_path / "not_sqlite.db")
+    with open(fake_backup, "w") as f:
+        f.write("This is definitely not a SQLite database file.")
+
+    with pytest.raises(BackupError):
+        restore_db(fake_backup)
+
+    assert _read_first_project_name(db_path) == "Sentinel Project"
+
+
+def test_restore_rejects_incomplete_schema(tmp_path, monkeypatch):
+    """A valid SQLite file missing required TermStory tables must be rejected."""
+    db_path = str(tmp_path / "live.db")
+    _patch_db_path(monkeypatch, db_path)
+    _seed_db(db_path, "Sentinel Project")
+
+    fake_backup = str(tmp_path / "incomplete.db")
+    conn = sqlite3.connect(fake_backup)
+    conn.execute(
+        "CREATE TABLE arbitrary_data (id INTEGER PRIMARY KEY, value TEXT)"
+    )
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(BackupError):
+        restore_db(fake_backup)
+
+    assert _read_first_project_name(db_path) == "Sentinel Project"
+
+
+def test_restore_rejects_corrupt_database(tmp_path, monkeypatch):
+    """A corrupted SQLite DB (failing integrity_check) must be rejected."""
+    db_path = str(tmp_path / "live.db")
+    _patch_db_path(monkeypatch, db_path)
+    _seed_db(db_path, "Sentinel Project")
+
+    corrupt_backup = str(tmp_path / "corrupt.db")
+    _make_corrupt_termstory_db(corrupt_backup)
+
+    with pytest.raises(BackupError):
+        restore_db(corrupt_backup)
+
+    assert _read_first_project_name(db_path) == "Sentinel Project"
+
+
+def test_restore_atomic_success_replaces_data(tmp_path, monkeypatch):
+    """A valid restore atomically replaces the active database data."""
+    db_path = str(tmp_path / "live.db")
+    _patch_db_path(monkeypatch, db_path)
+
+    _seed_db(db_path, "Old Project")
+
+    backup_db_path = str(tmp_path / "backup.db")
+    _seed_db(backup_db_path, "New Project")
+
+    restore_db(backup_db_path)
+
+    assert _read_first_project_name(db_path) == "New Project"
+
+
+def test_restore_idempotent(tmp_path, monkeypatch):
+    """Restoring the same valid backup twice must succeed both times."""
+    db_path = str(tmp_path / "live.db")
+    _patch_db_path(monkeypatch, db_path)
+
+    _seed_db(db_path, "Idempotent Project")
+    backup_path = backup_db()
+
+    restore_db(backup_path)
+    assert _read_first_project_name(db_path) == "Idempotent Project"
+
+    restore_db(backup_path)
+    assert _read_first_project_name(db_path) == "Idempotent Project"
+
+
+def test_restore_failed_no_temp_artifacts(tmp_path, monkeypatch):
+    """A failed restore must not leave temporary database files behind."""
+    db_path = str(tmp_path / "live.db")
+    _patch_db_path(monkeypatch, db_path)
+    _seed_db(db_path, "Sentinel Project")
+
+    fake_backup = str(tmp_path / "not_sqlite.db")
+    with open(fake_backup, "w") as f:
+        f.write("not a database")
+
+    with pytest.raises(BackupError):
+        restore_db(fake_backup)
+
+    leftover = glob.glob(os.path.join(str(tmp_path), ".termstory_restore_*"))
+    assert leftover == [], "Leftover temp files: {}".format(leftover)
+
+
+def test_restore_failed_preserves_all_active_data(tmp_path, monkeypatch):
+    """After a failed restore, every table in the active DB must be intact."""
+    db_path = str(tmp_path / "live.db")
+    _patch_db_path(monkeypatch, db_path)
+    _seed_db(db_path, "Preserve Me")
+
+    fake_backup = str(tmp_path / "not_sqlite.db")
+    with open(fake_backup, "w") as f:
+        f.write("corrupt")
+
+    with pytest.raises(BackupError):
+        restore_db(fake_backup)
+
+    assert _read_first_project_name(db_path) == "Preserve Me"
+    assert _count_rows(db_path, "projects") == 1
+    assert _count_rows(db_path, "sessions") == 1
+    assert _count_rows(db_path, "commands") == 1

--- a/tests/test_cli_restore_confirmation.py
+++ b/tests/test_cli_restore_confirmation.py
@@ -334,3 +334,77 @@ def test_restore_preserves_existing_error_contract_on_missing_file(tmp_path, mon
     result = runner.invoke(app, ["restore", "--yes", str(backup_db)])
     assert result.exit_code == 1, result.output
     assert "error" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Issue #479 — CLI validation error handling
+# ---------------------------------------------------------------------------
+
+def _make_corrupt_termstory_db(path):
+    """Create a valid TermStory DB then corrupt a data page so
+    PRAGMA integrity_check fails."""
+    from termstory.database import Database
+    db = Database(path)
+    db.init_db()
+    import sqlite3
+    conn = sqlite3.connect(path)
+    conn.executemany(
+        "INSERT INTO commands (timestamp, command, session_id, project_id) "
+        "VALUES (?, ?, ?, ?)",
+        [(1730000000 + i, "cmd%d" % i, 1, 1) for i in range(5000)],
+    )
+    conn.commit()
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    conn.commit()
+    conn.close()
+    page_size = 4096
+    with open(path, "r+b") as f:
+        f.seek(page_size * 2)
+        f.write(b"\xFF" * page_size)
+
+
+def test_restore_cli_rejects_non_sqlite_backup_cleanly(tmp_path, monkeypatch):
+    """A non-SQLite backup file must produce a clean CLI error (no traceback)
+    and the live database must remain untouched."""
+    live_db = _patch_paths(monkeypatch, tmp_path)
+    _seed_db(str(live_db), project_name="Live Project")
+
+    # Create a non-SQLite file as a fake backup
+    fake_backup = tmp_path / "not_sqlite.db"
+    fake_backup.write_text("This is not a database file at all.")
+
+    _force_non_interactive(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(app, ["restore", "--yes", str(fake_backup)])
+
+    assert result.exit_code == 1, result.output
+    assert "error" in result.output.lower()
+    assert "Traceback" not in result.output
+    # Active DB must be unchanged
+    restored = Database(str(live_db))
+    projects = restored.search_projects("")
+    assert len(projects) == 1
+    assert projects[0].name == "Live Project"
+
+
+def test_restore_cli_rejects_corrupt_backup_cleanly(tmp_path, monkeypatch):
+    """A corrupt (integrity_check-failing) backup must produce a clean CLI
+    error (no traceback) and the live database must remain untouched."""
+    live_db = _patch_paths(monkeypatch, tmp_path)
+    _seed_db(str(live_db), project_name="Live Project")
+
+    corrupt_backup = tmp_path / "corrupt.db"
+    _make_corrupt_termstory_db(str(corrupt_backup))
+
+    _force_non_interactive(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(app, ["restore", "--yes", str(corrupt_backup)])
+
+    assert result.exit_code == 1, result.output
+    assert "error" in result.output.lower()
+    assert "Traceback" not in result.output
+    # Active DB must be unchanged
+    restored = Database(str(live_db))
+    projects = restored.search_projects("")
+    assert len(projects) == 1
+    assert projects[0].name == "Live Project"

--- a/tests/test_cli_restore_confirmation.py
+++ b/tests/test_cli_restore_confirmation.py
@@ -408,3 +408,36 @@ def test_restore_cli_rejects_corrupt_backup_cleanly(tmp_path, monkeypatch):
     projects = restored.search_projects("")
     assert len(projects) == 1
     assert projects[0].name == "Live Project"
+
+
+def test_restore_cli_operational_failure_clean_no_traceback(tmp_path, monkeypatch):
+    """An operational failure (e.g. os.replace failing under simulated disk
+    error) must reach the clean CLI error path: exit 1, no traceback, active
+    DB untouched."""
+    live_db = _patch_paths(monkeypatch, tmp_path)
+    _seed_db(str(live_db), project_name="Live Project")
+
+    backup_db = tmp_path / "backup.db"
+    _seed_db(str(backup_db), project_name="Backup Project")
+
+    def boom_replace(src, dst):
+        raise OSError("simulated disk failure")
+
+    monkeypatch.setattr("termstory.backup.os.replace", boom_replace)
+
+    _force_non_interactive(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(app, ["restore", "--yes", str(backup_db)])
+
+    assert result.exit_code == 1, result.output
+    assert "error" in result.output.lower()
+    assert "Traceback" not in result.output
+    # Active DB must be unchanged.
+    restored = Database(str(live_db))
+    projects = restored.search_projects("")
+    assert len(projects) == 1
+    assert projects[0].name == "Live Project"
+    # No temp artifacts left behind.
+    import glob
+    leftover = glob.glob(os.path.join(str(tmp_path), ".termstory_restore_*"))
+    assert leftover == []


### PR DESCRIPTION
Closes #479

## Summary

- Validate backup readability, required Termstory schema, and SQLite integrity before restore.
- Restore into a temporary database rather than directly overwriting the active database.
- Re-validate the restored temporary database before replacement.
- Atomically replace the active database with `os.replace()`.
- Clean up temporary database and SQLite sidecar artifacts on failure.
- Handle restore validation failures cleanly in the CLI.
- Preserve the active database when validation or restoration fails.

## Validation

- `pytest tests/test_backup.py -q` — 13 passed
- `pytest tests/test_cli_restore_confirmation.py -q` — 11 passed
- `pytest tests/test_database.py -q` — 18 passed
- `pytest tests/test_save_data_none_safety.py -q` — 5 passed
- Combined — 47 passed
- `git diff --check` — clean

No schema or migration changes.