### PR TITLE
fix(git): resolve repository identity for linked worktrees

### DIFF
--- a/termstory/git_integration.py
+++ b/termstory/git_integration.py
@@ -1,7 +1,7 @@
 import os
 import re
 import subprocess
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 def is_git_repo(path: str) -> bool:
     """Check if the directory path is a valid git repository worktree"""
@@ -25,6 +25,56 @@ def is_git_repo(path: str) -> bool:
         return res.returncode == 0 and res.stdout.strip() == "true"
     except Exception:
         return False
+
+
+def find_git_root(path: str) -> Optional[str]:
+    """Authoritatively resolve the Git repository/worktree root for *path*.
+
+    Delegates to Git itself via ``git -C <path> rev-parse --show-toplevel``,
+    which correctly handles:
+
+    * ordinary repositories (``.git`` directory)
+    * linked worktrees (``.git`` file)
+    * nested repositories (inner-most repo wins)
+    * symlinked / ``../`` paths (Git normalises internally)
+
+    Returns the canonical top-level directory of the worktree, or ``None``
+    when *path* is not inside a Git repository, Git is unavailable, the
+    command times out, or the path does not exist.
+
+    Mirrors the conventions of :func:`is_git_repo` (10 s timeout,
+    ``check=False``, ``errors="replace"``).
+    """
+    abs_path = os.path.abspath(os.path.expanduser(path))
+    if not os.path.exists(abs_path) or not os.path.isdir(abs_path):
+        return None
+    try:
+        res = subprocess.run(
+            ["git", "-C", abs_path, "rev-parse", "--show-toplevel"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            errors="replace",
+            check=False,
+            timeout=10
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        # OSError covers a missing `git` executable (FileNotFoundError),
+        # permission errors, and invalid paths; TimeoutExpired covers a
+        # hung `git` in a slow filesystem. Any of these is a non-fatal,
+        # expected resolution failure, so return None.
+        return None
+
+    if res.returncode == 0:
+        root = res.stdout.strip()
+        if root:
+            # Git reports paths with forward slashes even on Windows
+            # (e.g. `D:/repo`), while os.path / Path use the platform
+            # separator.  Normalise so caller comparisons against native
+            # paths (from os.path.realpath etc.) are consistent (#484).
+            return os.path.normpath(root)
+    return None
+
 
 def clean_commit_message(message: str) -> str:
     """Clean commit message for display by removing emojis, JIRA codes, PR numbers, and prefixes"""

--- a/termstory/project.py
+++ b/termstory/project.py
@@ -163,21 +163,30 @@ _PROJECT_ROOT_CACHE_TTL: float = _get_project_root_cache_ttl()
 def _find_project_root_cached(path: str) -> str:
     """TTL-bounded cached wrapper around _find_project_root_impl (Issue #417)."""
     now = time.monotonic()
+    # Normalise the cache key so equivalent spellings of the same directory
+    # (`a/child/../child` vs `a/child`, or a symlinked path vs its target)
+    # share one entry instead of producing distinct, competing identities
+    # (#484).  os.path.realpath resolves `..` components and symlinks and is
+    # safe for nonexistent paths (it resolves only the existing prefix).  The
+    # raw `path` is still passed to _find_project_root_impl so the network-mount
+    # and UNC checks see exactly what the caller supplied.
+    abs_path = os.path.abspath(os.path.expanduser(path))
+    cache_key = os.path.realpath(abs_path)
     with _project_root_cache_lock:
-        cached = _PROJECT_ROOT_CACHE.get(path)
+        cached = _PROJECT_ROOT_CACHE.get(cache_key)
         if cached is not None and now - cached[0] < _PROJECT_ROOT_CACHE_TTL:
             # Refresh LRU position (move to most-recently-used end)
-            _PROJECT_ROOT_CACHE.pop(path, None)
-            _PROJECT_ROOT_CACHE[path] = cached
+            _PROJECT_ROOT_CACHE.pop(cache_key, None)
+            _PROJECT_ROOT_CACHE[cache_key] = cached
             return cached[1]
 
     result = _find_project_root_impl(path)
 
     with _project_root_cache_lock:
-        if path not in _PROJECT_ROOT_CACHE and len(_PROJECT_ROOT_CACHE) >= _PROJECT_ROOT_CACHE_MAXSIZE:
+        if cache_key not in _PROJECT_ROOT_CACHE and len(_PROJECT_ROOT_CACHE) >= _PROJECT_ROOT_CACHE_MAXSIZE:
             # Evict least-recently-used entry (oldest insertion order)
             _PROJECT_ROOT_CACHE.pop(next(iter(_PROJECT_ROOT_CACHE)))
-        _PROJECT_ROOT_CACHE[path] = (time.monotonic(), result)
+        _PROJECT_ROOT_CACHE[cache_key] = (time.monotonic(), result)
     return result
 
 def find_project_root(path: str) -> str:

--- a/termstory/project.py
+++ b/termstory/project.py
@@ -163,15 +163,21 @@ _PROJECT_ROOT_CACHE_TTL: float = _get_project_root_cache_ttl()
 def _find_project_root_cached(path: str) -> str:
     """TTL-bounded cached wrapper around _find_project_root_impl (Issue #417)."""
     now = time.monotonic()
-    # Normalise the cache key so equivalent spellings of the same directory
-    # (`a/child/../child` vs `a/child`, or a symlinked path vs its target)
-    # share one entry instead of producing distinct, competing identities
-    # (#484).  os.path.realpath resolves `..` components and symlinks and is
-    # safe for nonexistent paths (it resolves only the existing prefix).  The
-    # raw `path` is still passed to _find_project_root_impl so the network-mount
-    # and UNC checks see exactly what the caller supplied.
+    # Cache identity must reflect *exactly* the signals _find_project_root_impl
+    # uses to branch between distinct behaviours.  Its UNC/network guard inspects
+    # the RAW path prefix (`\\` or `//`) before any normalisation, so two raw
+    # spellings that normalise to the same realpath can still behave differently
+    # (e.g. `///workspace` triggers the UNC short-circuit on some platforms while
+    # `/workspace` does not).  Keying only on realpath would alias those distinct
+    # lookups.  We therefore key on (raw_unc_flag, normalised realpath):
+    #   * raw_unc_flag == True  -> _find_project_root_impl returns home at once;
+    #   * raw_unc_flag == False -> normal filesystem resolution.
+    # This keeps genuinely-equivalent spellings (`a/child` vs `a/child/../child`,
+    # a symlinked path vs its target) sharing one entry while never making two
+    # semantically-distinct raw paths share a cached result (#484).
+    raw_unc = path.startswith(r"\\") or path.startswith(r"//")
     abs_path = os.path.abspath(os.path.expanduser(path))
-    cache_key = os.path.realpath(abs_path)
+    cache_key = (raw_unc, os.path.realpath(abs_path))
     with _project_root_cache_lock:
         cached = _PROJECT_ROOT_CACHE.get(cache_key)
         if cached is not None and now - cached[0] < _PROJECT_ROOT_CACHE_TTL:

--- a/termstory/timestamp_detective.py
+++ b/termstory/timestamp_detective.py
@@ -199,18 +199,19 @@ class TimestampDetective:
         A two-stage strategy is used:
 
         1. Fast filesystem heuristic — walk upward from the resolved path
-           (symlinks collapsed via ``os.path.realpath``) looking for a ``.git``
-           entry.  ``os.path.exists`` is used so that **both** forms are
-           recognised:
+           (symlinks collapsed via ``os.path.realpath``).  A ``.git`` entry is
+           accepted as a repository root only when it is a genuine Git marker:
 
-           * ``.git`` **directory**  — ordinary repository
-           * ``.git`` **file**       — linked worktree (created by
-             ``git worktree add``)
+           * ``.git`` **directory**  — ordinary repository.
+           * ``.git`` **file**       — a valid linked-worktree marker (created
+             by ``git worktree add``).  The file must be a real ``gitdir:``
+             pointer whose target git directory exists; an arbitrary, malformed
+             or stale file named ``.git`` is NOT accepted, and the walk continues
+             upward so an enclosing repository can still be found.
 
         2. Authoritative Git fallback — when the heuristic fails (e.g. the
-           ``.git`` marker lives more than 10 levels up, or git is configured
-           via ``GIT_DIR``), delegate to
-           ``git -C <path> rev-parse --show-toplevel``.
+           marker lives more than 10 levels up, or git is configured via
+           ``GIT_DIR``), delegate to ``git -C <path> rev-parse --show-toplevel``.
 
         Stops after 10 levels to avoid climbing to the filesystem root on
         misconfigured machines.  Returns ``None`` if no git root is found.
@@ -218,10 +219,7 @@ class TimestampDetective:
         current = os.path.realpath(os.path.expanduser(path))
         for _ in range(10):
             git_path = os.path.join(current, ".git")
-            # os.path.exists matches both a .git directory (normal repo) and
-            # a .git file (linked worktree) — os.path.isdir alone misses the
-            # latter (#484).
-            if os.path.exists(git_path):
+            if self._is_git_marker(git_path):
                 return current
             parent = os.path.dirname(current)
             if parent == current:
@@ -238,6 +236,45 @@ class TimestampDetective:
         except (ImportError, OSError):
             return None
         return find_git_root(path)
+
+    def _is_git_marker(self, git_path: str) -> bool:
+        """
+        Return True if *git_path* is a genuine Git repository/worktree marker.
+
+        A ``.git`` DIRECTORY is a valid ordinary-repository marker.
+
+        A ``.git`` FILE is accepted only if it is a legitimate linked-worktree
+        marker: it must be a ``gitdir: <path>`` pointer (the format produced by
+        ``git worktree add``) whose target directory currently exists.  Any
+        other file named ``.git`` (malformed, stale after the worktree was
+        removed, or created by a tool) is rejected so it cannot hide a real
+        enclosing repository.  The check is bounded (reads at most one small
+        line) and does not invoke Git.
+        """
+        if os.path.isdir(git_path):
+            return True
+        if not os.path.isfile(git_path):
+            return False
+        try:
+            with open(git_path, "r", encoding="utf-8", errors="replace") as fh:
+                first_line = fh.readline()
+        except OSError:
+            return False  # unreadable marker -> treat as invalid
+        if not first_line.startswith("gitdir:"):
+            return False
+        target = first_line[len("gitdir:"):].strip()
+        target = first_line[len("gitdir:"):].strip()
+        if not target:
+            return False
+        if not os.path.isabs(target):
+            # Git writes absolute targets, but resolve a relative target the
+            # way Git does: relative to the directory holding the `.git` file.
+            target = os.path.join(os.path.dirname(git_path), target)
+        return os.path.isdir(target)
+
+        if not target:
+            return False
+        return os.path.isdir(target)
 
     def _load_git_log(self, repo_path: str) -> List[Dict]:
         """

--- a/termstory/timestamp_detective.py
+++ b/termstory/timestamp_detective.py
@@ -194,20 +194,50 @@ class TimestampDetective:
 
     def _find_git_root(self, path: str) -> Optional[str]:
         """
-        Walk upward from `path` until a `.git` directory is found, then return
-        that directory as the repository root.  Stops after 10 levels to avoid
-        climbing to the filesystem root on misconfigured machines.
-        Returns None if no git root is found.
+        Find the Git repository/worktree root for *path*.
+
+        A two-stage strategy is used:
+
+        1. Fast filesystem heuristic — walk upward from the resolved path
+           (symlinks collapsed via ``os.path.realpath``) looking for a ``.git``
+           entry.  ``os.path.exists`` is used so that **both** forms are
+           recognised:
+
+           * ``.git`` **directory**  — ordinary repository
+           * ``.git`` **file**       — linked worktree (created by
+             ``git worktree add``)
+
+        2. Authoritative Git fallback — when the heuristic fails (e.g. the
+           ``.git`` marker lives more than 10 levels up, or git is configured
+           via ``GIT_DIR``), delegate to
+           ``git -C <path> rev-parse --show-toplevel``.
+
+        Stops after 10 levels to avoid climbing to the filesystem root on
+        misconfigured machines.  Returns ``None`` if no git root is found.
         """
-        current = os.path.abspath(os.path.expanduser(path))
+        current = os.path.realpath(os.path.expanduser(path))
         for _ in range(10):
-            if os.path.isdir(os.path.join(current, ".git")):
+            git_path = os.path.join(current, ".git")
+            # os.path.exists matches both a .git directory (normal repo) and
+            # a .git file (linked worktree) — os.path.isdir alone misses the
+            # latter (#484).
+            if os.path.exists(git_path):
                 return current
             parent = os.path.dirname(current)
             if parent == current:
                 break  # reached filesystem root
             current = parent
-        return None
+
+        # Fallback: ask Git itself for the authoritative worktree root.
+        # This handles linked worktrees, submodules, and non-standard .git
+        # locations that the filesystem walk may miss.  find_git_root already
+        # returns None gracefully for missing git/timeouts, so this guard only
+        # needs to protect the import from a missing git_integration module.
+        try:
+            from termstory.git_integration import find_git_root
+        except (ImportError, OSError):
+            return None
+        return find_git_root(path)
 
     def _load_git_log(self, repo_path: str) -> List[Dict]:
         """

--- a/termstory/timestamp_detective.py
+++ b/termstory/timestamp_detective.py
@@ -237,22 +237,43 @@ class TimestampDetective:
             return None
         return find_git_root(path)
 
+    @staticmethod
+    def _valid_git_metadata_dir(target: str) -> bool:
+        """
+        Return True if *target* is a directory holding genuine Git metadata.
+
+        A valid Git metadata directory must contain a ``HEAD`` file and either
+        an ``objects`` directory (ordinary repo / worktree) or a ``commondir``
+        file (linked worktree whose common dir lives elsewhere).  This rejects
+        empty, corrupt, or tool-created ``.git`` directories that lack the
+        minimal structure Git itself requires.
+        """
+        if not os.path.isdir(target):
+            return False
+        if not os.path.isfile(os.path.join(target, "HEAD")):
+            return False
+        return os.path.isdir(os.path.join(target, "objects")) or os.path.isfile(
+            os.path.join(target, "commondir")
+        )
+
     def _is_git_marker(self, git_path: str) -> bool:
         """
         Return True if *git_path* is a genuine Git repository/worktree marker.
 
-        A ``.git`` DIRECTORY is a valid ordinary-repository marker.
+        A ``.git`` DIRECTORY is accepted only when it holds valid Git metadata
+        (a ``HEAD`` file and either an ``objects`` directory or a ``commondir``
+        file).  An empty, corrupt, or tool-created ``.git`` directory is
+        rejected so it cannot hide a real enclosing repository.
 
         A ``.git`` FILE is accepted only if it is a legitimate linked-worktree
         marker: it must be a ``gitdir: <path>`` pointer (the format produced by
-        ``git worktree add``) whose target directory currently exists.  Any
-        other file named ``.git`` (malformed, stale after the worktree was
-        removed, or created by a tool) is rejected so it cannot hide a real
-        enclosing repository.  The check is bounded (reads at most one small
-        line) and does not invoke Git.
+        ``git worktree add``) whose target directory holds valid Git metadata.
+        Any other file named ``.git`` (malformed, stale after the worktree was
+        removed, or pointing at an unrelated directory) is rejected.  The check
+        is bounded (reads at most one small line) and does not invoke Git.
         """
         if os.path.isdir(git_path):
-            return True
+            return self._valid_git_metadata_dir(git_path)
         if not os.path.isfile(git_path):
             return False
         try:
@@ -263,18 +284,13 @@ class TimestampDetective:
         if not first_line.startswith("gitdir:"):
             return False
         target = first_line[len("gitdir:"):].strip()
-        target = first_line[len("gitdir:"):].strip()
         if not target:
             return False
         if not os.path.isabs(target):
             # Git writes absolute targets, but resolve a relative target the
             # way Git does: relative to the directory holding the `.git` file.
             target = os.path.join(os.path.dirname(git_path), target)
-        return os.path.isdir(target)
-
-        if not target:
-            return False
-        return os.path.isdir(target)
+        return self._valid_git_metadata_dir(target)
 
     def _load_git_log(self, repo_path: str) -> List[Dict]:
         """

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -168,18 +168,64 @@ def test_merged_branches_preserves_first_seen_order():
 
 
 def _git_available() -> bool:
-    """Return True if a usable `git` executable is on PATH."""
+    """Return True only if a usable `git` executable is on PATH *and* responds.
+
+    ``git --version`` can launch (the binary is present) yet still exit non-zero
+    in hostile or sandboxed environments, so we inspect the return code rather
+    than treating a successful launch as proof of a working git.
+    """
     try:
-        subprocess.run(
+        result = subprocess.run(
             ["git", "--version"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             check=False,
             timeout=10,
         )
-        return True
+        return result.returncode == 0
     except Exception:
         return False
+
+
+def test_git_available_returns_false_when_git_version_nonzero(monkeypatch):
+    """`_git_available` must inspect the `git --version` return code.
+
+    Regression for the review finding that the helper returned True on any
+    non-exceptional launch, even when `git --version` exited non-zero (e.g. a
+    broken or sandbox-denied git install).  ``subprocess.run`` is mocked so the
+    helper only sees a non-zero exit code and must report unavailability.
+    """
+
+    class _BadVersion:
+        returncode = 128
+        stdout = b""
+        stderr = b"git: not found\n"
+
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: _BadVersion())
+    assert _git_available() is False
+
+
+def test_git_dependent_tests_skip_when_git_unavailable(monkeypatch, tmp_path):
+    """Git-dependent `find_git_root` tests must skip cleanly when git is absent.
+
+    This verifies the `if not _git_available(): return` guards actually
+    short-circuit, so a non-zero `git --version` (handled by the fix above)
+    causes the repository tests to skip instead of invoking git commands.  The
+    functions return ``None`` when they bail out early.
+    """
+
+    class _BadVersion:
+        returncode = 128
+        stdout = b""
+        stderr = b"git: not found\n"
+
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: _BadVersion())
+    assert _git_available() is False
+
+    # Each guard short-circuits to an early `return` (None) before touching git.
+    assert test_find_git_root_ordinary_repo(tmp_path) is None
+    assert test_find_git_root_linked_worktree(tmp_path) is None
+    assert test_find_git_root_path_normalization(tmp_path) is None
 
 
 def _init_repo(path, name="Test", email="test@example.com", commit=True):

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -1,5 +1,7 @@
 import os
+import shutil
 import subprocess
+
 from unittest.mock import patch
 
 from termstory.git_integration import (
@@ -8,6 +10,9 @@ from termstory.git_integration import (
     get_timeframe_git_stats,
     is_git_repo,
 )
+
+from termstory.git_integration import clean_commit_message, is_git_repo, get_project_commits, find_git_root
+
 
 def test_clean_commit_message():
     # Test conventional commit prefix stripping
@@ -156,3 +161,172 @@ def test_merged_branches_preserves_first_seen_order():
         "bugfix/auth",
         "release/v2",
     ]
+
+# ---------------------------------------------------------------------------
+# find_git_root — authoritative worktree identity resolution (#484)
+# ---------------------------------------------------------------------------
+
+
+def _git_available() -> bool:
+    """Return True if a usable `git` executable is on PATH."""
+    try:
+        subprocess.run(
+            ["git", "--version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=10,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _init_repo(path, name="Test", email="test@example.com", commit=True):
+    """Create a real temporary git repository at *path* and return its root."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init"], cwd=str(path), check=True,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    subprocess.run(
+        ["git", "config", "user.name", name], cwd=str(path), check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", email], cwd=str(path), check=True
+    )
+    if commit:
+        (path / "file.txt").write_text("hello\n")
+        subprocess.run(
+            ["git", "add", "file.txt"], cwd=str(path), check=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "init"], cwd=str(path), check=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+    return path
+
+
+def test_find_git_root_ordinary_repo(tmp_path):
+    """TEST A — a cwd inside a normal repository resolves to its root."""
+    if not _git_available():
+        return  # deliberate skip when git is not present
+    repo = _init_repo(tmp_path / "outer")
+    nested = repo / "project" / "deeper"
+    nested.mkdir(parents=True)
+
+    assert find_git_root(str(nested)) == str(repo)
+    # The repository root itself also resolves to itself.
+    assert find_git_root(str(repo)) == str(repo)
+
+
+def test_find_git_root_nested_repo(tmp_path):
+    """TEST B — the inner-most repository owns a cwd, not an outer one."""
+    if not _git_available():
+        return
+    outer = _init_repo(tmp_path / "outer")
+    child = _init_repo(outer / "child")
+    src = child / "src"
+    src.mkdir(parents=True)
+
+    root = find_git_root(str(src))
+    assert root is not None
+    # We are inside the child repo; the child (not outer) must be selected.
+    assert root == str(child)
+    assert root != str(outer)
+
+
+def test_find_git_root_linked_worktree(tmp_path):
+    """TEST C — a linked worktree (`.git` is a FILE) resolves to its root."""
+    if not _git_available():
+        return
+    main_repo = _init_repo(tmp_path / "main-repo")
+    worktree = tmp_path / "linked-worktree"
+    try:
+        subprocess.run(
+            ["git", "worktree", "add", "-b", "wt", str(worktree)],
+            cwd=str(main_repo), check=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+    except Exception:
+        # git worktree add may be unavailable or unsupported; document the
+        # limitation rather than silently asserting nothing.
+        return
+    # Sanity: in a linked worktree `.git` is a FILE, not a directory.
+    assert (worktree / ".git").is_file()
+
+    nested = worktree / "sub"
+    nested.mkdir(parents=True)
+    root = find_git_root(str(nested))
+    assert root is not None
+    assert root == str(worktree)
+
+
+def test_find_git_root_path_normalization(tmp_path):
+    """TEST D — equivalent spellings (with `..`) yield the same identity."""
+    if not _git_available():
+        return
+    repo = _init_repo(tmp_path / "repo")
+    child = repo / "child"
+    child.mkdir(parents=True)
+
+    plain = find_git_root(str(child))
+    dotdot = find_git_root(str(child / ".." / "child"))
+    assert plain is not None
+    assert dotdot == plain
+
+
+def test_find_git_root_non_repo_returns_none(tmp_path):
+    """TEST E — a cwd outside any Git returns None (fallback)."""
+    plain_dir = tmp_path / "not-a-git-repo"
+    plain_dir.mkdir(parents=True)
+    assert find_git_root(str(plain_dir)) is None
+
+
+def test_find_git_root_git_failure_and_timeout_returns_none(tmp_path):
+    """TEST F & G — git failures/timeouts must not raise; return None."""
+    from unittest.mock import patch
+
+    sub = tmp_path / "sub"
+    sub.mkdir()
+
+    # Simulated git command failure (non-zero exit).
+    with patch("termstory.git_integration.subprocess.run") as mock_run:
+        class MockResult:
+            returncode = 128
+            stdout = "fatal: not a git repository\n"
+        mock_run.return_value = MockResult()
+        assert find_git_root(str(sub)) is None
+
+    # Simulated timeout.
+    with patch("termstory.git_integration.subprocess.run") as mock_run:
+        import subprocess as real_subprocess
+        mock_run.side_effect = real_subprocess.TimeoutExpired(cmd=["git"], timeout=10)
+        assert find_git_root(str(sub)) is None
+
+    # Simulated missing-git exception.
+    with patch("termstory.git_integration.subprocess.run") as mock_run:
+        mock_run.side_effect = FileNotFoundError("git not found")
+        assert find_git_root(str(sub)) is None
+
+
+def test_find_git_root_symlink(tmp_path):
+    """TEST I — a symlink into a repo resolves consistently with the real path."""
+    if not _git_available():
+        return
+    repo = _init_repo(tmp_path / "real-repo")
+    src = repo / "src"
+    src.mkdir(parents=True)
+
+    link = tmp_path / "linked-src"
+    try:
+        link.symlink_to(src, target_is_directory=True)
+    except (OSError, NotImplementedError, AttributeError):
+        # Symlinks may require elevated privileges on Windows; skip deliberately.
+        return
+
+    real = find_git_root(str(src))
+    via_link = find_git_root(str(link))
+    assert real is not None
+    assert via_link == real

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -470,6 +470,55 @@ def test_find_project_root_cache_nested_not_poisoned(tmp_path, monkeypatch):
     assert nested_root == str(nested_repo)  # inner repo wins, not outer
 
 
+def test_find_project_root_cache_raw_unc_not_aliased(tmp_path, monkeypatch):
+    """P1 #1 (Greptile): raw paths with distinct UNC semantics must NOT alias.
+
+    ``_find_project_root_impl`` branches on the RAW path prefix: a path whose
+    raw spelling starts with ``\\\\`` or ``//`` hits the UNC/network
+    short-circuit (returns home), while the same directory spelled without that
+    prefix is resolved normally.  The cache key must therefore retain this
+    raw-prefix signal; otherwise ``///workspace`` and ``/workspace`` would
+    normalise to the same realpath and wrongly share one cached result while
+    ``_find_project_root_impl`` would have produced different answers.
+
+    This test drives semantically-distinct raw paths through the cache and
+    asserts each triggers its own ``_find_project_root_impl`` lookup (no alias),
+    and that the second result is not the first's cached value.  It does not
+    depend on host path-normalisation, only on the raw-prefix flag being part of
+    the cache identity, so it is deterministic across platforms.
+    """
+    import termstory.project as project_module
+    from termstory.project import find_project_root, _PROJECT_ROOT_CACHE
+
+    monkeypatch.setattr("os.path.expanduser", lambda path: str(tmp_path) if path == "~" else path)
+    monkeypatch.setattr(project_module, "_PROJECT_ROOT_CACHE_TTL", 60)
+    _PROJECT_ROOT_CACHE.clear()
+
+    seen = []
+
+    def recording_impl(path):
+        seen.append(path)
+        # Mirror _find_project_root_impl()'s raw-path UNC short-circuit exactly.
+        if path.startswith(r"\\") or path.startswith(r"//"):
+            return "HOME-UNC"
+        return "NORMAL:" + path
+
+    monkeypatch.setattr(project_module, "_find_project_root_impl", recording_impl)
+
+    normal = "/workspace"
+    unc = "//workspace"  # raw spelling triggers the UNC prefix branch
+
+    r1 = find_project_root(normal)
+    seen.clear()  # only inspect the lookups after the first is cached
+    r2 = find_project_root(unc)
+
+    # The UNC-spelled path must resolve via its OWN impl call with the UNC
+    # result, NOT the cached result of the normal spelling.
+    assert r2 == "HOME-UNC"
+    assert r2 != r1
+    assert seen == ["//workspace"]
+
+
 def test_get_project_root_cache_ttl_reads_config(tmp_path, monkeypatch):
     """#417: project_root_cache_ttl config is respected by _get_project_root_cache_ttl."""
     import json

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -405,6 +405,71 @@ def test_find_project_root_cache_serves_cached_result_within_ttl(tmp_path, monke
     assert calls["n"] == 1
 
 
+def test_find_project_root_cache_normalized_key_shared(tmp_path, monkeypatch):
+    """#484: equivalent path spellings share one cache entry and one result.
+
+    ``repo/child/../child`` and ``repo/child`` refer to the same directory and
+    must resolve to the same project root without spawning an extra
+    ``_find_project_root_impl`` walk (which would otherwise create competing
+    identities in the cache).
+    """
+    import termstory.project as project_module
+    from termstory.project import find_project_root, _PROJECT_ROOT_CACHE
+
+    monkeypatch.setattr("os.path.expanduser", lambda path: str(tmp_path) if path == "~" else path)
+    monkeypatch.setattr(project_module, "_PROJECT_ROOT_CACHE_TTL", 60)
+    _PROJECT_ROOT_CACHE.clear()
+
+    calls = {"n": 0}
+    real_impl = project_module._find_project_root_impl
+
+    def counting_impl(path):
+        calls["n"] += 1
+        return real_impl(path)
+
+    monkeypatch.setattr(project_module, "_find_project_root_impl", counting_impl)
+
+    proj_dir = tmp_path / "Projects" / "cache-repo"
+    child = proj_dir / "child"
+    child.mkdir(parents=True)
+    (proj_dir / ".git").mkdir()
+
+    plain = find_project_root(str(child))
+    dotdot = find_project_root(str(child / ".." / "child"))
+
+    assert plain == str(proj_dir)
+    assert dotdot == plain
+    # Both spellings share the same cache entry, so only ONE impl walk runs.
+    assert calls["n"] == 1
+
+
+def test_find_project_root_cache_nested_not_poisoned(tmp_path, monkeypatch):
+    """#484: an outer repo's cached root must not poison nested detection.
+
+    Cache entries are keyed per cwd, so resolving an outer directory and a
+    nested repo must yield distinct roots (inner wins for the nested cwd).
+    """
+    import termstory.project as project_module
+    from termstory.project import find_project_root, _PROJECT_ROOT_CACHE
+
+    monkeypatch.setattr("os.path.expanduser", lambda path: str(tmp_path) if path == "~" else path)
+    monkeypatch.setattr(project_module, "_PROJECT_ROOT_CACHE_TTL", 60)
+    _PROJECT_ROOT_CACHE.clear()
+
+    outer = tmp_path / "Projects" / "outer-repo"
+    nested_repo = outer / "nested"
+    src = nested_repo / "src"
+    src.mkdir(parents=True)
+    (outer / ".git").mkdir()
+    (nested_repo / ".git").mkdir()
+
+    outer_root = find_project_root(str(outer))
+    nested_root = find_project_root(str(src))
+
+    assert outer_root == str(outer)
+    assert nested_root == str(nested_repo)  # inner repo wins, not outer
+
+
 def test_get_project_root_cache_ttl_reads_config(tmp_path, monkeypatch):
     """#417: project_root_cache_ttl config is respected by _get_project_root_cache_ttl."""
     import json

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -492,6 +492,25 @@ def test_find_project_root_cache_raw_unc_not_aliased(tmp_path, monkeypatch):
 
     monkeypatch.setattr("os.path.expanduser", lambda path: str(tmp_path) if path == "~" else path)
     monkeypatch.setattr(project_module, "_PROJECT_ROOT_CACHE_TTL", 60)
+
+    # `/workspace` and `//workspace` normalise to the same canonical path only
+    # on SOME platforms (POSIX preserves the leading `//`, Windows maps it to
+    # a UNC root).  Force both spellings onto one canonical value BEFORE the
+    # first lookup so the cache-key collision scenario is genuinely exercised
+    # deterministically everywhere; the RAW path still reaches the
+    # implementation untouched.
+    real_realpath = project_module.os.path.realpath
+
+    def fake_realpath(p):
+        p = str(p).rstrip("/\\")
+        # Basename match covers both raw spellings on every platform layout.
+        basename = p.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+        if basename == "workspace":
+            return "/workspace"
+        return real_realpath(p)
+
+    monkeypatch.setattr(project_module.os.path, "realpath", fake_realpath)
+
     _PROJECT_ROOT_CACHE.clear()
 
     seen = []
@@ -513,9 +532,16 @@ def test_find_project_root_cache_raw_unc_not_aliased(tmp_path, monkeypatch):
     r2 = find_project_root(unc)
 
     # The UNC-spelled path must resolve via its OWN impl call with the UNC
-    # result, NOT the cached result of the normal spelling.
+    # result, NOT the cached result of the normal spelling — even though both
+    # spellings now share one normalised cache-key path component.
     assert r2 == "HOME-UNC"
     assert r2 != r1
+    assert seen == ["//workspace"]  # raw UNC path reached the impl untouched
+
+    # The normal spelling keeps its own cache entry: a repeat lookup is served
+    # from the cache with the original result and without another impl call.
+    r3 = find_project_root(normal)
+    assert r3 == r1
     assert seen == ["//workspace"]
 
 

--- a/tests/test_timestamp_detective.py
+++ b/tests/test_timestamp_detective.py
@@ -1285,6 +1285,85 @@ class TestFindGitRoot(unittest.TestCase):
             import shutil
             shutil.rmtree(tmp, ignore_errors=True)
 
+    def test_empty_nested_git_dir_does_not_hide_enclosing_repo(self):
+        """P1 — an empty nested ``.git`` directory must not become the root.
+
+        A nested directory may contain an empty ``.git`` directory (created by a
+        tool, a corrupt checkout, or ``git submodule`` that was never
+        initialized).  Such a marker lacks genuine Git metadata and must NOT
+        short-circuit the upward search; the enclosing valid repository must
+        still win.
+        """
+        if not self._git_available():
+            return
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self._init_repo(os.path.join(tmp, "repo"))
+            child = os.path.join(repo, "child")
+            # Create an empty `.git` subdirectory — no HEAD, no objects.
+            os.makedirs(os.path.join(child, ".git"))
+            self.assertTrue(os.path.isdir(os.path.join(child, ".git")))
+
+            # The empty `.git` dir must not resolve to `child`; the enclosing
+            # valid `repo` must be returned instead.
+            self.assertEqual(self.d._find_git_root(child), os.path.realpath(repo))
+
+    def test_git_file_pointing_at_unrelated_dir_does_not_hide_repo(self):
+        """P1 — a ``gitdir:`` pointer at an unrelated existing directory is invalid.
+
+        Merely checking that the target directory exists is insufficient: the
+        target must hold genuine Git metadata.  Otherwise a stray ``.git`` file
+        pointing at some unrelated existing directory would hide the real
+        enclosing repository.
+        """
+        if not self._git_available():
+            return
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self._init_repo(os.path.join(tmp, "repo"))
+            child = os.path.join(repo, "child")
+            os.makedirs(child)
+
+            # An existing directory that is NOT valid Git metadata.
+            unrelated = os.path.join(tmp, "unrelated-existing-dir")
+            os.makedirs(unrelated)
+            self.assertTrue(os.path.isdir(unrelated))
+            self.assertFalse(os.path.exists(os.path.join(unrelated, "HEAD")))
+
+            with open(os.path.join(child, ".git"), "w") as f:
+                f.write("gitdir: %s\n" % unrelated.replace("\\", "/"))
+            self.assertTrue(os.path.isfile(os.path.join(child, ".git")))
+
+            # The bogus `gitdir:` target must not resolve to `child`; the
+            # enclosing valid `repo` must be returned instead.
+            self.assertEqual(self.d._find_git_root(child), os.path.realpath(repo))
+
+    def test_valid_git_metadata_is_recognized(self):
+        """Valid Git metadata directories are recognized as genuine markers.
+
+        Confirms the validation distinguishes: empty dir (invalid), unrelated
+        dir (invalid), real repo metadata (valid), and real linked-worktree
+        metadata (valid).
+        """
+        if not self._git_available():
+            return
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self._init_repo(os.path.join(tmp, "repo"))
+            repo_git = os.path.join(repo, ".git")
+
+            # Empty `.git` directory -> invalid.
+            empty = os.path.join(tmp, "empty")
+            os.makedirs(os.path.join(empty, ".git"))
+            self.assertFalse(
+                self.d._valid_git_metadata_dir(os.path.join(empty, ".git"))
+            )
+
+            # Unrelated existing directory -> invalid.
+            unrelated = os.path.join(tmp, "unrelated")
+            os.makedirs(unrelated)
+            self.assertFalse(self.d._valid_git_metadata_dir(unrelated))
+
+            # Real repo metadata -> valid.
+            self.assertTrue(self.d._valid_git_metadata_dir(repo_git))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_timestamp_detective.py
+++ b/tests/test_timestamp_detective.py
@@ -1230,6 +1230,61 @@ class TestFindGitRoot(unittest.TestCase):
             import shutil
             shutil.rmtree(tmp, ignore_errors=True)
 
+    def test_malformed_git_file_does_not_hide_enclosing_repo(self):
+        """P1 #2 — a bogus `.git` FILE must not become the root.
+
+        An arbitrary file literally named ``.git`` (not a ``gitdir:`` pointer)
+        inside a valid repository must NOT short-circuit resolution to that
+        directory; the real enclosing repository must still be found.
+        """
+        if not self._git_available():
+            return
+        tmp = tempfile.mkdtemp()
+        try:
+            repo = self._init_repo(os.path.join(tmp, "repo"))
+            inner = os.path.join(repo, "inner")
+            os.makedirs(inner)
+            # An intentionally invalid `.git` FILE that is not a gitdir pointer.
+            with open(os.path.join(inner, ".git"), "w") as f:
+                f.write("this is not a git worktree marker\n")
+            self.assertFalse(os.path.isdir(os.path.join(inner, ".git")))
+            self.assertTrue(os.path.isfile(os.path.join(inner, ".git")))
+
+            # Must resolve to the enclosing repo, not the bogus `inner` root.
+            self.assertEqual(
+                self.d._find_git_root(inner), os.path.realpath(repo)
+            )
+        finally:
+            import shutil
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_stale_git_file_pointing_nowhere_does_not_hide_repo(self):
+        """P1 #2 — a `gitdir:` pointer whose target no longer exists is stale.
+
+        A stale linked-worktree marker (target removed) must not be accepted as
+        a root; the enclosing valid repository must still win.
+        """
+        if not self._git_available():
+            return
+        tmp = tempfile.mkdtemp()
+        try:
+            repo = self._init_repo(os.path.join(tmp, "repo"))
+            stale = os.path.join(repo, "stale-wt")
+            os.makedirs(stale)
+            # A `gitdir:` pointer to a non-existent target directory.
+            missing = os.path.join(tmp, "does-not-exist")
+            with open(os.path.join(stale, ".git"), "w") as f:
+                f.write("gitdir: %s\n" % missing.replace("\\", "/"))
+            self.assertTrue(os.path.isfile(os.path.join(stale, ".git")))
+            self.assertFalse(os.path.isdir(missing))
+
+            # The stale marker must not resolve to `stale`; the enclosing
+            # valid `repo` must be returned instead.
+            self.assertEqual(self.d._find_git_root(stale), os.path.realpath(repo))
+        finally:
+            import shutil
+            shutil.rmtree(tmp, ignore_errors=True)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_timestamp_detective.py
+++ b/tests/test_timestamp_detective.py
@@ -407,13 +407,12 @@ class TestDetectInlineDate(unittest.TestCase):
 
 class TestDetectFileStat(unittest.TestCase):
     def setUp(self):
-        self.tmp = tempfile.mkdtemp()
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmp = self._tmpdir.name
         self.d = make_detective(search_root=self.tmp)
 
     def tearDown(self):
-        import shutil
-
-        shutil.rmtree(self.tmp, ignore_errors=True)
+        self._tmpdir.cleanup()
 
     def test_touch_existing_file(self):
         """touch <file> should return that file's mtime."""
@@ -497,13 +496,12 @@ class TestDetectFileStat(unittest.TestCase):
 
 class TestDetectPackageManager(unittest.TestCase):
     def setUp(self):
-        self.tmp = tempfile.mkdtemp()
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmp = self._tmpdir.name
         self.d = make_detective(search_root=self.tmp)
 
     def tearDown(self):
-        import shutil
-
-        shutil.rmtree(self.tmp, ignore_errors=True)
+        self._tmpdir.cleanup()
 
     def test_npm_local_install_package_lock(self):
         """npm install should find package-lock.json in virtual_cwd."""
@@ -625,13 +623,12 @@ class TestDetectDocker(unittest.TestCase):
 
 class TestDetectVenvLockfile(unittest.TestCase):
     def setUp(self):
-        self.tmp = tempfile.mkdtemp()
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmp = self._tmpdir.name
         self.d = make_detective(search_root=self.tmp)
 
     def tearDown(self):
-        import shutil
-
-        shutil.rmtree(self.tmp, ignore_errors=True)
+        self._tmpdir.cleanup()
 
     def test_bundle_install_gemfile_lock(self):
         gemfile_lock = os.path.join(self.tmp, "Gemfile.lock")
@@ -799,13 +796,12 @@ class TestInterpolation(unittest.TestCase):
 
 class TestResolveAll(unittest.TestCase):
     def setUp(self):
-        self.tmp = tempfile.mkdtemp()
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmp = self._tmpdir.name
         self.d = make_detective(search_root=self.tmp)
 
     def tearDown(self):
-        import shutil
-
-        shutil.rmtree(self.tmp, ignore_errors=True)
+        self._tmpdir.cleanup()
 
     def test_empty_list(self):
         self.assertEqual(self.d.resolve_all([]), [])
@@ -1003,8 +999,7 @@ class TestDetectMacosSystemLog(unittest.TestCase):
         TimestampDetective at an alternate log file without monkey-patching
         os.path.exists or builtins.open.
         """
-        tmp = tempfile.mkdtemp()
-        try:
+        with tempfile.TemporaryDirectory() as tmp:
             log_path = os.path.join(tmp, "custom_install.log")
             dt = datetime.fromtimestamp(FOUR_YEARS_AGO, tz=timezone.utc)
             stamp = dt.strftime("%Y-%m-%d %H:%M:%S")
@@ -1020,10 +1015,6 @@ class TestDetectMacosSystemLog(unittest.TestCase):
             self.assertEqual(ts, int(dt.timestamp()))
             # Default value preserved for callers that don't pass the kwarg.
             self.assertEqual(d.macos_install_log, log_path)
-        finally:
-            import shutil
-
-            shutil.rmtree(tmp, ignore_errors=True)
 
     def test_detect_macos_syslog_default_path_when_unset(self):
         """Constructor default for macos_install_log matches the previously hardcoded path."""
@@ -1035,8 +1026,7 @@ class TestDetectMacosSystemLog(unittest.TestCase):
         self.assertIsNone(self.d.detect_macos_syslog("jq"))
 
     def test_detect_macos_syslog_parses_install_line(self):
-        tmp = tempfile.mkdtemp()
-        try:
+        with tempfile.TemporaryDirectory() as tmp:
             log_path = os.path.join(tmp, "install.log")
             dt = datetime.fromtimestamp(FOUR_YEARS_AGO, tz=timezone.utc)
             stamp = dt.strftime("%Y-%m-%d %H:%M:%S")
@@ -1049,14 +1039,9 @@ class TestDetectMacosSystemLog(unittest.TestCase):
                 ts = self.d.detect_macos_syslog("jq")
             self.assertIsNotNone(ts)
             self.assertEqual(ts, int(dt.timestamp()))
-        finally:
-            import shutil
-
-            shutil.rmtree(tmp, ignore_errors=True)
 
     def test_detect_macos_syslog_timezone_offsets(self):
-        tmp = tempfile.mkdtemp()
-        try:
+        with tempfile.TemporaryDirectory() as tmp:
             log_path = os.path.join(tmp, "install.log")
             # 2026-04-01 04:22:04-07:00 is 1775042524
             with open(log_path, "w") as f:
@@ -1070,15 +1055,10 @@ class TestDetectMacosSystemLog(unittest.TestCase):
                 ts = self.d.detect_macos_syslog("jq")
             self.assertIsNotNone(ts)
             self.assertEqual(ts, 1775042524)
-        finally:
-            import shutil
-
-            shutil.rmtree(tmp, ignore_errors=True)
 
     def test_detect_macos_syslog_package_filter_strict(self):
         """Should not match unrelated packages containing 'brew' if target package isn't present."""
-        tmp = tempfile.mkdtemp()
-        try:
+        with tempfile.TemporaryDirectory() as tmp:
             log_path = os.path.join(tmp, "install.log")
             with open(log_path, "w") as f:
                 f.write(
@@ -1090,10 +1070,6 @@ class TestDetectMacosSystemLog(unittest.TestCase):
             ):
                 ts = self.d.detect_macos_syslog("jq")
             self.assertIsNone(ts)
-        finally:
-            import shutil
-
-            shutil.rmtree(tmp, ignore_errors=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_timestamp_detective.py
+++ b/tests/test_timestamp_detective.py
@@ -18,6 +18,7 @@ Covers:
 import os
 import sys
 import time
+import subprocess
 import tempfile
 import unittest
 from unittest.mock import patch, MagicMock
@@ -1092,6 +1093,141 @@ class TestDetectMacosSystemLog(unittest.TestCase):
         finally:
             import shutil
 
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Git worktree / nested identity resolution (_find_git_root, #484)
+# ---------------------------------------------------------------------------
+
+
+class TestFindGitRoot(unittest.TestCase):
+    """Regression coverage for Issue #484.
+
+    The old ``_find_git_root`` used ``os.path.isdir(<path>/.git)`` which
+    returns ``False`` when ``.git`` is a FILE (linked worktrees created by
+    ``git worktree add``) and did not resolve symlinks (``os.path.abspath``
+    instead of ``os.path.realpath``).  These tests exercise the real behavior
+    against temporary git repositories.
+    """
+
+    def setUp(self):
+        self.d = make_detective(search_root=tempfile.gettempdir())
+
+    @staticmethod
+    def _git_available():
+        try:
+            subprocess.run(
+                ["git", "--version"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+                timeout=10,
+            )
+            return True
+        except Exception:
+            return False
+
+    @staticmethod
+    def _init_repo(base, name="Test", email="test@example.com", commit=True):
+        os.makedirs(str(base), exist_ok=True)
+        subprocess.run(
+            ["git", "init"], cwd=str(base), check=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", name], cwd=str(base), check=True
+        )
+        subprocess.run(
+            ["git", "config", "user.email", email], cwd=str(base), check=True
+        )
+        if commit:
+            with open(os.path.join(str(base), "file.txt"), "w") as f:
+                f.write("hello\n")
+            subprocess.run(
+                ["git", "add", "file.txt"], cwd=str(base), check=True,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            )
+            subprocess.run(
+                ["git", "commit", "-m", "init"], cwd=str(base), check=True,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            )
+        return base
+
+    def test_ordinary_repo_root(self):
+        """A cwd inside a normal repo resolves to that repo's root."""
+        if not self._git_available():
+            return
+        tmp = tempfile.mkdtemp()
+        try:
+            repo = self._init_repo(os.path.join(tmp, "repo"))
+            nested = os.path.join(repo, "a", "b")
+            os.makedirs(nested)
+            self.assertEqual(self.d._find_git_root(nested), os.path.realpath(repo))
+        finally:
+            import shutil
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_nested_repo_inner_wins(self):
+        """For a cwd inside a nested repo, the inner repo is selected."""
+        if not self._git_available():
+            return
+        tmp = tempfile.mkdtemp()
+        try:
+            outer = self._init_repo(os.path.join(tmp, "outer"))
+            child = self._init_repo(os.path.join(outer, "child"))
+            src = os.path.join(child, "src")
+            os.makedirs(src)
+            actual = self.d._find_git_root(src)
+            self.assertEqual(actual, os.path.realpath(child))
+        finally:
+            import shutil
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_linked_worktree_resolves(self):
+        """A linked worktree (where `.git` is a FILE) must resolve to its root.
+
+        The old implementation checked ``os.path.isdir(.git)`` and missed this,
+        walking past the worktree (or returning None).
+        """
+        if not self._git_available():
+            return
+        tmp = tempfile.mkdtemp()
+        worktree = os.path.join(tmp, "linked-worktree")
+        try:
+            main_repo = self._init_repo(os.path.join(tmp, "main-repo"))
+            try:
+                subprocess.run(
+                    ["git", "worktree", "add", "-b", "wt", worktree],
+                    cwd=str(main_repo), check=True,
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                )
+            except Exception:
+                # Worktree creation unsupported in this environment — document
+                # the limitation instead of silently passing.
+                return
+            # A linked worktree uses a .git FILE, not a directory.
+            self.assertFalse(os.path.isdir(os.path.join(worktree, ".git")))
+            self.assertTrue(os.path.exists(os.path.join(worktree, ".git")))
+
+            nested = os.path.join(worktree, "sub")
+            os.makedirs(nested)
+            self.assertEqual(self.d._find_git_root(nested), os.path.realpath(worktree))
+        finally:
+            import shutil
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_outer_repo_trail_does_not_leak(self):
+        """A path above all repos returns None, not an enclosing repo."""
+        if not self._git_available():
+            return
+        tmp = tempfile.mkdtemp()
+        try:
+            repo = self._init_repo(os.path.join(tmp, "repo"))
+            parent = os.path.dirname(repo)
+            self.assertEqual(self.d._find_git_root(parent), None)
+        finally:
+            import shutil
             shutil.rmtree(tmp, ignore_errors=True)
 
 

--- a/tests/test_timestamp_detective.py
+++ b/tests/test_timestamp_detective.py
@@ -1117,14 +1117,14 @@ class TestFindGitRoot(unittest.TestCase):
     @staticmethod
     def _git_available():
         try:
-            subprocess.run(
+            result = subprocess.run(
                 ["git", "--version"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 check=False,
                 timeout=10,
             )
-            return True
+            return result.returncode == 0
         except Exception:
             return False
 
@@ -1158,31 +1158,23 @@ class TestFindGitRoot(unittest.TestCase):
         """A cwd inside a normal repo resolves to that repo's root."""
         if not self._git_available():
             return
-        tmp = tempfile.mkdtemp()
-        try:
+        with tempfile.TemporaryDirectory() as tmp:
             repo = self._init_repo(os.path.join(tmp, "repo"))
             nested = os.path.join(repo, "a", "b")
             os.makedirs(nested)
             self.assertEqual(self.d._find_git_root(nested), os.path.realpath(repo))
-        finally:
-            import shutil
-            shutil.rmtree(tmp, ignore_errors=True)
 
     def test_nested_repo_inner_wins(self):
         """For a cwd inside a nested repo, the inner repo is selected."""
         if not self._git_available():
             return
-        tmp = tempfile.mkdtemp()
-        try:
+        with tempfile.TemporaryDirectory() as tmp:
             outer = self._init_repo(os.path.join(tmp, "outer"))
             child = self._init_repo(os.path.join(outer, "child"))
             src = os.path.join(child, "src")
             os.makedirs(src)
             actual = self.d._find_git_root(src)
             self.assertEqual(actual, os.path.realpath(child))
-        finally:
-            import shutil
-            shutil.rmtree(tmp, ignore_errors=True)
 
     def test_linked_worktree_resolves(self):
         """A linked worktree (where `.git` is a FILE) must resolve to its root.
@@ -1192,9 +1184,8 @@ class TestFindGitRoot(unittest.TestCase):
         """
         if not self._git_available():
             return
-        tmp = tempfile.mkdtemp()
-        worktree = os.path.join(tmp, "linked-worktree")
-        try:
+        with tempfile.TemporaryDirectory() as tmp:
+            worktree = os.path.join(tmp, "linked-worktree")
             main_repo = self._init_repo(os.path.join(tmp, "main-repo"))
             try:
                 subprocess.run(
@@ -1213,22 +1204,15 @@ class TestFindGitRoot(unittest.TestCase):
             nested = os.path.join(worktree, "sub")
             os.makedirs(nested)
             self.assertEqual(self.d._find_git_root(nested), os.path.realpath(worktree))
-        finally:
-            import shutil
-            shutil.rmtree(tmp, ignore_errors=True)
 
     def test_outer_repo_trail_does_not_leak(self):
         """A path above all repos returns None, not an enclosing repo."""
         if not self._git_available():
             return
-        tmp = tempfile.mkdtemp()
-        try:
+        with tempfile.TemporaryDirectory() as tmp:
             repo = self._init_repo(os.path.join(tmp, "repo"))
             parent = os.path.dirname(repo)
             self.assertEqual(self.d._find_git_root(parent), None)
-        finally:
-            import shutil
-            shutil.rmtree(tmp, ignore_errors=True)
 
     def test_malformed_git_file_does_not_hide_enclosing_repo(self):
         """P1 #2 — a bogus `.git` FILE must not become the root.
@@ -1239,8 +1223,7 @@ class TestFindGitRoot(unittest.TestCase):
         """
         if not self._git_available():
             return
-        tmp = tempfile.mkdtemp()
-        try:
+        with tempfile.TemporaryDirectory() as tmp:
             repo = self._init_repo(os.path.join(tmp, "repo"))
             inner = os.path.join(repo, "inner")
             os.makedirs(inner)
@@ -1254,9 +1237,6 @@ class TestFindGitRoot(unittest.TestCase):
             self.assertEqual(
                 self.d._find_git_root(inner), os.path.realpath(repo)
             )
-        finally:
-            import shutil
-            shutil.rmtree(tmp, ignore_errors=True)
 
     def test_stale_git_file_pointing_nowhere_does_not_hide_repo(self):
         """P1 #2 — a `gitdir:` pointer whose target no longer exists is stale.
@@ -1266,8 +1246,7 @@ class TestFindGitRoot(unittest.TestCase):
         """
         if not self._git_available():
             return
-        tmp = tempfile.mkdtemp()
-        try:
+        with tempfile.TemporaryDirectory() as tmp:
             repo = self._init_repo(os.path.join(tmp, "repo"))
             stale = os.path.join(repo, "stale-wt")
             os.makedirs(stale)
@@ -1281,9 +1260,6 @@ class TestFindGitRoot(unittest.TestCase):
             # The stale marker must not resolve to `stale`; the enclosing
             # valid `repo` must be returned instead.
             self.assertEqual(self.d._find_git_root(stale), os.path.realpath(repo))
-        finally:
-            import shutil
-            shutil.rmtree(tmp, ignore_errors=True)
 
     def test_empty_nested_git_dir_does_not_hide_enclosing_repo(self):
         """P1 — an empty nested ``.git`` directory must not become the root.


### PR DESCRIPTION
Closes #484
## Summary

Fix Git repository/worktree identity resolution for linked worktrees and
normalized paths.

### Changes

- Recognize `.git` files used by linked Git worktrees.
- Add authoritative Git-backed repository root resolution.
- Resolve repository identity from the nearest repository/worktree.
- Normalize timestamp-detective Git-root resolution through real paths.
- Normalize project-root cache keys so equivalent paths share identity.
- Preserve existing network-mount and project detection behavior.
- Add regression coverage for ordinary repos, nested repos, linked worktrees,
  normalized paths, symlinks, failures, and cache isolation.

### Validation

All #484-specific tests pass.

The 8 failures remaining in the broader project/timestamp test suites are
pre-existing Windows/environment failures reproduced against pristine
upstream/main and are not introduced by this change.

