### PR TITLE
[Parser] Honor TERMSTORY_DATE_OVERRIDE in bash timestamp bounds

### DIFF
--- a/termstory/parser.py
+++ b/termstory/parser.py
@@ -662,8 +662,7 @@ def _assign_missing_timestamps_fallback(
     commands_to_return = []
     
     # Pre-clean raw timestamps: discard any that are out of bounds
-    import time
-    now_clean = int(time.time())
+    now_clean = int(get_current_time().timestamp())
     from termstory.config import load_config
     max_history_age_clean = load_config().get("max_history_age", 5)
     five_years_ago_clean = now_clean - (max_history_age_clean * 365 * 24 * 60 * 60)
@@ -768,8 +767,7 @@ def _assign_missing_timestamps_fallback(
         else:
             first_known_timestamp = resolved_timestamps[first_known_idx]
             
-        import time
-        now = int(time.time())
+        now = int(get_current_time().timestamp())
         
         # Bounded Interpolation
         idx = 0

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -467,6 +467,27 @@ def test_assign_missing_timestamps_fallback_clamping():
     assert commands[0].timestamp == 1748851190
 
 
+def test_bash_history_honors_date_override_not_wall_clock(tmp_path, monkeypatch):
+    """Issue #450: bash timestamp bounds must follow TERMSTORY_DATE_OVERRIDE."""
+    from datetime import datetime
+
+    monkeypatch.setenv("TERMSTORY_DATE_OVERRIDE", "2027-06-01 12:00:00")
+    monkeypatch.setattr("time.time", lambda: 1_700_000_000)
+
+    override_ts = int(datetime(2027, 6, 1, 12, 0, 0).timestamp())
+    ts1 = override_ts - 120
+    ts2 = override_ts - 60
+    temp_file = tmp_path / "bash_date_override_test"
+    temp_file.write_text(f"#{ts1}\ngit status\n#{ts2}\ndocker ps\n")
+
+    commands = parse_bash_history(str(temp_file))
+    assert len(commands) == 2
+    assert commands[0].timestamp == ts1
+    assert commands[0].command == "git status"
+    assert commands[1].timestamp == ts2
+    assert commands[1].command == "docker ps"
+
+
 def test_parse_zsh_history_getmtime_oserror_falls_back(tmp_path):
     from unittest.mock import patch
 


### PR DESCRIPTION
## Summary
* Replace both `time.time()` calls in `_assign_missing_timestamps_fallback` with `get_current_time().timestamp()`
* Align bash/fish/powershell timestamp bounds with the zsh path under `TERMSTORY_DATE_OVERRIDE`
* Add a regression test that keeps bash timestamps when wall-clock `time.time()` would treat them as future

Fixes #450

## Test plan
* [ ] `pytest tests/test_parser.py -q`
* [ ] Confirm `test_bash_history_honors_date_override_not_wall_clock` passes