### PR TITLE
fix(reminder): make daemon claim recovery race-safe

### DIFF
--- a/termstory/reminder.py
+++ b/termstory/reminder.py
@@ -673,6 +673,7 @@ def start_sleep_daemon(db_path: str):
         try:
             fd = os.open(pid_file, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o666)
         except FileExistsError:
+            observed = _pid_from_file(pid_file)
             if not _claim_is_stale(pid_file):
                 # A live daemon runs, or another caller is about to run it
                 # (including a fresh in-progress claim whose PID has not been
@@ -681,17 +682,16 @@ def start_sleep_daemon(db_path: str):
             # The existing claim is stale (a daemon died without cleaning up,
             # or an abandoned empty/unparseable claim past the stale threshold).
             # Reclaim it, then retry the atomic claim on the next iteration.
-            try:
-                os.remove(pid_file)
-            except FileNotFoundError:
-                # Another invocation removed it concurrently; just retry the
-                # atomic claim rather than assuming ownership incorrectly.
-                continue
-            except OSError:
-                logger.exception(
-                    "Failed to remove stale sleep daemon PID file %s", pid_file
-                )
-                return
+            #
+            # We never remove the file blindly: between our stale inspection
+            # and the removal, another invocation may have reclaimed the file
+            # and published its own live PID. ``_remove_claim_safely`` only
+            # deletes the file while it still carries the exact stale content
+            # we observed (a dead PID, or an empty/unparseable claim), so a
+            # concurrently-created replacement claim is left untouched. If the
+            # file disappeared in the meantime it is a no-op; either way we
+            # simply retry the atomic claim below.
+            _remove_claim_safely(pid_file, owner_pid=observed)
             continue
         else:
             # We own the claim. Publish our PID as a placeholder so concurrent

--- a/termstory/reminder.py
+++ b/termstory/reminder.py
@@ -538,6 +538,110 @@ def consolidate_sleep_contexts(db, force: bool = False) -> int:
     return consolidated_count
 
 
+# Bounded stale threshold, in seconds, after which an empty/unparseable
+# sleep-daemon PID file is considered abandoned and safe to reclaim.
+#
+# When a caller wins the atomic ``O_CREAT | O_EXCL`` claim it creates the PID
+# file and then publishes its PID. Concurrent callers that observe the file
+# before that PID is written must NOT delete it merely because it does not yet
+# parse: doing so would mistake a freshly-claimed, in-progress claim for a
+# stale one and let a second caller reclaim it, spawning two daemons. A
+# recently-created empty/unparseable claim is therefore treated as an active
+# in-progress claim; only once this threshold has elapsed without a parseable
+# PID appearing is it safe to reclaim as abandoned.
+_SLEEP_DAEMON_CLAIM_STALE_SECONDS = 2.0
+
+
+def _pid_from_file(pid_file: str) -> Optional[int]:
+    """Return the PID stored in the sleep-daemon PID file, or None.
+
+    Returns None when the file cannot be read or does not hold a parseable,
+    positive integer PID - e.g. it is empty because the claiming caller has not
+    published its PID yet, or it is malformed.
+    """
+    try:
+        with open(pid_file, "r") as f:
+            raw = f.read().strip()
+    except OSError:
+        return None
+    if not raw:
+        return None
+    try:
+        pid = int(raw)
+    except ValueError:
+        return None
+    if pid <= 0:
+        return None
+    return pid
+
+
+def _claim_is_stale(pid_file: str) -> bool:
+    """Return True when an existing sleep-daemon claim is safe to reclaim.
+
+    A claim is stale (and therefore reclaimable) only in two situations:
+
+      * it holds a valid PID whose process is no longer alive (a daemon that
+        died without cleaning up), or
+      * it is empty/unparseable *and* older than the bounded stale threshold
+        ``_SLEEP_DAEMON_CLAIM_STALE_SECONDS``, i.e. a genuinely abandoned claim
+        whose creator never published a PID.
+
+    Every other state - a live daemon, or a fresh in-progress claim whose PID
+    has not been published yet - is treated as active and NOT reclaimable. This
+    is what prevents the race where a freshly created-but-unpopulated PID file
+    is mistaken for a stale one and deleted, allowing a second claimant to
+    spawn a duplicate daemon.
+    """
+    pid = _pid_from_file(pid_file)
+    if pid is not None:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True  # daemon process has gone away
+        except (PermissionError, OSError):
+            # Cannot confirm the process is dead; conservatively defer rather
+            # than race over a possibly-live claim.
+            return False
+        return False  # process is alive; defer
+
+    # Empty or unparseable PID file. Use its modification time (which for a
+    # freshly created, not-yet-populated claim reflects its creation) to tell
+    # an in-progress claim apart from an abandoned one.
+    try:
+        age = time.time() - os.path.getmtime(pid_file)
+    except OSError:
+        # The file disappeared or is unreadable; it no longer represents a
+        # valid claim, so retrying the atomic claim is harmless.
+        return True
+    if age < _SLEEP_DAEMON_CLAIM_STALE_SECONDS:
+        return False  # in-progress claim; defer, do not delete
+    return True  # abandoned empty/unparseable claim; reclaim
+
+
+def _remove_claim_safely(pid_file: str, owner_pid: Optional[int]) -> None:
+    """Remove a claim we created, without removing a replacement claim.
+
+    Between claiming the file and cleaning it up (e.g. on a failure), another
+    caller may have reclaimed the file and re-populated it with its own PID. To
+    avoid deleting that replacement's claim we only remove the file while it
+    still carries our content: ``owner_pid`` if we published one, or an empty
+    file if we had not published yet.
+    """
+    current = _pid_from_file(pid_file)
+    if owner_pid is not None:
+        if current != owner_pid:
+            return  # someone else owns the claim now; leave it alone
+    else:
+        if current is not None:
+            return  # a replacement published a PID; leave it alone
+    try:
+        os.remove(pid_file)
+    except FileNotFoundError:
+        pass  # already gone; that is fine
+    except OSError:
+        logger.exception("Failed to remove sleep daemon PID file %s", pid_file)
+
+
 def start_sleep_daemon(db_path: str):
     """Spawns the sleep daemon in the background if it's not already running.
 
@@ -546,8 +650,17 @@ def start_sleep_daemon(db_path: str):
     exactly one wins the race and goes on to spawn the daemon. Every other
     invocation finds the file already exists and defers to the running (or
     just-started) daemon, which later overwrites the placeholder PID with its
-    own. A stale PID file (a daemon that died without cleaning up) is reclaimed
-    so the daemon can be restarted.
+    own.
+
+    The protocol distinguishes four states of an existing PID file:
+
+      * a valid PID belonging to a live process -> defer (daemon running),
+      * a valid PID belonging to a dead process -> reclaim as stale,
+      * a fresh empty/unparseable file -> defer (the owner created the claim
+        but has not published its PID yet; never deleted just because parsing
+        fails),
+      * an empty/unparseable file older than the bounded stale threshold
+        ``_SLEEP_DAEMON_CLAIM_STALE_SECONDS`` -> reclaim as abandoned.
     """
     import sys
     import subprocess
@@ -555,44 +668,51 @@ def start_sleep_daemon(db_path: str):
     pid_file = os.path.join(get_app_dir("data"), "sleep_daemon.pid")
     os.makedirs(os.path.dirname(pid_file), exist_ok=True)
 
-    for attempt in range(2):
+    our_pid = os.getpid()
+    for _attempt in range(2):
         try:
             fd = os.open(pid_file, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o666)
         except FileExistsError:
-            # Another invocation already owns the daemon. If its PID is alive it
-            # is (or is about to become) the running daemon — defer to it.
+            if not _claim_is_stale(pid_file):
+                # A live daemon runs, or another caller is about to run it
+                # (including a fresh in-progress claim whose PID has not been
+                # published yet). Defer and leave the PID file untouched.
+                return
+            # The existing claim is stale (a daemon died without cleaning up,
+            # or an abandoned empty/unparseable claim past the stale threshold).
+            # Reclaim it, then retry the atomic claim on the next iteration.
             try:
-                with open(pid_file, "r") as f:
-                    pid = int(f.read().strip())
-                os.kill(pid, 0)
-                return  # Already running
-            except (ValueError, OSError):
-                if attempt == 0:
-                    # Stale PID file (a daemon died without cleaning up).
-                    # Reclaim ownership on the next attempt.
-                    try:
-                        os.remove(pid_file)
-                    except OSError:
-                        logger.exception("Failed to remove stale sleep daemon PID file %s", pid_file)
-                    continue
-            # Someone else just claimed ownership; defer to them.
-            return
+                os.remove(pid_file)
+            except FileNotFoundError:
+                # Another invocation removed it concurrently; just retry the
+                # atomic claim rather than assuming ownership incorrectly.
+                continue
+            except OSError:
+                logger.exception(
+                    "Failed to remove stale sleep daemon PID file %s", pid_file
+                )
+                return
+            continue
         else:
-            # We own the daemon. Record our PID as a placeholder so concurrent
-            # invocations can recognise the claim as held by a live owner.
+            # We own the claim. Publish our PID as a placeholder so concurrent
+            # invocations can recognise it as a claim held by a live owner.
+            published = True
             try:
-                os.write(fd, str(os.getpid()).encode("ascii"))
+                os.write(fd, str(our_pid).encode("ascii"))
             except OSError:
                 logger.exception("Failed to write sleep daemon PID file %s", pid_file)
-                try:
-                    os.remove(pid_file)
-                except OSError:
-                    pass
-                return
+                published = False
             finally:
                 os.close(fd)
+            if not published:
+                # We could not publish a PID for our claim. Clean it up, but
+                # never remove a replacement claim that another process may
+                # have created in the meantime.
+                _remove_claim_safely(pid_file, owner_pid=None)
+                return
             break
     else:
+        # Exhausted the bounded reclaim attempts without acquiring the claim.
         return
 
     # Inherit and configure the python path
@@ -614,11 +734,10 @@ def start_sleep_daemon(db_path: str):
     except OSError:
         logger.exception("Failed to start sleep daemon")
         # We claimed ownership but failed to spawn; release the claim so a
-        # later invocation can start the daemon.
-        try:
-            os.remove(pid_file)
-        except OSError:
-            logger.exception("Failed to remove sleep daemon PID file %s", pid_file)
+        # later invocation can start the daemon. Only remove the file while it
+        # still carries our placeholder PID, so we never delete a replacement
+        # claim created by another process.
+        _remove_claim_safely(pid_file, owner_pid=our_pid)
 
 
 def run_sleep_daemon(db_path: str):

--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -365,6 +365,102 @@ def test_start_sleep_daemon_concurrent_invocations_spawn_once(tmp_path, monkeypa
     assert len(calls) == 1
 
 
+def test_start_sleep_daemon_creator_fails_before_pid_publication(tmp_path, monkeypatch):
+    """Regression: a caller that wins the PID-file claim but fails before
+    publishing its PID must not let a concurrent invocation delete/reclaim the
+    now-empty claim while it is still fresh.
+
+    If the empty claim were treated as stale, it would be deleted and a second
+    caller could acquire it and spawn a duplicate daemon (the
+    ``ValueError -> os.remove() -> second claimant`` race). The empty claim may
+    only be reclaimed after it has sat stale beyond the bounded threshold.
+
+    This test is fully deterministic: it drives ``time.time`` and
+    ``os.path.getmtime`` directly rather than depending on real process
+    scheduling.
+    """
+    import subprocess
+    import termstory.reminder as reminder
+
+    monkeypatch.setattr(reminder, "get_app_dir", lambda name: str(tmp_path))
+    pid_file = tmp_path / "sleep_daemon.pid"
+
+    # A published PID is treated as pointing at a live daemon (our own process).
+    monkeypatch.setattr(reminder.os, "kill", lambda pid, sig: None)
+
+    calls = []
+    monkeypatch.setattr(subprocess, "Popen", lambda *args, **kwargs: calls.append(args))
+
+    # Deterministic clock: we control both "now" and the PID file's mtime.
+    held_now = [100.0]
+    held_mtime = [99.0]
+    monkeypatch.setattr(reminder.time, "time", lambda: held_now[0])
+    monkeypatch.setattr(reminder.os.path, "getmtime", lambda path: held_mtime[0])
+
+    # 1) A creator atomically creates the PID-file claim but fails before
+    #    publishing a PID (simulated by creating an empty claim directly).
+    fd = os.open(str(pid_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o666)
+    os.close(fd)
+    assert pid_file.read_text().strip() == ""
+
+    # 2) A concurrent invocation sees the fresh empty claim (age 1s, below the
+    #    stale threshold). It must defer - NOT spawn and NOT delete the claim.
+    reminder.start_sleep_daemon("dummy.db")
+    assert calls == []
+    assert pid_file.exists()  # the in-progress claim is left intact
+
+    # 3) Time passes beyond the bounded stale threshold; the empty claim is now
+    #    genuinely abandoned.
+    held_now[0] = held_mtime[0] + reminder._SLEEP_DAEMON_CLAIM_STALE_SECONDS + 1.0
+
+    # 4) A replacement claimant reclaims the abandoned empty claim and spawns
+    #    exactly one daemon.
+    reminder.start_sleep_daemon("dummy.db")
+    assert len(calls) == 1
+    # The reclaimed claim now points at the replacement owner (our PID).
+    assert pid_file.read_text().strip() == str(os.getpid())
+
+
+def test_start_sleep_daemon_reclaims_empty_claim_removed_concurrently(tmp_path, monkeypatch):
+    """A stale empty claim whose file disappears during reclaim handling must
+    not error or terminate the claim; it simply retries the atomic claim."""
+    import subprocess
+    import termstory.reminder as reminder
+
+    monkeypatch.setattr(reminder, "get_app_dir", lambda name: str(tmp_path))
+    pid_file = tmp_path / "sleep_daemon.pid"
+
+    calls = []
+    monkeypatch.setattr(subprocess, "Popen", lambda *args, **kwargs: calls.append(args))
+
+    # The claim is deemed stale (dead PID).
+    def dead_process(pid, sig):
+        raise ProcessLookupError(pid, "no such process")
+    monkeypatch.setattr(reminder.os, "kill", dead_process)
+
+    pid_file.write_text("999999999")
+
+    # While reclaiming, another invocation removes the file between our stale
+    # inspection and os.remove() - i.e. os.remove raises FileNotFoundError and
+    # the file is genuinely gone. The claim must not error or claim ownership
+    # incorrectly; the retry atomically re-acquires the (now absent) file.
+    real_remove = reminder.os.remove
+    attempts = {"count": 0}
+    def flaky_remove(path):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            # The other invocation already deleted the file.
+            real_remove(path)
+            raise FileNotFoundError()
+        return real_remove(path)
+    monkeypatch.setattr(reminder.os, "remove", flaky_remove)
+
+    reminder.start_sleep_daemon("dummy.db")
+
+    assert len(calls) == 1
+    assert pid_file.read_text().strip() == str(os.getpid())
+
+
 def test_add_reminder_explicit_days_prefix_suffix_stripping(tmp_path, monkeypatch):
     reminders_file = tmp_path / "reminders.json"
     monkeypatch.setattr("termstory.reminder.get_reminders_file_path", lambda: str(reminders_file))

--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -461,6 +461,65 @@ def test_start_sleep_daemon_reclaims_empty_claim_removed_concurrently(tmp_path, 
     assert pid_file.read_text().strip() == str(os.getpid())
 
 
+def test_start_sleep_daemon_reclaim_never_deletes_replacement_claim(tmp_path, monkeypatch):
+    """Regression: a stale claim whose file is reclaimed by another invocation
+    between our stale inspection and our removal attempt must never be deleted.
+
+    Without the compare-and-remove protocol the stale-reclaim path removed the
+    PID file blindly, so if a concurrent caller reacquired the stale file and
+    published its own live PID in the window between ``_claim_is_stale`` and
+    ``os.remove``, that replacement's live claim would be destroyed - allowing
+    a further caller to spawn a duplicate daemon.
+
+    This test is deterministic: it flips the PID file to a live replacement at
+    the exact moment ``_remove_claim_safely`` inspects it, and asserts the
+    replacement is not deleted and no extra daemon is spawned.
+    """
+    import subprocess
+    import termstory.reminder as reminder
+
+    monkeypatch.setattr(reminder, "get_app_dir", lambda name: str(tmp_path))
+    pid_file = tmp_path / "sleep_daemon.pid"
+
+    calls = []
+    monkeypatch.setattr(subprocess, "Popen", lambda *args, **kwargs: calls.append(args))
+
+    # The loser's liveness probe reports the stale owner dead, so the stale
+    # claim is reclaimable, but reports the replacement live, so we defer to
+    # it once it owns the file.
+    def fake_kill(pid, sig):
+        if pid == 999999999:
+            raise ProcessLookupError(pid, "no such process")
+    monkeypatch.setattr(reminder.os, "kill", fake_kill)
+
+    # The initially claimed file holds a dead PID -> stale and reclaimable.
+    pid_file.write_text("999999999")
+
+    real_pid_from_file = reminder._pid_from_file
+    state = {"reads": 0, "created_replacement": False}
+
+    def fake_pid_from_file(path):
+        state["reads"] += 1
+        if state["reads"] == 3:
+            # The moment _remove_claim_safely re-reads the file, another
+            # invocation has reclaimed it and published its own live PID.
+            with open(path, "w") as f:
+                f.write(str(os.getpid()))
+            state["created_replacement"] = True
+        return real_pid_from_file(path)
+
+    monkeypatch.setattr(reminder, "_pid_from_file", fake_pid_from_file)
+
+    reminder.start_sleep_daemon("dummy.db")
+
+    # The replacement was created exactly during our removal attempt.
+    assert state["created_replacement"] is True
+    # We deferred to the replacement owner instead of deleting or spawning.
+    assert calls == []
+    # The replacement's live claim is intact.
+    assert pid_file.read_text().strip() == str(os.getpid())
+
+
 def test_add_reminder_explicit_days_prefix_suffix_stripping(tmp_path, monkeypatch):
     reminders_file = tmp_path / "reminders.json"
     monkeypatch.setattr("termstory.reminder.get_reminders_file_path", lambda: str(reminders_file))


### PR DESCRIPTION
## Summary

Fixes the sleep-daemon PID-file claim race where concurrent invocations could
mistake a freshly-created, not-yet-populated PID file for a stale claim and
delete it, allowing multiple daemon processes to spawn.

## Changes

- Atomically claim the PID file with `O_CREAT | O_EXCL`.
- Distinguish live, dead, fresh, and abandoned PID-file claims.
- Treat fresh empty/unparseable claims as in-progress rather than stale.
- Reclaim genuinely stale empty claims after a bounded threshold.
- Safely clean up claims without deleting a replacement claim.
- Handle concurrent PID-file removal during stale-claim recovery.
- Add regression coverage for the claim/publication race.

## Validation

- `tests/test_reminder.py`: 33 passed
- `git diff --check`: clean
- No unrelated files included in the commit.

## Related

Fixes the daemon claim race reported in issue/PR #427.