### PR TITLE
Fix/494 deterministic command ordering

### DIFF
--- a/termstory/database.py
+++ b/termstory/database.py
@@ -858,7 +858,7 @@ class Database:
             SELECT id, timestamp, command, exit_code, session_id, project_id, recovery_source, is_legacy
             FROM commands
             WHERE session_id IN ({s_ids_str})
-            ORDER BY timestamp ASC
+            ORDER BY timestamp ASC, id ASC
         """, session_ids)
         all_cmd_rows = cursor.fetchall()
         

--- a/termstory/replay.py
+++ b/termstory/replay.py
@@ -106,7 +106,7 @@ def run_replay(db: Database, session_id: Optional[int] = None, speed: float = 1.
         if projects:
             project_name = projects[0].name
 
-    commands = sorted(session.commands, key=lambda c: c.timestamp)
+    commands = sorted(session.commands, key=lambda c: (c.timestamp, c.id or 0))
     if not commands:
         console.print(f"[yellow]Session #{session_id} has no commands to replay.[/yellow]")
         return

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -930,3 +930,163 @@ def test_recovery_preserves_command_and_session_identity(tmp_path):
 
     # Session→command relationships are intact.
     assert {r[3] for r in commands_after} == {1, 2}
+
+
+# ---------------------------------------------------------------------------
+# Issue #494: deterministic command ordering for equal timestamps (id ASC)
+# ---------------------------------------------------------------------------
+
+def _seed_session_for_ordering(db, session_id, start_ts, command_pairs):
+    """Insert a session row and commands with explicit (timestamp, command) values.
+
+    ``command_pairs`` is a list of (timestamp, command_text) tuples. Commands are
+    inserted in the given order so their auto-incremented ids reflect that order.
+    Returns a dict mapping command text -> persisted id.
+    """
+    conn = db.get_connection()
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO sessions (id, start_time, end_time, duration_seconds) "
+            "VALUES (?, ?, ?, ?)",
+            (session_id, start_ts, start_ts, 0),
+        )
+        id_by_cmd = {}
+        for ts, cmd_text in command_pairs:
+            cursor.execute(
+                "INSERT INTO commands (timestamp, command, exit_code, session_id, project_id, is_legacy) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (ts, cmd_text, 0, session_id, None, 0),
+            )
+            id_by_cmd[cmd_text] = cursor.lastrowid
+        conn.commit()
+        return id_by_cmd
+    finally:
+        conn.close()
+
+
+def test_command_ordering_tie_break_by_id(tmp_path):
+    """Equal timestamps must be ordered by persisted id ASC (not rowid/text)."""
+    db_file = tmp_path / "test_ordering_tie.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    # Insert two commands with identical timestamps but deliberately reversed
+    # command-text ordering relative to insertion order, so the only stable
+    # tiebreaker is the persisted id (insertion order).
+    session_id = 1
+    id_by_cmd = _seed_session_for_ordering(
+        db, session_id=session_id, start_ts=1000,
+        command_pairs=[
+            (1000, "cmd-first-id-lower"),
+            (1000, "cmd-second-id-higher"),
+        ],
+    )
+
+    # The lower id exists and precedes the higher id.
+    lower_id = id_by_cmd["cmd-first-id-lower"]
+    higher_id = id_by_cmd["cmd-second-id-higher"]
+    assert lower_id < higher_id
+
+    # Retrieve through the production session-building path (get_sessions_by_ids
+    # -> _build_sessions) with fresh connections: ordering must be stable and
+    # id-based for equal timestamps.
+    for _ in range(50):
+        sessions = Database(str(db_file)).get_sessions_by_ids([session_id])
+        assert len(sessions) == 1
+        cmds = sessions[0].commands
+        assert len(cmds) == 2
+        # lower id must appear first despite identical timestamps.
+        assert cmds[0].id == lower_id
+        assert cmds[1].id == higher_id
+        assert cmds[0].command == "cmd-first-id-lower"
+        assert cmds[1].command == "cmd-second-id-higher"
+
+
+def test_command_ordering_different_timestamps_not_overridden_by_id(tmp_path):
+    """When timestamps differ, chronological ordering wins over id ordering.
+
+    Scenario from the issue:
+        id 1 -> ts 1000
+        id 2 -> ts 1000
+        id 3 -> ts 1001
+    Expected traversal order: 1, 2, 3.
+    """
+    db_file = tmp_path / "test_ordering_chrono.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    session_id = 1
+    id_by_cmd = _seed_session_for_ordering(
+        db, session_id=session_id, start_ts=1000,
+        command_pairs=[
+            (1000, "cmd-ts-1000-a"),   # id 1
+            (1000, "cmd-ts-1000-b"),   # id 2
+            (1001, "cmd-ts-1001-c"),   # id 3
+        ],
+    )
+    expected_id_order = [
+        id_by_cmd["cmd-ts-1000-a"],
+        id_by_cmd["cmd-ts-1000-b"],
+        id_by_cmd["cmd-ts-1001-c"],
+    ]
+
+    for _ in range(50):
+        sessions = Database(str(db_file)).get_sessions_by_ids([session_id])
+        assert len(sessions) == 1
+        actual_id_order = [c.id for c in sessions[0].commands]
+        assert actual_id_order == expected_id_order
+
+
+def test_session_commands_deterministic_across_fresh_connections(tmp_path):
+    """session.commands (via get_sessions_by_ids -> _build_sessions) must be
+    deterministically ordered (timestamp ASC, id ASC) even when re-queried on
+    a brand-new database connection."""
+    db_file = tmp_path / "test_session_ordering.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    _seed_session_for_ordering(
+        db, session_id=1, start_ts=1000,
+        command_pairs=[
+            (1000, "cmd-a"),
+            (1000, "cmd-b"),
+            (1000, "cmd-c"),
+            (1001, "cmd-d"),
+        ],
+    )
+
+    # Expected: equal-timestamp group ordered by id ASC, then the ts=1001 cmd.
+    # Because insertion order == id order, "cmd-a" < "cmd-b" < "cmd-c" by id.
+    expected = ["cmd-a", "cmd-b", "cmd-c", "cmd-d"]
+
+    for _ in range(50):
+        # Fresh Database instance (new connection pool) each iteration.
+        db_fresh = Database(str(db_file))
+        sessions = db_fresh.get_sessions_by_ids([1])
+        assert len(sessions) == 1
+        cmd_texts = [c.command for c in sessions[0].commands]
+        assert cmd_texts == expected
+
+
+def test_session_commands_id_populated_and_distinct(tmp_path):
+    """Sanity: commands read back via get_sessions_by_ids must have populated,
+    distinct persisted ids so (timestamp, id) is a valid deterministic key."""
+    db_file = tmp_path / "test_session_ids.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    _seed_session_for_ordering(
+        db, session_id=1, start_ts=1000,
+        command_pairs=[
+            (1000, "cmd-a"),
+            (1000, "cmd-b"),
+            (1000, "cmd-c"),
+        ],
+    )
+
+    sessions = Database(str(db_file)).get_sessions_by_ids([1])
+    cmds = sessions[0].commands
+    ids = [c.id for c in cmds]
+    assert None not in ids
+    assert len(set(ids)) == 3

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -184,3 +184,140 @@ def test_cli_replay_mcp_command(tmp_path, monkeypatch):
     assert "/mock/cwd" in result.output
     assert "VS Code" in result.output
 
+
+
+def _record_command_order(db, session_id, cmds):
+    """Run replay against an injected session and return command texts in the
+    order they are typed out (i.e. the replay execution order).
+
+    ``db.get_sessions_by_ids`` is expected to be pre-monkeypatched by the
+    caller so the session/commands used by run_replay are fully controlled.
+    """
+    written = []
+
+    def _write(char):
+        written.append(char)
+
+    with patch("time.sleep"), \
+         patch("sys.stdout.write", side_effect=_write), \
+         patch("sys.stdout.flush"), \
+         patch("termstory.replay.console.print"):
+        run_replay(db, session_id=session_id, speed=100.0)
+
+    typed = "".join(written)
+    order = []
+    for c in cmds:
+        idx = typed.find(c)
+        if idx == -1:
+            continue
+        order.append((idx, c))
+    order.sort()
+    return [c for _, c in order]
+
+
+def test_run_replay_orders_equal_timestamps_by_id(tmp_path):
+    """Issue #494: replay must execute commands with equal timestamps in
+    (timestamp ASC, id ASC) order, NOT list/insertion order.
+
+    The session.commands list is deliberately scrambled so its list order
+    DIFFERS from the persisted id order. run_replay is fed this session via a
+    monkeypatched get_sessions_by_ids (bypassing the DB, so the in-memory
+    sort in replay.py is what we are exercising), and we assert the typed
+    output follows (timestamp, id) rather than the scrambled list arrangement.
+    """
+    db_file = tmp_path / "test_replay_order.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    now = int(time.time())
+
+    # Explicit persisted ids: lower id first, higher id second.
+    cmd_lower_id = Command(id=1, timestamp=now, command="lower-id-cmd",
+                           exit_code=0, session_id=1, project_id=None)
+    cmd_higher_id = Command(id=2, timestamp=now, command="higher-id-cmd",
+                            exit_code=0, session_id=1, project_id=None)
+
+    # List arrangement is REVERSED relative to id order on purpose.
+    scrambled_session = Session(
+        id=1, start_time=now, end_time=now, duration_seconds=0,
+        project_id=None, commands=[cmd_higher_id, cmd_lower_id],
+    )
+
+    with patch.object(db, "get_sessions_by_ids", return_value=[scrambled_session]):
+        order = _record_command_order(db, 1, [cmd_lower_id.command, cmd_higher_id.command])
+
+    # Replay's (timestamp, id) sort must override the scrambled list arrangement:
+    # lower id first, despite higher id appearing first in session.commands.
+    assert order == [cmd_lower_id.command, cmd_higher_id.command]
+
+
+def test_run_replay_preserves_chronological_order(tmp_path):
+    """Issue #494: different timestamps must keep chronological ordering; the id
+    tiebreaker must NOT override a later timestamp."""
+    db_file = tmp_path / "test_replay_chrono.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    now = int(time.time())
+
+    # Three commands: two share a timestamp (ids 1, 2) and one is later (id 3).
+    cmd_a = Command(id=1, timestamp=now, command="cmd-a",
+                    exit_code=0, session_id=1, project_id=None)
+    cmd_b = Command(id=2, timestamp=now, command="cmd-b",
+                    exit_code=0, session_id=1, project_id=None)
+    cmd_c = Command(id=3, timestamp=now + 1, command="cmd-c",
+                    exit_code=0, session_id=1, project_id=None)
+
+    # List arrangement intentionally scrambled.
+    scrambled_session = Session(
+        id=1, start_time=now, end_time=now + 1, duration_seconds=1,
+        project_id=None, commands=[cmd_c, cmd_a, cmd_b],
+    )
+
+    with patch.object(db, "get_sessions_by_ids", return_value=[scrambled_session]):
+        order = _record_command_order(db, 1, [cmd_a.command, cmd_b.command, cmd_c.command])
+
+    # Chronological order wins; for the equal-timestamp pair (a, b) id order wins.
+    assert order == [cmd_a.command, cmd_b.command, cmd_c.command]
+
+
+def test_run_replay_with_none_command_ids_does_not_crash(tmp_path):
+    """Issue #494: replay must not raise TypeError when an in-memory command has
+    id=None.
+
+    - a None-ID command is accepted (no crash);
+    - timestamp stays primary (a later None-ID command still comes last);
+    - for equal timestamps, persisted IDs (>=1) sort after a None command whose
+      missing ID falls back to 0, so ordering stays deterministic.
+    """
+    db_file = tmp_path / "test_replay_none_ids.db"
+    db = Database(str(db_file))
+    db.init_db()
+
+    now = int(time.time())
+
+    # Persisted command with an explicit id.
+    cmd_persisted = Command(id=5, timestamp=now, command="persisted-cmd",
+                            exit_code=0, session_id=1, project_id=None)
+    # In-memory command without a persisted id (the default is None).
+    cmd_none = Command(id=None, timestamp=now, command="none-id-cmd",
+                       exit_code=0, session_id=1, project_id=None)
+    # Another in-memory command with a later timestamp (id stays None).
+    cmd_later = Command(id=None, timestamp=now + 5, command="later-none-id-cmd",
+                        exit_code=0, session_id=1, project_id=None)
+
+    # Scramble the list order so only the (timestamp, id or 0) sort decides.
+    scrambled_session = Session(
+        id=1, start_time=now, end_time=now + 5, duration_seconds=5,
+        project_id=None, commands=[cmd_later, cmd_persisted, cmd_none],
+    )
+
+    with patch.object(db, "get_sessions_by_ids", return_value=[scrambled_session]):
+        order = _record_command_order(
+            db, 1,
+            [cmd_none.command, cmd_persisted.command, cmd_later.command],
+        )
+
+    # Equal timestamps: the None-ID command (fallback 0) precedes the persisted
+    # id command. The later-timestamp command stays last regardless of order.
+    assert order == [cmd_none.command, cmd_persisted.command, cmd_later.command]


### PR DESCRIPTION
Closes #494
# Fix #494: Make Equal-Timestamp Command Ordering Deterministic

## Summary

Fix nondeterministic command ordering when multiple persisted commands have the same timestamp.

SQLite does not guarantee ordering between rows whose `timestamp` values are equal unless an explicit secondary ordering key is provided. This could cause timeline/replay consumers to receive commands in an inconsistent order.

This PR uses the persisted `commands.id` as the deterministic secondary ordering key while preserving chronological ordering for commands with different timestamps.

## Root Cause

The canonical command-fetching query in `termstory/database.py` ordered commands only by:

```sql
ORDER BY timestamp ASC
```

When multiple commands had identical timestamps, their relative order was left to SQLite's unspecified row ordering.

Additionally, `termstory/replay.py` sorted commands using only:

```python
sorted(session.commands, key=lambda c: c.timestamp)
```

Python's stable sort preserved whatever ordering had already been produced by the database, meaning an unstable database ordering could propagate directly into replay.

## Changes

### Database command ordering

Updated the canonical command retrieval query in `termstory/database.py` from:

```sql
ORDER BY timestamp ASC
```

to:

```sql
ORDER BY timestamp ASC, id ASC
```

This establishes:

1. `timestamp ASC` — chronological ordering remains the primary criterion.
2. `id ASC` — persisted command identity deterministically resolves equal timestamps.

### Replay ordering

Updated `run_replay()` in `termstory/replay.py` from timestamp-only sorting to:

```python
sorted(session.commands, key=lambda c: (c.timestamp, c.id))
```

This ensures replay remains deterministic even when commands share the same timestamp.

### Timeline behavior

No direct change was required in `termstory/timeline.py`.

Timeline consumers obtain commands through the database session-building path, which now provides deterministic `(timestamp, id)` ordering. Timeline rendering itself does not independently reorder commands.

### Parser behavior

`termstory/parser.py` was intentionally left unchanged.

Parser-level timestamp sorting occurs before commands are persisted and therefore before their database IDs are assigned. Using `commands.id` at that stage would not provide a meaningful persisted ordering key.

## Regression Tests

Added coverage for:

* Two commands with identical timestamps being ordered by `id`
* Commands with different timestamps remaining chronologically ordered
* Deterministic `session.commands` ordering across fresh database connections
* Persisted command IDs being populated and distinct
* Replay ordering equal-timestamp commands by ID
* Replay preserving chronological ordering when timestamps differ

The replay regression test was also verified against the old implementation: reverting the replay change causes the equal-timestamp regression test to fail, confirming that the test catches the original bug.

## Validation

Focused tests:

```text
tests/test_replay.py       11 passed
tests/test_timeline.py      4 passed
tests/test_database.py     29 passed
```

Broader relevant test suite:

```text
214 passed
```

No existing tests were weakened or removed.

## Scope

No changes were made to:

* Timestamp generation
* Session recovery
* Export date-boundary logic
* Backup/restore behavior
* MCP snapshot handling
* Search ranking / issue #493
* Deduplication or migration logic
* Parser pre-persistence ordering
* Database schema

No migration is required because `commands.id` already exists as the persisted primary key.

## Issue


