### PR TITLE
[Parser] Replace invalid UTF-8 in fish/powershell history

### DIFF
--- a/termstory/parser.py
+++ b/termstory/parser.py
@@ -774,7 +774,7 @@ def parse_fish_history(
         mtime = int(get_current_time().timestamp())
         
     temp_commands = []
-    with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
+    with open(filepath, 'r', encoding='utf-8', errors='replace') as f:
         current_cmd = None
         current_when = None
         
@@ -824,7 +824,7 @@ def parse_powershell_history(
         mtime = int(get_current_time().timestamp())
         
     raw_lines = []
-    with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
+    with open(filepath, 'r', encoding='utf-8', errors='replace') as f:
         for line in f:
             raw_lines.append(line)
             

--- a/termstory/reminder.py
+++ b/termstory/reminder.py
@@ -563,7 +563,11 @@ def start_sleep_daemon(db_path: str):
             # is (or is about to become) the running daemon — defer to it.
             try:
                 with open(pid_file, "r") as f:
-                    pid = int(f.read().strip())
+                    content = f.read().strip()
+                if not content:
+                    # Winner created the file but has not written its PID yet.
+                    return
+                pid = int(content)
                 os.kill(pid, 0)
                 return  # Already running
             except (ValueError, OSError):

--- a/termstory/reminder.py
+++ b/termstory/reminder.py
@@ -563,11 +563,7 @@ def start_sleep_daemon(db_path: str):
             # is (or is about to become) the running daemon — defer to it.
             try:
                 with open(pid_file, "r") as f:
-                    content = f.read().strip()
-                if not content:
-                    # Winner created the file but has not written its PID yet.
-                    return
-                pid = int(content)
+                    pid = int(f.read().strip())
                 os.kill(pid, 0)
                 return  # Already running
             except (ValueError, OSError):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -290,6 +290,16 @@ def test_parse_powershell_history(tmp_path):
     assert commands[0].command == "git status"
     assert commands[1].command == "docker ps ` -a"
 
+
+def test_parse_powershell_history_replaces_invalid_utf8(tmp_path):
+    """Issue #451: PowerShell path must keep U+FFFD for invalid UTF-8 (same as fish)."""
+    temp_file = tmp_path / "consolehost_history_bad_utf8.txt"
+    temp_file.write_bytes(b"echo hello\xffworld\n")
+    commands = parse_powershell_history(str(temp_file))
+    assert len(commands) == 1
+    assert commands[0].command == "echo hello\ufffdworld"
+
+
 def test_parser_multiplexer_boundary_resets(tmp_path):
     # Zsh multiline interrupted by kitty +kitten
     zsh_file = tmp_path / "zsh_multiplexer"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -263,6 +263,20 @@ def test_parse_fish_history(tmp_path):
     assert commands[1].timestamp == 1748851210
     assert commands[1].command == 'echo "hello world"'
 
+
+def test_parse_fish_history_replaces_invalid_utf8(tmp_path):
+    """Issue #451: invalid UTF-8 must become U+FFFD, not be silently dropped."""
+    temp_file = tmp_path / "fish_history_bad_utf8"
+    temp_file.write_bytes(
+        b"- cmd: echo hello\xffworld\n"
+        b"  when: 1748851200\n"
+    )
+    commands = parse_fish_history(str(temp_file))
+    assert len(commands) == 1
+    assert commands[0].command == "echo hello\ufffdworld"
+    assert commands[0].timestamp == 1748851200
+
+
 def test_parse_powershell_history(tmp_path):
     temp_file = tmp_path / "consolehost_history.txt"
     temp_file.write_text(


### PR DESCRIPTION
## Summary
* Open fish and PowerShell history with `errors='replace'` (same as zsh) instead of `errors='ignore'`
* Keep non-UTF-8 bytes as U+FFFD so command text is not silently eaten
* Add a fish regression test with an invalid byte sequence

Fixes #451

## Test plan
* [ ] `pytest tests/test_parser.py -q`
* [ ] Confirm `test_parse_fish_history_replaces_invalid_utf8` passes