### PR TITLE
[Parser] Run TimestampDetective on bash/fish/powershell history

### DIFF
--- a/termstory/parser.py
+++ b/termstory/parser.py
@@ -599,10 +599,12 @@ def _assign_missing_timestamps_with_detective(
 
     detective_commands: List[Command] = []
     claimed: set = set()
+    # Shared across detective + fallback so repeated commands don't both take
+    # existing_lookup[cmd][0] and later collapse under exact deduplication.
+    consumed: Dict[str, int] = {}
 
     if legacy_items:
         enriched = _run_timestamp_detective(legacy_items, project_paths)
-        consumed: Dict[str, int] = {}
 
         def resolve_timestamp(cmd: str, fallback_ts: int) -> int:
             if existing_lookup and cmd in existing_lookup:
@@ -632,7 +634,9 @@ def _assign_missing_timestamps_with_detective(
 
     remaining = [(t, cmd) for i, (t, cmd) in enumerate(temp_commands) if i not in claimed]
     fallback_commands = (
-        _assign_missing_timestamps_fallback(remaining, mtime, existing_lookup)
+        _assign_missing_timestamps_fallback(
+            remaining, mtime, existing_lookup, consumed=consumed
+        )
         if remaining else []
     )
 
@@ -652,7 +656,8 @@ def _assign_missing_timestamps_with_detective(
 def _assign_missing_timestamps_fallback(
     temp_commands: List[tuple],
     mtime: int,
-    existing_lookup: Optional[Dict[str, List[int]]]
+    existing_lookup: Optional[Dict[str, List[int]]],
+    consumed: Optional[Dict[str, int]] = None,
 ) -> List[Command]:
     commands_to_return = []
     
@@ -673,7 +678,8 @@ def _assign_missing_timestamps_fallback(
     
     has_any_timestamps = any(t is not None for t, _ in temp_commands)
     
-    consumed = {}
+    if consumed is None:
+        consumed = {}
     def resolve_timestamp(cmd: str, fallback_ts: int) -> int:
         if existing_lookup and cmd in existing_lookup:
             ts_list = existing_lookup[cmd]

--- a/termstory/parser.py
+++ b/termstory/parser.py
@@ -551,7 +551,103 @@ def parse_bash_history(
             if cmd_cleaned:
                 temp_commands.append((None, cmd_cleaned))
                 
-    return _assign_missing_timestamps_fallback(temp_commands, mtime, existing_lookup)
+    return _assign_missing_timestamps_with_detective(
+        temp_commands, mtime, existing_lookup, project_paths
+    )
+
+
+def _run_timestamp_detective(
+    legacy_items: List[dict],
+    project_paths: Optional[Union[List[str], Callable[[], List[str]]]] = None,
+) -> List[dict]:
+    """Run TimestampDetective on untimestamped items (shared by bash/fish/powershell)."""
+    resolved_paths: List[str] = []
+    if project_paths:
+        try:
+            resolved_paths = project_paths() if callable(project_paths) else list(project_paths)
+        except Exception:
+            logger.exception(
+                "TimestampDetective: project_paths callback raised; "
+                "continuing without project-path enrichment."
+            )
+    from termstory.config import load_config
+    _td_config = load_config()
+    detective = TimestampDetective(
+        search_root=os.path.expanduser("~"),
+        project_paths=resolved_paths or [],
+        macos_install_log=_td_config.get("macos_install_log", "/private/var/log/install.log"),
+    )
+    return detective.resolve_all(legacy_items)
+
+
+def _assign_missing_timestamps_with_detective(
+    temp_commands: List[tuple],
+    mtime: int,
+    existing_lookup: Optional[Dict[str, List[int]]],
+    project_paths: Optional[Union[List[str], Callable[[], List[str]]]] = None,
+) -> List[Command]:
+    """Resolve missing timestamps via TimestampDetective, then fall back for the rest."""
+    legacy_items = []
+    legacy_indices = []
+    for i, (t, cmd) in enumerate(temp_commands):
+        if t is None:
+            legacy_items.append({"timestamp": None, "duration": None, "command": cmd})
+            legacy_indices.append(i)
+
+    if legacy_items:
+        os.environ["TERMSTORY_MISSING_TIMESTAMPS"] = "1"
+
+    detective_commands: List[Command] = []
+    claimed: set = set()
+
+    if legacy_items:
+        enriched = _run_timestamp_detective(legacy_items, project_paths)
+        consumed: Dict[str, int] = {}
+
+        def resolve_timestamp(cmd: str, fallback_ts: int) -> int:
+            if existing_lookup and cmd in existing_lookup:
+                ts_list = existing_lookup[cmd]
+                idx = consumed.get(cmd, 0)
+                if idx < len(ts_list):
+                    consumed[cmd] = idx + 1
+                    return ts_list[idx]
+            return fallback_ts
+
+        for map_i, item in enumerate(enriched):
+            orig_i = legacy_indices[map_i]
+            detected_ts = item.get("detected_ts")
+            if detected_ts is None:
+                continue
+            resolved_ts = resolve_timestamp(item["command"], detected_ts)
+            is_real = not item.get("is_legacy_still", True)
+            detective_commands.append(Command(
+                timestamp=resolved_ts,
+                command=item["command"],
+                exit_code=0,
+                duration=None,
+                is_legacy=not is_real,
+                recovery_source=item.get("detected_source"),
+            ))
+            claimed.add(orig_i)
+
+    remaining = [(t, cmd) for i, (t, cmd) in enumerate(temp_commands) if i not in claimed]
+    fallback_commands = (
+        _assign_missing_timestamps_fallback(remaining, mtime, existing_lookup)
+        if remaining else []
+    )
+
+    combined = detective_commands + fallback_commands
+    now = int(get_current_time().timestamp())
+    from termstory.config import load_config
+    max_history_age = load_config().get("max_history_age", 5)
+    five_years_ago = now - (max_history_age * 365 * 24 * 60 * 60)
+    filtered = [
+        c for c in combined
+        if five_years_ago <= c.timestamp <= now
+    ]
+    filtered.sort(key=lambda x: x.timestamp)
+    return filtered
+
 
 def _assign_missing_timestamps_fallback(
     temp_commands: List[tuple],
@@ -802,7 +898,9 @@ def parse_fish_history(
             if cleaned:
                 temp_commands.append((current_when, cleaned))
                 
-    return _assign_missing_timestamps_fallback(temp_commands, mtime, existing_lookup)
+    return _assign_missing_timestamps_with_detective(
+        temp_commands, mtime, existing_lookup, project_paths
+    )
 
 def parse_powershell_history(
     filepath: str,
@@ -851,7 +949,9 @@ def parse_powershell_history(
         if cmd_cleaned:
             temp_commands.append((None, cmd_cleaned))
             
-    return _assign_missing_timestamps_fallback(temp_commands, mtime, existing_lookup)
+    return _assign_missing_timestamps_with_detective(
+        temp_commands, mtime, existing_lookup, project_paths
+    )
 
 def parse_all_histories(
     filepaths: List[str],

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -125,6 +125,41 @@ def test_bash_history_timestamp_detective_recovers_file_anchor(tmp_path, monkeyp
     assert "npm" in npm_cmds[0].recovery_source
 
 
+def test_fish_history_shares_timestamp_locks_across_detective_and_fallback(tmp_path, monkeypatch):
+    """Repeated commands must not both consume existing_lookup[cmd][0]."""
+    monkeypatch.delenv("TERMSTORY_MISSING_TIMESTAMPS", raising=False)
+    monkeypatch.setenv("TERMSTORY_DATE_OVERRIDE", "2026-06-14 12:00:00")
+
+    class MockTimestampDetective:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def resolve_all(self, items):
+            return [
+                {
+                    "command": item["command"],
+                    "is_legacy_still": False,
+                    "detected_ts": 1748851300,
+                    "detected_source": "Mock",
+                }
+                for item in items
+            ]
+
+    monkeypatch.setattr("termstory.parser.TimestampDetective", MockTimestampDetective)
+
+    temp_file = tmp_path / "fish_history_lock"
+    temp_file.write_text(
+        "- cmd: git status\n"
+        "  when: 1748851200\n"
+        "- cmd: git status\n"
+    )
+    existing_lookup = {"git status": [1748851000, 1748851100]}
+    commands = parse_fish_history(str(temp_file), existing_lookup=existing_lookup)
+    status_cmds = [c for c in commands if c.command == "git status"]
+    assert len(status_cmds) == 2
+    assert sorted(c.timestamp for c in status_cmds) == [1748851000, 1748851100]
+
+
 def test_parse_zsh_history_legacy_fallback(tmp_path):
     temp_file = tmp_path / "zsh_legacy_test"
     temp_file.write_text(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -100,6 +100,31 @@ def test_parse_bash_history_without_timestamps(tmp_path):
     assert commands[0].command == "git status"
     assert commands[1].command == "docker ps"
 
+
+def test_bash_history_timestamp_detective_recovers_file_anchor(tmp_path, monkeypatch):
+    """Issue #453: untimestamped bash commands use TimestampDetective like zsh."""
+    monkeypatch.delenv("TERMSTORY_MISSING_TIMESTAMPS", raising=False)
+    monkeypatch.setenv("TERMSTORY_DATE_OVERRIDE", "2026-06-14 12:00:00")
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    lock = project / "package-lock.json"
+    lock.write_text("{}\n")
+    known_ts = 1748851200
+    os.utime(str(lock), (known_ts, known_ts))
+
+    history = tmp_path / "bash_history"
+    history.write_text(f"cd {project}\nnpm install\n")
+    os.utime(str(history), (known_ts + 86400, known_ts + 86400))
+
+    commands = parse_bash_history(str(history), project_paths=[str(project)])
+    npm_cmds = [c for c in commands if c.command == "npm install"]
+    assert len(npm_cmds) == 1
+    assert npm_cmds[0].is_legacy is False
+    assert npm_cmds[0].recovery_source is not None
+    assert "npm" in npm_cmds[0].recovery_source
+
+
 def test_parse_zsh_history_legacy_fallback(tmp_path):
     temp_file = tmp_path / "zsh_legacy_test"
     temp_file.write_text(


### PR DESCRIPTION
## Summary
* Run `TimestampDetective` on untimestamped bash/fish/powershell commands before the synthetic fallback
* Detective-resolved items get `is_legacy=False` and a `recovery_source` (zsh parity)
* Items the detective cannot place still use `_assign_missing_timestamps_fallback`
* Add a bash regression test with a recoverable npm lockfile anchor

Fixes #453

## Test plan
* [ ] `pytest tests/test_parser.py -q`
* [ ] Confirm `test_bash_history_timestamp_detective_recovers_file_anchor` passes