### PR TITLE
[Predict] Exclude legacy commands from prediction signals (fixes #463)

### DIFF
--- a/termstory/predict.py
+++ b/termstory/predict.py
@@ -134,7 +134,11 @@ class Predictor:
                 if cmd_rows and all(bool(r[1]) for r in cmd_rows):
                     continue
 
-                cmds = [r[0] for r in cmd_rows if not _is_noise_command(r[0])]
+                non_legacy_cmds = [r[0] for r in cmd_rows if not bool(r[1])]
+                if not non_legacy_cmds:
+                    continue
+
+                cmds = [cmd for cmd in non_legacy_cmds if not _is_noise_command(cmd)]
                 project_name = p_name if p_name and p_name not in ("General / No Project", "") else "Other"
 
                 sessions.append({

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -227,6 +227,34 @@ class TestPredictorEmptyHistory:
         finally:
             os.unlink(db_path)
 
+    def test_mixed_legacy_live_session_excludes_legacy_commands(self):
+        """#463: legacy commands in a mixed session must not feed prediction signals."""
+        now = datetime.now()
+        db_path = _make_db([
+            {
+                "start": now - timedelta(hours=1),
+                "project": "acme",
+                "commands": ["make", "pytest"],
+            },
+        ])
+        conn = sqlite3.connect(db_path)
+        conn.execute("UPDATE commands SET is_legacy=1 WHERE command='make'")
+        conn.commit()
+        conn.close()
+        try:
+            p = Predictor(db_path)
+            sessions = p._load_sessions()
+            assert len(sessions) == 1
+            assert sessions[0]["commands"] == ["pytest"]
+
+            result = p.predict(top_n=1, now=now)
+            assert result["total_sessions_analysed"] == 1
+            suggested = result["top_projects"][0]["suggested_commands"]
+            assert "pytest" in suggested
+            assert "make" not in suggested
+        finally:
+            os.unlink(db_path)
+
 
 class TestPredictorRanking:
     def test_recency_drives_top_rank(self):


### PR DESCRIPTION
## Summary
- Closes #463
- `_load_sessions()` now drops `is_legacy` commands before scoring
- Sessions with no non-legacy commands are omitted (all-legacy fast path kept)
- Add regression test for mixed legacy/live session

## Test plan
- [x] `pytest tests/test_predict.py::TestPredictorEmptyHistory::test_mixed_legacy_live_session_excludes_legacy_commands -q`
- [x] `pytest tests/test_predict.py -q`