### PR TITLE
Add Weekly Digest Command

### DIFF
--- a/termstory/cli.py
+++ b/termstory/cli.py
@@ -13,7 +13,7 @@ from termstory.parser import parse_all_histories
 from termstory.session import create_sessions
 from termstory.project import detect_projects
 from termstory.database import Database
-from termstory.date_utils import get_current_time, get_today_range, parse_date_range_helper
+from termstory.date_utils import get_current_time, get_today_range, get_week_range, parse_date_range_helper
 from termstory.formatter import format_search_results, format_today_output, format_project_output, format_insights_output, format_stats_output, format_profile_output, format_necromancer_score, format_rage_quit_signatures
 import sqlite3
 
@@ -552,6 +552,48 @@ def show_tags(
             output_lines.append(f"{date_str}  {proj_name:<15}  {dur_str:<6}  {summary}")
             
         console.print("\n".join(output_lines))
+
+
+
+@app.command("weekly")
+def show_weekly(
+    last: bool = typer.Option(False, "--last", help="Show last week instead of the current week"),
+):
+    """Show a comprehensive weekly digest with daily breakdown, project focus, and week-over-week comparison"""
+    db_path = get_db_path()
+    db = Database(db_path)
+    safe_init_db(db)
+
+    run_ingestion(db)
+
+    start_ts, end_ts = get_week_range(last=last)
+    sessions = db.get_range_sessions(start_ts, end_ts)
+
+    # Previous-week sessions for comparison
+    prev_start, prev_end = get_week_range(last=True)
+    previous_sessions = db.get_range_sessions(prev_start, prev_end)
+
+    # Project names map
+    project_ids = list({s.project_id for s in sessions if s.project_id is not None})
+    project_names: dict = {}
+    if project_ids:
+        projects = db.get_projects_by_ids(project_ids)
+        project_names = {p.id: p.name for p in projects if p.id is not None}
+
+    all_projects = db.get_all_projects_with_stats()
+
+    from termstory.weekly_digest import build_weekly_digest
+    digest = build_weekly_digest(
+        sessions=sessions,
+        projects=all_projects,
+        project_names=project_names,
+        previous_sessions=previous_sessions if previous_sessions else None,
+    )
+
+    from termstory.formatter import format_weekly_digest_output
+    output = format_weekly_digest_output(digest, start_ts, end_ts)
+    from rich.text import Text
+    console.print(Text.from_ansi(output))
 
 
 

--- a/termstory/formatter.py
+++ b/termstory/formatter.py
@@ -2055,6 +2055,168 @@ def format_mcp_snapshots(snapshots: List[Dict]) -> str:
     return render_to_string(Text.from_markup("\n".join(output_lines).strip()))
 
 
+# ── Weekly Digest Formatter ─────────────────────────────────────────
+
+
+def format_weekly_digest_output(
+    digest: dict,
+    start_ts: int,
+    end_ts: int,
+) -> str:
+    """Render a comprehensive weekly digest from the computed digest dict.
+
+    Parameters
+    ----------
+    digest:
+        Output of ``weekly_digest.build_weekly_digest()``.
+    start_ts, end_ts:
+        Unix timestamps marking the week boundaries.
+    """
+    range_str = format_date_range(start_ts, end_ts)
+    header = f"📅 Weekly Digest ({range_str})"
+
+    if not digest.get("daily_totals"):
+        return render_to_string(
+            Text.from_markup(f"{header}\n\n[yellow]No sessions recorded this week.[/]")
+        )
+
+    lines: list[str] = [header, ""]
+
+    # ── 1. Summary stats ────────────────────────────────────────────
+    lines.append("[bold]Summary[/]")
+    lines.append("─" * 44)
+    lines.append(
+        f"  Sessions  : [bold]{digest['total_sessions']}[/]"
+        f"  │  Active Days : [bold]{digest['active_days']}[/] / 7"
+    )
+    lines.append(
+        f"  Commands  : [bold]{digest['total_commands']}[/]"
+        f"  │  Commits     : [bold]{digest['total_commits']}[/]"
+    )
+    lines.append(
+        f"  Work Time : [bold green]{format_duration(digest['total_time'])}[/]"
+        f"  │  Error Rate  : [bold]{digest['error_rate']}%[/]"
+    )
+    lines.append(
+        f"  Focus     : [bold yellow]{digest['focus_score']}/10.0[/]"
+        f"  │  Best Streak : [bold]{digest['streak']} day(s)[/]"
+    )
+    lines.append("")
+
+    # ── 2. Week-over-week comparison ────────────────────────────────
+    comp = digest.get("comparison")
+    if comp is not None:
+        lines.append("[bold]vs. Previous Week[/]")
+        lines.append("─" * 44)
+        t_sign = "+" if comp["time_delta"] >= 0 else ""
+        t_color = "green" if comp["time_delta"] >= 0 else "red"
+        t_pct = f" ({comp['time_pct']:+.1f}%)" if comp["time_pct"] is not None else ""
+        lines.append(
+            f"  Time : [{t_color}]{t_sign}{format_duration(abs(comp['time_delta']))}{t_pct}[/]"
+        )
+        c_sign = "+" if comp["commit_delta"] >= 0 else ""
+        c_color = "green" if comp["commit_delta"] >= 0 else "red"
+        c_pct = f" ({comp['commit_pct']:+.1f}%)" if comp["commit_pct"] is not None else ""
+        lines.append(
+            f"  Commits : [{c_color}]{c_sign}{comp['commit_delta']}{c_pct}[/]"
+        )
+        s_sign = "+" if comp["session_delta"] >= 0 else ""
+        lines.append(f"  Sessions: {s_sign}{comp['session_delta']}")
+        f_sign = "+" if comp["focus_delta"] >= 0 else ""
+        f_color = "green" if comp["focus_delta"] >= 0 else "red"
+        lines.append(f"  Focus   : [{f_color}]{f_sign}{comp['focus_delta']}[/]")
+        lines.append("")
+
+    # ── 3. Per-day breakdown ────────────────────────────────────────
+    lines.append("[bold]Daily Breakdown[/]")
+    lines.append("─" * 44)
+    days_order = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+    start_dt = datetime.fromtimestamp(start_ts)
+
+    # Map weekday index to YYYY-MM-DD keys
+    day_date_map: dict[int, str] = {}
+    for i in range(7):
+        d = start_dt + timedelta(days=i)
+        day_date_map[i] = d.strftime("%Y-%m-%d")
+
+    max_day_time = max(digest["daily_totals"].values()) if digest["daily_totals"] else 1
+
+    for idx, label in enumerate(days_order):
+        key = day_date_map.get(idx, "")
+        secs = digest["daily_totals"].get(key, 0)
+        sess_count = digest["daily_session_counts"].get(key, 0)
+        cmd_count = digest["daily_command_counts"].get(key, 0)
+        commit_count = digest["daily_commit_counts"].get(key, 0)
+        focus = digest["daily_focus_scores"].get(key, 0.0)
+
+        bar = make_visual_bar(secs, max_day_time, width=12) if secs > 0 else "[dim]░░░░░░░░░░░░[/]"
+
+        line = f"  {label}  {bar}  [bold green]{format_duration(secs):>7}[/]"
+        if sess_count > 0:
+            detail = f"{sess_count}s {cmd_count}c"
+            if commit_count > 0:
+                detail += f" {commit_count}📈"
+            line += f"  [dim]{detail}[/]"
+        lines.append(line)
+    lines.append("")
+
+    # ── 4. Project distribution ─────────────────────────────────────
+    lines.append("[bold]Project Focus[/]")
+    lines.append("─" * 44)
+    total = digest["total_time"] or 1
+    for name, secs in digest["project_distribution"][:6]:
+        pct = (secs / total) * 100
+        bar = make_visual_bar(secs, total, width=10)
+        lines.append(
+            f"  [bold cyan]{escape(name):<22}[/] {bar} {format_duration(secs):>7} [dim]({pct:.0f}%)[/]"
+        )
+    lines.append("")
+
+    # ── 5. Time-of-day distribution ─────────────────────────────────
+    lines.append("[bold]Active Hours[/]")
+    lines.append("─" * 44)
+    tod = digest["time_of_day"]
+    tod_max = max(tod.values()) if any(tod.values()) else 1
+    tod_labels = {
+        "morning": "🌅 Morning  (6-12)",
+        "afternoon": "☀️  Afternoon(12-18)",
+        "evening": "🌙 Evening  (18-22)",
+        "night": "🦉 Night    (22-6) ",
+    }
+    for key, label in tod_labels.items():
+        secs = tod.get(key, 0)
+        bar = make_visual_bar(secs, tod_max, width=12)
+        lines.append(f"  {label}  {bar}  {format_duration(secs):>7}")
+    lines.append("")
+
+    # ── 6. Command categories ───────────────────────────────────────
+    lines.append("[bold]Top Command Categories[/]")
+    lines.append("─" * 44)
+    for cat, count in digest["category_frequency"][:8]:
+        lines.append(f"  {cat:<22} [bold]{count:>4}[/]")
+    lines.append("")
+
+    # ── 7. Top achievements ────────────────────────────────────────
+    achievements = digest.get("top_achievements", [])
+    if achievements:
+        lines.append("[bold]Highlights[/]")
+        lines.append("─" * 44)
+        for ach in achievements[:5]:
+            ts = ach["timestamp"]
+            day_str = datetime.fromtimestamp(ts).strftime("%b %d")
+            if ach["type"] == "commit":
+                lines.append(
+                    f"  [dim]{day_str}[/]  [bold yellow]•[/] [cyan]{ach['hash']}[/] {escape(ach['description'][:60])}"
+                )
+            else:
+                lines.append(
+                    f"  [dim]{day_str}[/]  [bold yellow]•[/] {escape(ach['description'][:60])}"
+                )
+        lines.append("")
+
+    return render_to_string(Text.from_markup("\n".join(lines).strip()))
+
+
 
 
 

--- a/termstory/weekly_digest.py
+++ b/termstory/weekly_digest.py
@@ -1,0 +1,335 @@
+"""Weekly Digest — comprehensive weekly analytics for TermStory.
+
+Collects per-day session breakdown, project time distribution, commit
+velocity, command-category frequency, focus-score trend, week-over-week
+comparison, and top-achievement highlights into a single structured dict
+that the formatter renders for the ``termstory weekly`` CLI command.
+
+Design notes
+------------
+* Pure-computation module: no I/O, no formatting.  The formatter owns
+  all Rich rendering so this module stays testable.
+* Operates on raw SQLite rows via the Database helper methods (same
+  pattern as ``insights.py``).
+* All public helpers accept plain data, not DB connections, so unit tests
+  can exercise them with hand-crafted inputs.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
+from termstory.formatter import classify_command, DISPLAY_NAMES, _is_noise_command
+from termstory.models import Command, Project, Session, format_duration
+
+
+# ── helpers (public, testable) ──────────────────────────────────────
+
+
+def _classify_command_category(cmd_text: str) -> str:
+    """Return a human-friendly display name for a command category."""
+    cat = classify_command(cmd_text)
+    return DISPLAY_NAMES.get(cat, cat.capitalize())
+
+
+def _daily_session_totals(sessions: List[Session]) -> Dict[str, int]:
+    """Map ``YYYY-MM-DD`` → total seconds across all sessions on that day."""
+    totals: Dict[str, int] = defaultdict(int)
+    for s in sessions:
+        day = datetime.fromtimestamp(s.start_time).strftime("%Y-%m-%d")
+        totals[day] += s.duration_seconds
+    return dict(totals)
+
+
+def _daily_session_counts(sessions: List[Session]) -> Dict[str, int]:
+    """Map ``YYYY-MM-DD`` → number of sessions on that day."""
+    counts: Dict[str, int] = defaultdict(int)
+    for s in sessions:
+        day = datetime.fromtimestamp(s.start_time).strftime("%Y-%m-%d")
+        counts[day] += 1
+    return dict(counts)
+
+
+def _daily_command_counts(sessions: List[Session]) -> Dict[str, int]:
+    """Map ``YYYY-MM-DD`` → number of commands executed on that day."""
+    counts: Dict[str, int] = defaultdict(int)
+    for s in sessions:
+        day = datetime.fromtimestamp(s.start_time).strftime("%Y-%m-%d")
+        counts[day] += len(s.commands)
+    return dict(counts)
+
+
+def _project_time_distribution(
+    sessions: List[Session], project_names: Dict[int, str]
+) -> List[Tuple[str, int]]:
+    """Return ``[(project_name, seconds), ...]`` sorted by duration DESC."""
+    times: Dict[str, int] = defaultdict(int)
+    for s in sessions:
+        name = project_names.get(s.project_id, "Other")
+        if not name or name == "General / No Project":
+            name = "Other"
+        times[name] += s.duration_seconds
+    return sorted(times.items(), key=lambda x: x[1], reverse=True)
+
+
+def _category_frequency(sessions: List[Session]) -> List[Tuple[str, int]]:
+    """Return ``[(display_name, count), ...]`` sorted by frequency DESC."""
+    counts: Counter[str] = Counter()
+    for s in sessions:
+        for cmd in s.commands:
+            counts[_classify_command_category(cmd.command)] += 1
+    return counts.most_common()
+
+
+def _daily_commit_counts(sessions: List[Session]) -> Dict[str, int]:
+    """Map ``YYYY-MM-DD`` → unique-commits count on that day."""
+    seen_hashes: set = set()
+    counts: Dict[str, int] = defaultdict(int)
+    for s in sessions:
+        for c in s.commits:
+            h = c.get("hash")
+            if h and h not in seen_hashes:
+                seen_hashes.add(h)
+                day = datetime.fromtimestamp(c["timestamp"]).strftime("%Y-%m-%d")
+                counts[day] += 1
+    return dict(counts)
+
+
+def _error_rate(sessions: List[Session]) -> float:
+    """Return the command failure rate as a percentage (0-100)."""
+    total = 0
+    errors = 0
+    for s in sessions:
+        for cmd in s.commands:
+            total += 1
+            if cmd.exit_code != 0:
+                errors += 1
+    return round((errors / total) * 100, 1) if total > 0 else 0.0
+
+
+def _longest_streak_within_range(sessions: List[Session]) -> int:
+    """Consecutive active work-days within the given session list."""
+    if not sessions:
+        return 0
+    active_dates = sorted(
+        {datetime.fromtimestamp(s.start_time).date() for s in sessions}
+    )
+    if not active_dates:
+        return 0
+    streak = 1
+    best = 1
+    for i in range(1, len(active_dates)):
+        if (active_dates[i] - active_dates[i - 1]).days == 1:
+            streak += 1
+            best = max(best, streak)
+        else:
+            streak = 1
+    return best
+
+
+def _time_of_day_split(sessions: List[Session]) -> Dict[str, int]:
+    """Distribute total seconds into morning/afternoon/evening/night."""
+    buckets = {"morning": 0, "afternoon": 0, "evening": 0, "night": 0}
+    for s in sessions:
+        dt = datetime.fromtimestamp(s.start_time)
+        h = dt.hour
+        dur = s.duration_seconds
+        if 6 <= h < 12:
+            buckets["morning"] += dur
+        elif 12 <= h < 18:
+            buckets["afternoon"] += dur
+        elif 18 <= h < 22:
+            buckets["evening"] += dur
+        else:
+            buckets["night"] += dur
+    return buckets
+
+
+def _week_over_week_delta(
+    current: Dict[str, Any], previous: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Compute deltas between two weekly summaries for comparison display."""
+    ct = current.get("total_time", 0)
+    pt = previous.get("total_time", 0)
+    time_delta = ct - pt
+    time_pct = round((time_delta / pt) * 100, 1) if pt > 0 else None
+
+    cc = current.get("total_commits", 0)
+    pc = previous.get("total_commits", 0)
+    commit_delta = cc - pc
+    commit_pct = round((commit_delta / pc) * 100, 1) if pc > 0 else None
+
+    cs = current.get("total_sessions", 0)
+    ps = previous.get("total_sessions", 0)
+    session_delta = cs - ps
+
+    ef = current.get("focus_score", 0)
+    pf = previous.get("focus_score", 0)
+    focus_delta = round(ef - pf, 1)
+
+    return {
+        "time_delta": time_delta,
+        "time_pct": time_pct,
+        "commit_delta": commit_delta,
+        "commit_pct": commit_pct,
+        "session_delta": session_delta,
+        "focus_delta": focus_delta,
+    }
+
+
+def _daily_focus_scores(sessions: List[Session]) -> Dict[str, float]:
+    """Per-day focus score (mirrors ``insights.calculate_focus_score`` logic)."""
+    by_day: Dict[str, List[Session]] = defaultdict(list)
+    for s in sessions:
+        day = datetime.fromtimestamp(s.start_time).strftime("%Y-%m-%d")
+        by_day[day].append(s)
+
+    scores: Dict[str, float] = {}
+    for day, day_sessions in by_day.items():
+        projects_by_session = defaultdict(set)
+        total_dur = 0
+        for s in day_sessions:
+            projects_by_session[s.start_time].add(s.project_id)
+            total_dur += s.duration_seconds
+        if not day_sessions:
+            scores[day] = 0.0
+            continue
+        avg_projects = sum(len(p) for p in projects_by_session.values()) / len(day_sessions)
+        avg_mins = (total_dur / len(day_sessions)) / 60.0
+        score = 6.0
+        score -= max(0.0, (avg_projects - 1.0) * 1.5)
+        score += min(4.0, avg_mins / 20.0)
+        scores[day] = round(max(0.0, min(10.0, score)), 1)
+    return scores
+
+
+def _top_achievements(sessions: List[Session], limit: int = 5) -> List[Dict[str, Any]]:
+    """Return the most meaningful commits and commands as weekly highlights."""
+    achievements: List[Dict[str, Any]] = []
+
+    seen_hashes: set = set()
+    for s in sessions:
+        for c in s.commits:
+            h = c.get("hash")
+            if h and h not in seen_hashes:
+                seen_hashes.add(h)
+                msg = c.get("cleaned_message") or c.get("message", "")
+                achievements.append({
+                    "type": "commit",
+                    "description": msg,
+                    "hash": h[:7],
+                    "timestamp": c["timestamp"],
+                    "project_id": s.project_id,
+                })
+
+    for s in sessions:
+        for cmd in s.commands:
+            if not _is_noise_command(cmd.command) and cmd.exit_code == 0:
+                text = cmd.command.strip()
+                # Keep only commands that look meaningful (longer than 10 chars)
+                if len(text) > 10:
+                    achievements.append({
+                        "type": "command",
+                        "description": text[:120],
+                        "hash": None,
+                        "timestamp": cmd.timestamp,
+                        "project_id": cmd.project_id,
+                    })
+
+    achievements.sort(key=lambda a: a["timestamp"], reverse=True)
+    return achievements[:limit]
+
+
+# ── main entry point ────────────────────────────────────────────────
+
+
+def build_weekly_digest(
+    sessions: List[Session],
+    projects: List[Project],
+    project_names: Dict[int, str],
+    previous_sessions: Optional[List[Session]] = None,
+) -> Dict[str, Any]:
+    """Build a complete weekly digest dict from session data.
+
+    Parameters
+    ----------
+    sessions:
+        Sessions belonging to the **current** week.
+    projects:
+        All projects (for reference).
+    project_names:
+        Mapping of ``project_id → display_name``.
+    previous_sessions:
+        Optional sessions from the **previous** week for comparison.
+
+    Returns
+    -------
+    dict
+        A rich structure consumed by ``format_weekly_digest_output``.
+    """
+    total_time = sum(s.duration_seconds for s in sessions)
+    total_commands = sum(len(s.commands) for s in sessions)
+
+    # Unique commits
+    seen_hashes: set = set()
+    for s in sessions:
+        for c in s.commits:
+            h = c.get("hash")
+            if h:
+                seen_hashes.add(h)
+    total_commits = len(seen_hashes)
+
+    active_days = len({datetime.fromtimestamp(s.start_time).date() for s in sessions})
+
+    digest: Dict[str, Any] = {
+        "total_time": total_time,
+        "total_sessions": len(sessions),
+        "total_commands": total_commands,
+        "total_commits": total_commits,
+        "active_days": active_days,
+        "error_rate": _error_rate(sessions),
+        "streak": _longest_streak_within_range(sessions),
+        "focus_score": round(
+            sum(
+                _daily_focus_scores(sessions).values()
+            ) / max(1, len(_daily_focus_scores(sessions))),
+            1,
+        ),
+        "daily_totals": _daily_session_totals(sessions),
+        "daily_session_counts": _daily_session_counts(sessions),
+        "daily_command_counts": _daily_command_counts(sessions),
+        "daily_commit_counts": _daily_commit_counts(sessions),
+        "daily_focus_scores": _daily_focus_scores(sessions),
+        "project_distribution": _project_time_distribution(sessions, project_names),
+        "category_frequency": _category_frequency(sessions),
+        "time_of_day": _time_of_day_split(sessions),
+        "top_achievements": _top_achievements(sessions, limit=7),
+    }
+
+    # Week-over-week comparison
+    if previous_sessions is not None:
+        prev_total_time = sum(s.duration_seconds for s in previous_sessions)
+        prev_seen: set = set()
+        for s in previous_sessions:
+            for c in s.commits:
+                h = c.get("hash")
+                if h:
+                    prev_seen.add(h)
+        prev_summary = {
+            "total_time": prev_total_time,
+            "total_commits": len(prev_seen),
+            "total_sessions": len(previous_sessions),
+            "focus_score": round(
+                sum(_daily_focus_scores(previous_sessions).values())
+                / max(1, len(_daily_focus_scores(previous_sessions))),
+                1,
+            ) if previous_sessions else 0.0,
+        }
+        digest["comparison"] = _week_over_week_delta(digest, prev_summary)
+    else:
+        digest["comparison"] = None
+
+    return digest

--- a/tests/test_weekly_digest.py
+++ b/tests/test_weekly_digest.py
@@ -1,0 +1,533 @@
+"""Tests for the weekly digest module (termstory.weekly_digest).
+
+These tests exercise the pure-computation helpers with hand-crafted Session
+and Command objects so we never touch the database.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import List, Optional
+
+import pytest
+
+from termstory.models import Command, Project, Session, format_duration
+from termstory.weekly_digest import (
+    _category_frequency,
+    _daily_command_counts,
+    _daily_commit_counts,
+    _daily_focus_scores,
+    _daily_session_counts,
+    _daily_session_totals,
+    _error_rate,
+    _longest_streak_within_range,
+    _project_time_distribution,
+    _time_of_day_split,
+    _top_achievements,
+    _week_over_week_delta,
+    build_weekly_digest,
+)
+
+
+# ── fixtures ────────────────────────────────────────────────────────
+
+
+def _ts(y: int, m: int, d: int, h: int = 9, mi: int = 0) -> int:
+    """Convenience: build a Unix timestamp for a specific date/time."""
+    return int(datetime(y, m, d, h, mi).timestamp())
+
+
+def _make_session(
+    start_ts: int,
+    duration: int,
+    project_id: Optional[int] = None,
+    commands: Optional[List[Command]] = None,
+    commits: Optional[List[dict]] = None,
+    session_id: int = 1,
+) -> Session:
+    """Build a minimal Session with the required fields."""
+    return Session(
+        id=session_id,
+        start_time=start_ts,
+        end_time=start_ts + duration,
+        duration_seconds=duration,
+        project_id=project_id,
+        commands=commands or [],
+        commits=commits or [],
+    )
+
+
+def _make_command(
+    timestamp: int,
+    command: str,
+    exit_code: int = 0,
+    session_id: int = 1,
+    project_id: Optional[int] = None,
+) -> Command:
+    """Build a minimal Command."""
+    return Command(
+        timestamp=timestamp,
+        command=command,
+        exit_code=exit_code,
+        session_id=session_id,
+        project_id=project_id,
+    )
+
+
+def _sample_sessions() -> List[Session]:
+    """A realistic week of sessions: Mon 2026-06-01 → Sun 2026-06-07."""
+    sessions: List[Session] = []
+
+    # Monday — 3 hours on project 1
+    s1 = _make_session(_ts(2026, 6, 1, 9), 3600, project_id=1, commands=[
+        _make_command(_ts(2026, 6, 1, 9), "git push origin main"),
+        _make_command(_ts(2026, 6, 1, 9, 10), "docker compose up -d", exit_code=0),
+        _make_command(_ts(2026, 6, 1, 10), "python manage.py test", exit_code=0),
+    ])
+    s1.commits = [
+        {"hash": "abc1234567890", "timestamp": _ts(2026, 6, 1, 9, 5), "message": "feat(auth): add login", "cleaned_message": "feat(auth): add login"},
+    ]
+    sessions.append(s1)
+
+    # Tuesday — 2 hours on project 1, 1 hour on project 2
+    s2 = _make_session(_ts(2026, 6, 2, 10), 7200, project_id=1, commands=[
+        _make_command(_ts(2026, 6, 2, 10), "pytest tests/ -v", exit_code=0),
+        _make_command(_ts(2026, 6, 2, 10, 30), "grep ERROR logs/app.log"),
+    ])
+    s2.commits = [
+        {"hash": "def2345678901", "timestamp": _ts(2026, 6, 2, 11), "message": "fix(auth): token refresh", "cleaned_message": "fix(auth): token refresh"},
+    ]
+    sessions.append(s2)
+
+    s3 = _make_session(_ts(2026, 6, 2, 14), 3600, project_id=2, commands=[
+        _make_command(_ts(2026, 6, 2, 14), "npm run build", exit_code=1),
+        _make_command(_ts(2026, 6, 2, 14, 10), "npm run build", exit_code=0),
+    ], session_id=2)
+    sessions.append(s3)
+
+    # Wednesday — 1 hour
+    s4 = _make_session(_ts(2026, 6, 3, 13), 3600, project_id=1, commands=[
+        _make_command(_ts(2026, 6, 3, 13), "git commit -m 'refactor(core)': clean up"),
+    ])
+    s4.commits = [
+        {"hash": "ghi3456789012", "timestamp": _ts(2026, 6, 3, 13, 30), "message": "refactor(core): clean up", "cleaned_message": "refactor(core): clean up"},
+    ]
+    sessions.append(s4)
+
+    # Thursday — no sessions (gap day)
+
+    # Friday — 4 hours on project 1
+    s5 = _make_session(_ts(2026, 6, 5, 9), 14400, project_id=1, commands=[
+        _make_command(_ts(2026, 6, 5, 9), "docker compose logs -f"),
+        _make_command(_ts(2026, 6, 5, 10), "python manage.py migrate"),
+        _make_command(_ts(2026, 6, 5, 11), "git push", exit_code=0),
+    ], session_id=3)
+    sessions.append(s5)
+
+    # Saturday — 2 hours on project 3
+    s6 = _make_session(_ts(2026, 6, 6, 15), 7200, project_id=3, commands=[
+        _make_command(_ts(2026, 6, 6, 15), "cargo build --release", exit_code=0),
+    ], session_id=4)
+    sessions.append(s6)
+
+    return sessions
+
+
+def _sample_projects() -> List[Project]:
+    return [
+        Project(id=1, name="termstory", path="~/termstory", first_seen=_ts(2026, 5, 1), last_seen=_ts(2026, 6, 5), session_count=4, total_time=25200),
+        Project(id=2, name="frontend-app", path="~/frontend", first_seen=_ts(2026, 5, 15), last_seen=_ts(2026, 6, 2), session_count=1, total_time=3600),
+        Project(id=3, name="rust-utils", path="~/rust-utils", first_seen=_ts(2026, 6, 1), last_seen=_ts(2026, 6, 6), session_count=1, total_time=7200),
+    ]
+
+
+# ── tests: _daily_session_totals ────────────────────────────────────
+
+
+class TestDailySessionTotals:
+    def test_basic_totals(self):
+        sessions = _sample_sessions()
+        totals = _daily_session_totals(sessions)
+        assert totals["2026-06-01"] == 3600
+        # Tuesday: 7200 + 3600 = 10800
+        assert totals["2026-06-02"] == 10800
+        assert totals["2026-06-06"] == 7200
+
+    def test_empty(self):
+        assert _daily_session_totals([]) == {}
+
+    def test_no_double_counting(self):
+        """Each session's duration is counted exactly once per day."""
+        s1 = _make_session(_ts(2026, 6, 1, 9), 1800, project_id=1)
+        s2 = _make_session(_ts(2026, 6, 1, 14), 1800, project_id=1)
+        totals = _daily_session_totals([s1, s2])
+        assert totals["2026-06-01"] == 3600
+
+
+# ── tests: _daily_session_counts ────────────────────────────────────
+
+
+class TestDailySessionCounts:
+    def test_counts(self):
+        sessions = _sample_sessions()
+        counts = _daily_session_counts(sessions)
+        assert counts["2026-06-01"] == 1
+        assert counts["2026-06-02"] == 2
+        assert counts["2026-06-05"] == 1
+
+    def test_empty(self):
+        assert _daily_session_counts([]) == {}
+
+
+# ── tests: _daily_command_counts ────────────────────────────────────
+
+
+class TestDailyCommandCounts:
+    def test_counts_commands_per_day(self):
+        sessions = _sample_sessions()
+        counts = _daily_command_counts(sessions)
+        # Monday: 3 commands
+        assert counts["2026-06-01"] == 3
+        # Tuesday: 2 + 2 = 4
+        assert counts["2026-06-02"] == 4
+
+    def test_empty(self):
+        assert _daily_command_counts([]) == {}
+
+
+# ── tests: _daily_commit_counts ─────────────────────────────────────
+
+
+class TestDailyCommitCounts:
+    def test_unique_commits(self):
+        sessions = _sample_sessions()
+        counts = _daily_commit_counts(sessions)
+        assert counts["2026-06-01"] == 1
+        assert counts["2026-06-02"] == 1
+        assert counts["2026-06-03"] == 1
+
+    def test_deduplication(self):
+        """Same commit hash appearing in two sessions counts once."""
+        c = {"hash": "same1234567", "timestamp": _ts(2026, 6, 1, 10), "message": "m", "cleaned_message": "m"}
+        s1 = _make_session(_ts(2026, 6, 1, 9), 3600, commits=[c])
+        s2 = _make_session(_ts(2026, 6, 1, 14), 3600, commits=[c])
+        counts = _daily_commit_counts([s1, s2])
+        assert counts["2026-06-01"] == 1
+
+
+# ── tests: _error_rate ─────────────────────────────────────────────
+
+
+class TestErrorRate:
+    def test_zero_commands(self):
+        assert _error_rate([]) == 0.0
+
+    def test_all_pass(self):
+        s = _make_session(_ts(2026, 6, 1, 9), 3600, commands=[
+            _make_command(_ts(2026, 6, 1, 9), "echo hello", exit_code=0),
+            _make_command(_ts(2026, 6, 1, 9, 1), "ls", exit_code=0),
+        ])
+        assert _error_rate([s]) == 0.0
+
+    def test_half_errors(self):
+        s = _make_session(_ts(2026, 6, 1, 9), 3600, commands=[
+            _make_command(_ts(2026, 6, 1, 9), "cmd1", exit_code=0),
+            _make_command(_ts(2026, 6, 1, 9, 1), "cmd2", exit_code=1),
+            _make_command(_ts(2026, 6, 1, 9, 2), "cmd3", exit_code=0),
+            _make_command(_ts(2026, 6, 1, 9, 3), "cmd4", exit_code=2),
+        ])
+        assert _error_rate([s]) == 50.0
+
+
+# ── tests: _longest_streak_within_range ────────────────────────────
+
+
+class TestLongestStreak:
+    def test_empty(self):
+        assert _longest_streak_within_range([]) == 0
+
+    def test_single_day(self):
+        s = _make_session(_ts(2026, 6, 1, 9), 3600)
+        assert _longest_streak_within_range([s]) == 1
+
+    def test_three_day_streak(self):
+        sessions = [
+            _make_session(_ts(2026, 6, 1, 9), 3600),
+            _make_session(_ts(2026, 6, 2, 9), 3600),
+            _make_session(_ts(2026, 6, 3, 9), 3600),
+        ]
+        assert _longest_streak_within_range(sessions) == 3
+
+    def test_gap_breaks_streak(self):
+        sessions = [
+            _make_session(_ts(2026, 6, 1, 9), 3600),
+            _make_session(_ts(2026, 6, 2, 9), 3600),
+            _make_session(_ts(2026, 6, 5, 9), 3600),  # gap
+            _make_session(_ts(2026, 6, 6, 9), 3600),
+        ]
+        assert _longest_streak_within_range(sessions) == 2
+
+
+# ── tests: _project_time_distribution ───────────────────────────────
+
+
+class TestProjectTimeDistribution:
+    def test_sorted_by_time(self):
+        sessions = _sample_sessions()
+        project_names = {1: "termstory", 2: "frontend-app", 3: "rust-utils"}
+        dist = _project_time_distribution(sessions, project_names)
+        # termstory: 3600+7200+3600+14400 = 28800
+        # frontend-app: 3600
+        # rust-utils: 7200
+        assert dist[0][0] == "termstory"
+        assert dist[0][1] == 28800
+        assert dist[1][0] == "rust-utils"
+        assert dist[2][0] == "frontend-app"
+
+    def test_unknown_project_becomes_other(self):
+        s = _make_session(_ts(2026, 6, 1, 9), 3600, project_id=99)
+        dist = _project_time_distribution([s], {1: "known"})
+        assert dist[0][0] == "Other"
+
+
+# ── tests: _category_frequency ──────────────────────────────────────
+
+
+class TestCategoryFrequency:
+    def test_sorted_by_count(self):
+        s = _make_session(_ts(2026, 6, 1, 9), 3600, commands=[
+            _make_command(_ts(2026, 6, 1, 9), "git push"),
+            _make_command(_ts(2026, 6, 1, 9, 1), "git commit -m 'x'"),
+            _make_command(_ts(2026, 6, 1, 9, 2), "docker ps"),
+        ])
+        freq = _category_frequency([s])
+        assert freq[0][0] == "Git"
+        assert freq[0][1] == 2
+        assert freq[1][0] == "Docker"
+        assert freq[1][1] == 1
+
+
+# ── tests: _time_of_day_split ──────────────────────────────────────
+
+
+class TestTimeOfDaySplit:
+    def test_morning_and_night(self):
+        s1 = _make_session(_ts(2026, 6, 1, 8), 3600)    # morning
+        s2 = _make_session(_ts(2026, 6, 1, 23), 3600)    # night
+        result = _time_of_day_split([s1, s2])
+        assert result["morning"] == 3600
+        assert result["night"] == 3600
+        assert result["afternoon"] == 0
+        assert result["evening"] == 0
+
+
+# ── tests: _week_over_week_delta ────────────────────────────────────
+
+
+class TestWeekOverWeekDelta:
+    def test_improvement(self):
+        current = {"total_time": 20000, "total_commits": 10, "total_sessions": 8, "focus_score": 7.0}
+        previous = {"total_time": 10000, "total_commits": 5, "total_sessions": 5, "focus_score": 5.0}
+        delta = _week_over_week_delta(current, previous)
+        assert delta["time_delta"] == 10000
+        assert delta["time_pct"] == 100.0
+        assert delta["commit_delta"] == 5
+        assert delta["commit_pct"] == 100.0
+        assert delta["session_delta"] == 3
+        assert delta["focus_delta"] == 2.0
+
+    def test_decline(self):
+        current = {"total_time": 5000, "total_commits": 2, "total_sessions": 3, "focus_score": 4.0}
+        previous = {"total_time": 15000, "total_commits": 8, "total_sessions": 6, "focus_score": 6.0}
+        delta = _week_over_week_delta(current, previous)
+        assert delta["time_delta"] == -10000
+        assert delta["time_pct"] < 0
+        assert delta["focus_delta"] == -2.0
+
+    def test_previous_zero(self):
+        current = {"total_time": 5000, "total_commits": 0, "total_sessions": 3, "focus_score": 5.0}
+        previous = {"total_time": 0, "total_commits": 0, "total_sessions": 0, "focus_score": 0.0}
+        delta = _week_over_week_delta(current, previous)
+        assert delta["time_pct"] is None
+        assert delta["commit_pct"] is None
+
+
+# ── tests: _top_achievements ────────────────────────────────────────
+
+
+class TestTopAchievements:
+    def test_commits_preferred(self):
+        c = {
+            "hash": "abc1234567890",
+            "timestamp": _ts(2026, 6, 1, 10),
+            "message": "feat: add login",
+            "cleaned_message": "feat: add login",
+        }
+        s = _make_session(_ts(2026, 6, 1, 9), 3600, commands=[
+            _make_command(_ts(2026, 6, 1, 9), "git push origin main"),
+        ], commits=[c])
+        ach = _top_achievements([s], limit=3)
+        assert ach[0]["type"] == "commit"
+        assert ach[0]["hash"] == "abc1234"
+
+    def test_limit(self):
+        sessions = []
+        for i in range(10):
+            sessions.append(_make_session(_ts(2026, 6, 1, 9, i * 10), 300, commits=[
+                {"hash": f"hash{i:010d}", "timestamp": _ts(2026, 6, 1, 9, i * 10), "message": f"commit {i}", "cleaned_message": f"commit {i}"},
+            ]))
+        ach = _top_achievements(sessions, limit=3)
+        assert len(ach) <= 3
+
+
+# ── tests: _daily_focus_scores ─────────────────────────────────────
+
+
+class TestDailyFocusScores:
+    def test_single_session_day(self):
+        s = _make_session(_ts(2026, 6, 1, 9), 7200, project_id=1)
+        scores = _daily_focus_scores([s])
+        assert "2026-06-01" in scores
+        assert 0.0 <= scores["2026-06-01"] <= 10.0
+
+    def test_empty(self):
+        assert _daily_focus_scores([]) == {}
+
+
+# ── tests: build_weekly_digest (integration) ────────────────────────
+
+
+class TestBuildWeeklyDigest:
+    def test_basic_structure(self):
+        sessions = _sample_sessions()
+        projects = _sample_projects()
+        project_names = {1: "termstory", 2: "frontend-app", 3: "rust-utils"}
+
+        digest = build_weekly_digest(sessions, projects, project_names)
+
+        assert digest["total_time"] == 28800 + 3600 + 7200  # 39600
+        assert digest["total_sessions"] == 6
+        assert digest["total_commands"] == 9
+        assert digest["total_commits"] == 3
+        assert digest["active_days"] == 5  # Mon, Tue, Wed, Fri, Sat
+        assert digest["streak"] == 3  # Mon, Tue, Wed
+        assert "daily_totals" in digest
+        assert "project_distribution" in digest
+        assert "category_frequency" in digest
+        assert "time_of_day" in digest
+        assert "top_achievements" in digest
+
+    def test_with_previous_week(self):
+        sessions = _sample_sessions()
+        projects = _sample_projects()
+        project_names = {1: "termstory", 2: "frontend-app", 3: "rust-utils"}
+
+        # Previous week: 2 sessions, less time
+        prev_sessions = [
+            _make_session(_ts(2026, 5, 25, 9), 3600, project_id=1),
+            _make_session(_ts(2026, 5, 27, 9), 3600, project_id=1),
+        ]
+
+        digest = build_weekly_digest(
+            sessions, projects, project_names, previous_sessions=prev_sessions
+        )
+        comp = digest["comparison"]
+        assert comp is not None
+        assert comp["time_delta"] > 0  # This week has more time
+        assert comp["commit_delta"] >= 0
+
+    def test_without_previous_week(self):
+        sessions = _sample_sessions()
+        projects = _sample_projects()
+        project_names = {1: "termstory", 2: "frontend-app", 3: "rust-utils"}
+
+        digest = build_weekly_digest(sessions, projects, project_names)
+        assert digest["comparison"] is None
+
+    def test_empty_week(self):
+        digest = build_weekly_digest([], [], {})
+        assert digest["total_time"] == 0
+        assert digest["total_sessions"] == 0
+        assert digest["total_commands"] == 0
+        assert digest["total_commits"] == 0
+        assert digest["active_days"] == 0
+
+    def test_error_rate_populated(self):
+        sessions = [
+            _make_session(_ts(2026, 6, 1, 9), 3600, commands=[
+                _make_command(_ts(2026, 6, 1, 9), "cmd1", exit_code=0),
+                _make_command(_ts(2026, 6, 1, 9, 1), "cmd2", exit_code=1),
+                _make_command(_ts(2026, 6, 1, 9, 2), "cmd3", exit_code=0),
+            ]),
+        ]
+        digest = build_weekly_digest(sessions, [], {})
+        assert digest["error_rate"] == pytest.approx(33.3, abs=0.1)
+
+
+# ── tests: format_weekly_digest_output ──────────────────────────────
+
+
+class TestFormatWeeklyDigestOutput:
+    """Smoke tests that the formatter does not crash and contains key sections."""
+
+    def test_empty_week(self):
+        from termstory.formatter import format_weekly_digest_output
+        start_ts = _ts(2026, 6, 1)
+        end_ts = _ts(2026, 6, 7, 23, 59)
+        digest = build_weekly_digest([], [], {})
+        output = format_weekly_digest_output(digest, start_ts, end_ts)
+        assert "No sessions" in output
+
+    def test_full_week_has_all_sections(self):
+        from termstory.formatter import format_weekly_digest_output
+        sessions = _sample_sessions()
+        projects = _sample_projects()
+        project_names = {1: "termstory", 2: "frontend-app", 3: "rust-utils"}
+
+        digest = build_weekly_digest(sessions, projects, project_names)
+        start_ts = _ts(2026, 6, 1)
+        end_ts = _ts(2026, 6, 7, 23, 59)
+        output = format_weekly_digest_output(digest, start_ts, end_ts)
+
+        assert "Summary" in output
+        assert "Daily Breakdown" in output
+        assert "Project Focus" in output
+        assert "Active Hours" in output
+        assert "Top Command Categories" in output
+        assert "Highlights" in output
+
+    def test_with_comparison(self):
+        from termstory.formatter import format_weekly_digest_output
+        sessions = _sample_sessions()
+        projects = _sample_projects()
+        project_names = {1: "termstory", 2: "frontend-app", 3: "rust-utils"}
+        prev_sessions = [
+            _make_session(_ts(2026, 5, 25, 9), 3600, project_id=1),
+        ]
+        digest = build_weekly_digest(
+            sessions, projects, project_names, previous_sessions=prev_sessions
+        )
+        start_ts = _ts(2026, 6, 1)
+        end_ts = _ts(2026, 6, 7, 23, 59)
+        output = format_weekly_digest_output(digest, start_ts, end_ts)
+        assert "vs. Previous Week" in output
+
+
+# ── tests: format_duration edge cases (regression guard) ────────────
+
+
+class TestFormatDurationEdge:
+    def test_zero(self):
+        assert format_duration(0) == "0s"
+
+    def test_seconds_only(self):
+        assert format_duration(45) == "45s"
+
+    def test_minutes_only(self):
+        assert format_duration(120) == "2m"
+
+    def test_hours_and_minutes(self):
+        assert format_duration(3720) == "1h 2m"
+
+    def test_days_format(self):
+        assert format_duration(90000) == "1d 1h"


### PR DESCRIPTION
closes #509 
Summary

This PR adds a new termstory weekly CLI command that generates a comprehensive weekly productivity and activity report.

Features
Weekly Analytics

The command provides:

Weekly summary statistics.
Daily session, command, and commit breakdown.
Visual activity bars.
Project-wise time distribution.
Time-of-day activity heatmap.
Command category frequency.
Focus score.
Activity streak tracking.
Top achievements.
Previous Week Comparison

Added the --last flag to view the previous week's report.

When comparing weeks, the command automatically calculates percentage changes for:

Time spent.
Commits.
Sessions.
Focus score.
Architecture
Added a pure-computation analytics engine in weekly_digest.py.
Kept analytics logic independent of I/O for easier testing and reuse.
Added a dedicated formatter for rendering the weekly report.
Wired the new command into the existing CLI and database flow.
Testing

Added 30+ unit tests covering:

Analytics helpers.
Weekly calculations.
Activity aggregation.
Streak tracking.
Week-over-week comparisons.
Formatting and integration behaviour.
Files Changed
termstory/weekly_digest.py
termstory/formatter.py
termstory/cli.py
tests/test_weekly_digest.py
Impact

Users can now generate a detailed weekly overview of their development activity and productivity directly from the CLI, while the --last option makes it easy to compare current performance with the previous week.

Branch: feature/weekly-digest-command

Commit: 6eb32d9 — feat(cli): add weekly digest command with comprehensive analytics