### PR TITLE
fix(export): respect per-command project attribution

### DIFF
--- a/termstory/exporter.py
+++ b/termstory/exporter.py
@@ -146,6 +146,56 @@ def parse_until(until_str: Optional[str]) -> Optional[int]:
         raise ValueError(f"Invalid date or day count format '{until_str}': {e}")
 
 
+def _project_matches_filter(proj: Optional[Project], filter_lower: str) -> bool:
+    """Return True if a resolved :class:`Project` matches the lowercased filter.
+
+    ``proj`` is ``None`` for sessions/commands carrying no project attribution.
+    In that case the filter only matches the conventional "no project" bucket
+    names, preserving the existing behaviour for sessions without a project.
+    """
+    if proj is None:
+        return filter_lower in ("other", "general", "no project")
+    return filter_lower in proj.name.lower() or filter_lower in proj.path.lower()
+
+
+def _session_matches_project_filter(
+    session: Session, project_map: Dict[int, Project], filter_lower: str
+) -> bool:
+    """Return True if *session* matches a project filter.
+
+    A session matches when the requested project is reflected in *either*:
+
+    * the session-level attribution (``session.project_id`` — the final
+      project the session ended in), **or**
+    * the per-command attribution of at least one command belonging to the
+      session (``command.project_id``) — e.g. a session that ``cd``-ed
+      between projects mid-stream.
+
+    This mirrors the per-command project matching already used by
+    :mod:`termstory.search` (see #339) and fixes #498, where the export
+    path only considered the session's final project.
+
+    ``project_map`` maps resolved project IDs to :class:`Project` entities
+    (name/path). Commands whose ``project_id`` is not present in the map are
+    treated as an unresolvable, real project and are *not* matched — this
+    prevents an unattributed/missing command from falsely matching the
+    "other" bucket.
+    """
+    # Session-level attribution (the final/current project).
+    session_proj = project_map.get(session.project_id) if session.project_id is not None else None
+    if _project_matches_filter(session_proj, filter_lower):
+        return True
+    # Per-command attribution: a session matches if any of its commands was
+    # attributed to the requested project, even when the session's final
+    # project differs.
+    for cmd in session.commands:
+        if cmd.project_id is not None:
+            cmd_proj = project_map.get(cmd.project_id)
+            if cmd_proj is not None and _project_matches_filter(cmd_proj, filter_lower):
+                return True
+    return False
+
+
 def fetch_export_data(
     db: Database,
     project_filter: Optional[str] = None,
@@ -181,24 +231,27 @@ def fetch_export_data(
     # Fetch all sessions in the range (up to far in the future)
     sessions = db.get_range_sessions(start_ts, end_ts)
     
-    # Get project info to map names/paths
-    project_ids = list(set(s.project_id for s in sessions if s.project_id is not None))
+    # Get project info to map names/paths. Include project IDs attributed at
+    # the per-command level (not only the session's final project) so that
+    # command-level attribution can be matched against the project filter
+    # (see Issue #498).
+    project_ids = list(set(
+        s.project_id for s in sessions if s.project_id is not None
+    ) | set(
+        c.project_id for s in sessions for c in s.commands if c.project_id is not None
+    ))
     projects = db.get_projects_by_ids(project_ids)
     project_map = {p.id: p for p in projects}
     
-    # Filter sessions by project if specified
+    # Filter sessions by project if specified. A session matches when its
+    # session-level project OR at least one of its commands' projects
+    # matches the filter (Issue #498).
     if project_filter:
         filter_lower = project_filter.lower()
-        filtered_sessions = []
-        for s in sessions:
-            proj = project_map.get(s.project_id) if s.project_id is not None else None
-            if proj:
-                if filter_lower in proj.name.lower() or filter_lower in proj.path.lower():
-                    filtered_sessions.append(s)
-            else:
-                if filter_lower in ("other", "general", "no project"):
-                    filtered_sessions.append(s)
-        sessions = filtered_sessions
+        sessions = [
+            s for s in sessions
+            if _session_matches_project_filter(s, project_map, filter_lower)
+        ]
         
     return sessions
 

--- a/termstory/exporter.py
+++ b/termstory/exporter.py
@@ -171,15 +171,22 @@ def _session_matches_project_filter(
       session (``command.project_id``) — e.g. a session that ``cd``-ed
       between projects mid-stream.
 
+    The no-project filter (``"other"`` / ``"general"`` / ``"no project"``)
+    matches a session when the session itself is unattributed (``project_id``
+    is ``None``) *or* when at least one command in the session is explicitly
+    unattributed (``command.project_id`` is ``None``), so a mixed-practice
+    session with a named final project and some unattributed commands is
+    still included in the no-project export.
+
     This mirrors the per-command project matching already used by
     :mod:`termstory.search` (see #339) and fixes #498, where the export
     path only considered the session's final project.
 
     ``project_map`` maps resolved project IDs to :class:`Project` entities
-    (name/path). Commands whose ``project_id`` is not present in the map are
-    treated as an unresolvable, real project and are *not* matched — this
-    prevents an unattributed/missing command from falsely matching the
-    "other" bucket.
+    (name/path). Only an actual ``None`` attribution counts as "no project";
+    a command whose ``project_id`` is not present in the map is treated as an
+    unresolvable, real project and is *not* matched — this prevents an
+    unknown/missing project ID from falsely matching the "other" bucket.
     """
     # Session-level attribution (the final/current project).
     session_proj = project_map.get(session.project_id) if session.project_id is not None else None
@@ -187,12 +194,17 @@ def _session_matches_project_filter(
         return True
     # Per-command attribution: a session matches if any of its commands was
     # attributed to the requested project, even when the session's final
-    # project differs.
+    # project differs. An explicitly unattributed command (project_id is
+    # None) matches the no-project bucket ("other" / "general" /
+    # "no project") so that a mixed session is included there.
     for cmd in session.commands:
-        if cmd.project_id is not None:
-            cmd_proj = project_map.get(cmd.project_id)
-            if cmd_proj is not None and _project_matches_filter(cmd_proj, filter_lower):
+        if cmd.project_id is None:
+            if _project_matches_filter(None, filter_lower):
                 return True
+            continue
+        cmd_proj = project_map.get(cmd.project_id)
+        if cmd_proj is not None and _project_matches_filter(cmd_proj, filter_lower):
+            return True
     return False
 
 

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -9,7 +9,7 @@ import pytest
 from termstory.cli import app
 from termstory.database import Database
 from termstory.models import Project, Session, Command
-from termstory.exporter import parse_since, parse_until, fetch_export_data, serialize_sessions_to_dict, export_json, export_csv, export_markdown
+from termstory.exporter import parse_since, parse_until, fetch_export_data, serialize_sessions_to_dict, export_json, export_csv, export_markdown, _session_matches_project_filter
 
 @pytest.fixture
 def temp_db(tmp_path):
@@ -1049,4 +1049,109 @@ def test_project_filter_unknown_project_name_excludes(tmp_path):
                  project_id=2, commands=[cmd_beta])
     db = _make_attribution_db(tmp_path / "r10.db", _alpha_beta_projects(), [s1], [cmd_beta])
     assert len(fetch_export_data(db, project_filter="alpha")) == 0
+    assert len(fetch_export_data(db, project_filter="gamma")) == 0
+
+
+def test_project_filter_other_includes_session_with_unattributed_command(tmp_path):
+    """P1: session final project = Beta, one command in Alpha, one command
+    unattributed (project_id=None) - the 'other' bucket must include it."""
+    cmd_alpha = Command(id=101, timestamp=1010, command="git status", exit_code=0,
+                        session_id=1, project_id=1)
+    cmd_none = Command(id=102, timestamp=1020, command="ls -la", exit_code=0,
+                       session_id=1, project_id=None)
+    s1 = Session(id=1, start_time=1000, end_time=1050, duration_seconds=50,
+                 project_id=2, commands=[cmd_alpha, cmd_none])
+    db = _make_attribution_db(tmp_path / "p1a.db", _alpha_beta_projects(), [s1],
+                              [cmd_alpha, cmd_none])
+    assert len(fetch_export_data(db, project_filter="other")) == 1
+    assert len(fetch_export_data(db, project_filter="general")) == 1
+    assert len(fetch_export_data(db, project_filter="no project")) == 1
+
+
+def test_project_filter_other_excludes_session_with_all_real_commands(tmp_path):
+    """P1: session final project = Beta, all commands attributed to real
+    projects - the 'other' bucket must exclude it."""
+    cmd_alpha = Command(id=101, timestamp=1010, command="git status", exit_code=0,
+                        session_id=1, project_id=1)
+    cmd_beta = Command(id=102, timestamp=1030, command="git log", exit_code=0,
+                       session_id=1, project_id=2)
+    s1 = Session(id=1, start_time=1000, end_time=1050, duration_seconds=50,
+                 project_id=2, commands=[cmd_alpha, cmd_beta])
+    db = _make_attribution_db(tmp_path / "p1b.db", _alpha_beta_projects(), [s1],
+                              [cmd_alpha, cmd_beta])
+    assert len(fetch_export_data(db, project_filter="other")) == 0
+    assert len(fetch_export_data(db, project_filter="general")) == 0
+    # Sanity: it still matches its real projects.
+    assert len(fetch_export_data(db, project_filter="alpha")) == 1
+    assert len(fetch_export_data(db, project_filter="beta")) == 1
+
+
+def test_project_filter_other_includes_session_with_none_project_id(tmp_path):
+    """P1: a session whose own project_id is None is still in the 'other'
+    bucket (existing behaviour preserved)."""
+    cmd_none = Command(id=101, timestamp=1010, command="ls -la", exit_code=0,
+                       session_id=1, project_id=None)
+    s1 = Session(id=1, start_time=1000, end_time=1050, duration_seconds=50,
+                 project_id=None, commands=[cmd_none])
+    db = _make_attribution_db(tmp_path / "p1c.db", _alpha_beta_projects(), [s1], [cmd_none])
+    assert len(fetch_export_data(db, project_filter="other")) == 1
+    assert len(fetch_export_data(db, project_filter="general")) == 1
+    assert len(fetch_export_data(db, project_filter="no project")) == 1
+
+
+def test_project_filter_other_excludes_unknown_command_project_id(tmp_path):
+    """P1: an unknown/nonexistent command project_id must NOT be treated as
+    "no project" and make the session match 'other'.
+
+    ``Database.save_data`` enforces a foreign key, so a command pointing at a
+    project ID missing from the ``projects`` table cannot be persisted through
+    the public API. Instead exercise :func:`_session_matches_project_filter`
+    directly with a ``project_map`` that omits the command's (stale/unknown)
+    ID -- exactly the guard the export path relies on.
+    """
+    cmd_ghost = Command(id=101, timestamp=1010, command="git status", exit_code=0,
+                        session_id=1, project_id=9999)  # unknown ID
+    s1 = Session(id=1, start_time=1000, end_time=1050, duration_seconds=50,
+                 project_id=2, commands=[cmd_ghost])
+    # project_map has only the session's project (Beta); 9999 is absent.
+    project_map = {2: Project(id=2, name="Beta", path="~/src/beta",
+                              first_seen=1000, last_seen=5000,
+                              session_count=0, total_time=0)}
+    assert _session_matches_project_filter(s1, project_map, "other") is False
+    assert _session_matches_project_filter(s1, project_map, "general") is False
+    assert _session_matches_project_filter(s1, project_map, "no project") is False
+    # Nor does it match a real named project.
+    assert _session_matches_project_filter(s1, project_map, "alpha") is False
+
+
+def test_project_filter_other_excludes_unattributed_only_in_text(tmp_path):
+    """P1: a command that merely *mentions* a project name in its text, but is
+    attributed to a real project, does not count as 'other'."""
+    cmd_beta = Command(id=101, timestamp=1010, command="git status other repo",
+                       exit_code=0, session_id=1, project_id=2)
+    s1 = Session(id=1, start_time=1000, end_time=1050, duration_seconds=50,
+                 project_id=2, commands=[cmd_beta])
+    db = _make_attribution_db(tmp_path / "p1e.db", _alpha_beta_projects(), [s1], [cmd_beta])
+    assert len(fetch_export_data(db, project_filter="other")) == 0
+
+
+def test_project_filter_mixed_session_matches_named_and_other(tmp_path):
+    """P1: a mixed session with Alpha + Beta commands plus an unattributed
+    command matches the correct named filters AND 'other'."""
+    cmd_alpha = Command(id=101, timestamp=1010, command="git status", exit_code=0,
+                        session_id=1, project_id=1)
+    cmd_beta = Command(id=102, timestamp=1030, command="git log", exit_code=0,
+                       session_id=1, project_id=2)
+    cmd_none = Command(id=103, timestamp=1040, command="ls -la", exit_code=0,
+                       session_id=1, project_id=None)
+    s1 = Session(id=1, start_time=1000, end_time=1050, duration_seconds=50,
+                 project_id=2, commands=[cmd_alpha, cmd_beta, cmd_none])
+    db = _make_attribution_db(tmp_path / "p1f.db", _alpha_beta_projects(), [s1],
+                              [cmd_alpha, cmd_beta, cmd_none])
+    assert len(fetch_export_data(db, project_filter="alpha")) == 1
+    assert len(fetch_export_data(db, project_filter="beta")) == 1
+    assert len(fetch_export_data(db, project_filter="other")) == 1
+    assert len(fetch_export_data(db, project_filter="general")) == 1
+    assert len(fetch_export_data(db, project_filter="no project")) == 1
+    # Unrelated project excluded.
     assert len(fetch_export_data(db, project_filter="gamma")) == 0

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -875,3 +875,178 @@ def test_parse_until_preserves_explicit_time():
     # Explicit midnight must NOT be expanded to end-of-day — the user asked for 00:00:00.
     assert parse_until("2026-06-10T00:00:00") == int(datetime(2026, 6, 10, 0, 0, 0).timestamp())
 
+
+
+def _make_attribution_db(path, projects, sessions, commands):
+    """Create an initialised DB seeded with the given projects/sessions/commands.
+
+    Projects are keyed by ``path`` in Database.save_data, so explicit ``id``
+    values are remapped and every session/command ``project_id`` is kept
+    consistent with the database-assigned IDs.
+    """
+    db = Database(str(path))
+    db.init_db()
+    db.save_data(projects, sessions, commands)
+    return db
+
+
+def _alpha_beta_projects():
+    """Two projects: Alpha (name+path) and Beta (name+path)."""
+    return [
+        Project(id=1, name="Alpha", path="~/src/alpha",
+                first_seen=1000, last_seen=5000, session_count=0, total_time=0),
+        Project(id=2, name="Beta", path="~/src/beta",
+                first_seen=1000, last_seen=5000, session_count=0, total_time=0),
+    ]
+
+
+def test_project_filter_final_project_matches(tmp_path):
+    """#498 scenario 1: the session-level (final) project matches - the session
+    is included (existing behaviour preserved)."""
+    db = _make_attribution_db(
+        tmp_path / "r1.db", _alpha_beta_projects(),
+        [Session(id=1, start_time=1000, end_time=1050, duration_seconds=50,
+                 project_id=1, commands=[Command(id=101, timestamp=1010,
+                 command="git status", exit_code=0, session_id=1, project_id=1)])],
+        [Command(id=101, timestamp=1010, command="git status", exit_code=0,
+                 session_id=1, project_id=1)],
+    )
+    assert len(fetch_export_data(db, project_filter="alpha")) == 1
+    # Filtering by the other project excludes it.
+    assert len(fetch_export_data(db, project_filter="beta")) == 0
+
+
+def test_project_filter_command_level_only_matches(tmp_path):
+    """#498 scenario 2: only a command-level project matches. The session's
+    final project is Beta, but a command ran in Alpha - the session must be
+    included when filtering by Alpha."""
+    cmd_alpha = Command(id=101, timestamp=1010, command="git status", exit_code=0,
+                        session_id=1, project_id=1)
+    cmd_beta = Command(id=102, timestamp=1030, command="git log", exit_code=0,
+                       session_id=1, project_id=2)
+    s1 = Session(id=1, start_time=1000, end_time=1050, duration_seconds=50,
+                 project_id=2, commands=[cmd_alpha, cmd_beta])
+    db = _make_attribution_db(tmp_path / "r2.db", _alpha_beta_projects(), [s1],
+                              [cmd_alpha, cmd_beta])
+    alpha_sessions = fetch_export_data(db, project_filter="alpha")
+    assert len(alpha_sessions) == 1
+    assert alpha_sessions[0].id == 1
+    # Beta still matches too (session-level + a command).
+    assert len(fetch_export_data(db, project_filter="beta")) == 1
+
+
+def test_project_filter_command_level_does_not_match(tmp_path):
+    """#498 scenario 3: neither the session nor any command is attributed to
+    the requested project - the session is excluded."""
+    projects = _alpha_beta_projects() + [
+        Project(id=3, name="Gamma", path="~/src/gamma",
+                first_seen=1000, last_seen=5000, session_count=0, total_time=0),
+    ]
+    cmd_beta = Command(id=101, timestamp=1010, command="git status", exit_code=0,
+                       session_id=1, project_id=2)
+    cmd_gamma = Command(id=102, timestamp=1030, command="npm test", exit_code=0,
+                        session_id=1, project_id=3)
+    s1 = Session(id=1, start_time=1000, end_time=1050, duration_seconds=50,
+                 project_id=2, commands=[cmd_beta, cmd_gamma])
+    db = _make_attribution_db(tmp_path / "r3.db", projects, [s1],
+                              [cmd_beta, cmd_gamma])
+    assert len(fetch_export_data(db, project_filter="alpha")) == 0
+    # Sanity: the session is still reachable via its actual projects.
+    assert len(fetch_export_data(db, project_filter="beta")) == 1
+def test_project_filter_mixed_project_session(tmp_path):
+    """#498 scenario 4: a session with commands attributed to both Alpha and
+    Beta, final project Beta - filtering by either project includes it."""
+    cmd_a1 = Command(id=101, timestamp=1010, command="cd ~/src/alpha", exit_code=0,
+                     session_id=1, project_id=1)
+    cmd_b1 = Command(id=102, timestamp=1030, command="cd ~/src/beta", exit_code=0,
+                     session_id=1, project_id=2)
+    cmd_a2 = Command(id=103, timestamp=1040, command="git commit", exit_code=0,
+                     session_id=1, project_id=1)
+    s1 = Session(id=1, start_time=1000, end_time=1050, duration_seconds=50,
+                 project_id=2, commands=[cmd_a1, cmd_b1, cmd_a2])
+    db = _make_attribution_db(tmp_path / "r4.db", _alpha_beta_projects(), [s1],
+                              [cmd_a1, cmd_b1, cmd_a2])
+    by_alpha = fetch_export_data(db, project_filter="alpha")
+    by_beta = fetch_export_data(db, project_filter="beta")
+    assert len(by_alpha) == 1 and by_alpha[0].id == 1
+    assert len(by_beta) == 1 and by_beta[0].id == 1
+
+
+def test_project_filter_single_project_unchanged(tmp_path):
+    """#498 scenario 5: single-project sessions behave exactly as before
+    (case-insensitive name AND path matching)."""
+    cmd_a = Command(id=101, timestamp=1010, command="git status", exit_code=0,
+                    session_id=1, project_id=1)
+    cmd_b = Command(id=102, timestamp=1110, command="ls", exit_code=0,
+                    session_id=2, project_id=2)
+    s1 = Session(id=1, start_time=1000, end_time=1050, duration_seconds=50,
+                 project_id=1, commands=[cmd_a])
+    s2 = Session(id=2, start_time=2000, end_time=2050, duration_seconds=50,
+                 project_id=2, commands=[cmd_b])
+    db = _make_attribution_db(tmp_path / "r5.db", _alpha_beta_projects(), [s1, s2],
+                              [cmd_a, cmd_b])
+    assert len(fetch_export_data(db, project_filter="ALPHA")) == 1
+    assert len(fetch_export_data(db, project_filter="src/alpha")) == 1
+    assert len(fetch_export_data(db, project_filter="src/beta")) == 1
+    assert len(fetch_export_data(db, project_filter="nonexistent")) == 0
+
+
+def test_project_filter_no_project_attribution(tmp_path):
+    """#498 scenario 6: a session with no project attribution (session-level
+    and per-command) is handled by the existing 'other' bucket."""
+    cmd = Command(id=101, timestamp=1010, command="ls -la", exit_code=0,
+                  session_id=1, project_id=None)
+    s1 = Session(id=1, start_time=1000, end_time=1050, duration_seconds=50,
+                 project_id=None, commands=[cmd])
+    db = _make_attribution_db(tmp_path / "r6.db", _alpha_beta_projects(), [s1], [cmd])
+    assert len(fetch_export_data(db, project_filter="other")) == 1
+    assert len(fetch_export_data(db, project_filter="general")) == 1
+    assert len(fetch_export_data(db, project_filter="no project")) == 1
+    assert len(fetch_export_data(db, project_filter="alpha")) == 0
+
+
+def test_project_filter_command_path_match(tmp_path):
+    """Command-level project can be matched by project path, not only name."""
+    cmd_alpha = Command(id=101, timestamp=1010, command="git status", exit_code=0,
+                        session_id=1, project_id=1)
+    s1 = Session(id=1, start_time=1000, end_time=1050, duration_seconds=50,
+                 project_id=2, commands=[cmd_alpha])
+    db = _make_attribution_db(tmp_path / "r7.db", _alpha_beta_projects(), [s1], [cmd_alpha])
+    sessions = fetch_export_data(db, project_filter="src/alpha")
+    assert len(sessions) == 1
+    assert sessions[0].id == 1
+
+
+def test_project_filter_command_text_does_not_cause_match(tmp_path):
+    """#498 Step 6: a session must NOT match merely because a command's text
+    contains the project name - only persisted project_id attribution counts."""
+    cmd = Command(id=101, timestamp=1010, command="git status in alpha repo",
+                  exit_code=0, session_id=1, project_id=None)
+    s1 = Session(id=1, start_time=1000, end_time=1050, duration_seconds=50,
+                 project_id=None, commands=[cmd])
+    db = _make_attribution_db(tmp_path / "r8.db", _alpha_beta_projects(), [s1], [cmd])
+    assert len(fetch_export_data(db, project_filter="alpha")) == 0
+    assert len(fetch_export_data(db, project_filter="other")) == 1
+
+
+def test_project_filter_command_path_in_text_does_not_cause_match(tmp_path):
+    """#498 Step 6: a command whose text contains a project path string must
+    not match unless its project_id is actually attributed."""
+    cmd = Command(id=101, timestamp=1010, command="cd ~/src/alpha", exit_code=0,
+                  session_id=1, project_id=None)
+    s1 = Session(id=1, start_time=1000, end_time=1050, duration_seconds=50,
+                 project_id=None, commands=[cmd])
+    db = _make_attribution_db(tmp_path / "r9.db", _alpha_beta_projects(), [s1], [cmd])
+    assert len(fetch_export_data(db, project_filter="src/alpha")) == 0
+    assert len(fetch_export_data(db, project_filter="other")) == 1
+
+
+def test_project_filter_unknown_project_name_excludes(tmp_path):
+    """#498: an unrelated project name with no attribution match excludes."""
+    cmd_beta = Command(id=101, timestamp=1010, command="git log", exit_code=0,
+                       session_id=1, project_id=2)
+    s1 = Session(id=1, start_time=1000, end_time=1050, duration_seconds=50,
+                 project_id=2, commands=[cmd_beta])
+    db = _make_attribution_db(tmp_path / "r10.db", _alpha_beta_projects(), [s1], [cmd_beta])
+    assert len(fetch_export_data(db, project_filter="alpha")) == 0
+    assert len(fetch_export_data(db, project_filter="gamma")) == 0


### PR DESCRIPTION
Closes #498 
## Summary

Fixes project-filtered exports to respect per-command project attribution.

Previously, `fetch_export_data()` considered only the session-level `project_id` when applying a project filter. For sessions that moved between projects, this could exclude a session from an earlier project's export even when commands in that session were explicitly attributed to that project.

### Changes

- Project filters now match against:
  - the session-level `project_id`, or
  - any command-level `project_id` belonging to the session.
- Project resolution now includes project IDs referenced by commands.
- Unresolvable command project IDs are ignored rather than incorrectly matching the `"other"` bucket.
- Added regression coverage for session-level, command-level, mixed-project, path, no-project, and false-positive cases.

### Validation

- `tests/test_exporter.py`: **56 passed**
- Search/database/integration tests: **24 passed**
- Database query test: **1 passed**
- Consolidated relevant suite: **80 passed**
- `git diff --check`: clean

No schema or project-attribution persistence changes were made.